### PR TITLE
build: add cross toolchain and simplify build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ If NEAT is installed in a non-standard prefix, set `CMAKE_PREFIX_PATH`:
 CMAKE_PREFIX_PATH=/opt/sima-neat ./build.sh
 ```
 
+### Cross Compilation
+
+`build.sh` auto-selects `cmake/toolchains/aarch64-modalix.cmake` when cross
+environment variables are present (`SYSROOT`, `CROSS_COMPILE`, `CC`, `CXX`).
+
+Typical usage:
+
+```bash
+./build.sh
+```
+
 ## Python Examples
 
 Python examples are not implemented yet.

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,8 @@ Options:
 
 Environment:
   SIMA_CLI_BIN              Path to sima-cli binary (default: sima-cli)
-  CMAKE_PREFIX_PATH         Set if SimaNeatConfig.cmake is not in a default prefix
+  CMAKE_TOOLCHAIN_FILE      Optional CMake toolchain file (auto-detected for cross)
+  SYSROOT                   Target sysroot (used by the default cross toolchain file)
 EOF
 }
 
@@ -134,10 +135,29 @@ if [[ "${CLEAN}" -eq 1 ]]; then
   rm -rf "${BUILD_DIR}"
 fi
 
+# Auto-enable repo toolchain for cross builds unless caller already set one.
+TOOLCHAIN_FILE="${CMAKE_TOOLCHAIN_FILE:-}"
+DEFAULT_CROSS_TOOLCHAIN="${ROOT_DIR}/cmake/toolchains/aarch64-modalix.cmake"
+if [[ -z "${TOOLCHAIN_FILE}" ]]; then
+  if [[ -n "${SYSROOT:-}" || -n "${CROSS_COMPILE:-}" || "${CC:-}" == *aarch64-linux-gnu* || "${CXX:-}" == *aarch64-linux-gnu* ]]; then
+    if [[ -f "${DEFAULT_CROSS_TOOLCHAIN}" ]]; then
+      TOOLCHAIN_FILE="${DEFAULT_CROSS_TOOLCHAIN}"
+    fi
+  fi
+fi
+
+TOOLCHAIN_ARG=()
+if [[ -n "${TOOLCHAIN_FILE}" ]]; then
+  TOOLCHAIN_ARG=("-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}")
+fi
+
+echo "  Toolchain file         : ${TOOLCHAIN_FILE:-"(none)"}"
+
 cmake -S . -B "${BUILD_DIR}" \
   -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
   -DSIMANEAT_APPS_BUILD_CPP="${BUILD_CPP}" \
-  -DSIMANEAT_APPS_BUILD_PYTHON="${BUILD_PYTHON}"
+  -DSIMANEAT_APPS_BUILD_PYTHON="${BUILD_PYTHON}" \
+  "${TOOLCHAIN_ARG[@]}"
 
 if [[ "${BUILD_CPP}" == "ON" ]]; then
   cmake --build "${BUILD_DIR}" -j"$(nproc 2>/dev/null || echo 8)"

--- a/cmake/toolchains/aarch64-modalix.cmake
+++ b/cmake/toolchains/aarch64-modalix.cmake
@@ -1,0 +1,60 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# Avoid link checks against host during toolchain probing.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+if(DEFINED ENV{SYSROOT} AND NOT "$ENV{SYSROOT}" STREQUAL "")
+  set(_SYSROOT "$ENV{SYSROOT}")
+elseif(DEFINED SYSROOT AND NOT "${SYSROOT}" STREQUAL "")
+  set(_SYSROOT "${SYSROOT}")
+endif()
+
+if(DEFINED ENV{CC} AND NOT "$ENV{CC}" STREQUAL "")
+  set(CMAKE_C_COMPILER "$ENV{CC}" CACHE FILEPATH "C compiler")
+elseif(DEFINED ENV{CROSS_COMPILE} AND NOT "$ENV{CROSS_COMPILE}" STREQUAL "")
+  set(CMAKE_C_COMPILER "$ENV{CROSS_COMPILE}gcc" CACHE FILEPATH "C compiler")
+endif()
+
+if(DEFINED ENV{CXX} AND NOT "$ENV{CXX}" STREQUAL "")
+  set(CMAKE_CXX_COMPILER "$ENV{CXX}" CACHE FILEPATH "CXX compiler")
+elseif(DEFINED ENV{CROSS_COMPILE} AND NOT "$ENV{CROSS_COMPILE}" STREQUAL "")
+  set(CMAKE_CXX_COMPILER "$ENV{CROSS_COMPILE}g++" CACHE FILEPATH "CXX compiler")
+endif()
+
+if(DEFINED _SYSROOT)
+  set(CMAKE_SYSROOT "${_SYSROOT}" CACHE PATH "Cross sysroot")
+  set(CMAKE_FIND_ROOT_PATH "${_SYSROOT}" CACHE PATH "CMake find root path")
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY CACHE STRING "Find packages only in sysroot")
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY CACHE STRING "Find libraries only in sysroot")
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY CACHE STRING "Find headers only in sysroot")
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER CACHE STRING "Find programs on host")
+
+  if(NOT DEFINED CMAKE_PREFIX_PATH OR CMAKE_PREFIX_PATH STREQUAL "")
+    set(
+      CMAKE_PREFIX_PATH
+      "${_SYSROOT}/usr;${_SYSROOT}/usr/lib/cmake;${_SYSROOT}/usr/lib/aarch64-linux-gnu/cmake"
+      CACHE STRING "Cross package prefixes"
+    )
+  endif()
+
+  # Make host pkg-config resolve target .pc metadata and sysroot all paths.
+  if(NOT DEFINED ENV{PKG_CONFIG_SYSROOT_DIR} OR "$ENV{PKG_CONFIG_SYSROOT_DIR}" STREQUAL "")
+    set(ENV{PKG_CONFIG_SYSROOT_DIR} "${_SYSROOT}")
+  endif()
+  if(NOT DEFINED ENV{PKG_CONFIG_LIBDIR} OR "$ENV{PKG_CONFIG_LIBDIR}" STREQUAL "")
+    set(
+      ENV{PKG_CONFIG_LIBDIR}
+      "${_SYSROOT}/usr/lib/aarch64-linux-gnu/pkgconfig:${_SYSROOT}/usr/lib/pkgconfig:${_SYSROOT}/usr/share/pkgconfig"
+    )
+  endif()
+  set(ENV{PKG_CONFIG_DIR} "")
+endif()
+
+if(NOT DEFINED PKG_CONFIG_EXECUTABLE OR PKG_CONFIG_EXECUTABLE STREQUAL "")
+  if(DEFINED ENV{PKG_CONFIG_EXECUTABLE} AND NOT "$ENV{PKG_CONFIG_EXECUTABLE}" STREQUAL "")
+    set(PKG_CONFIG_EXECUTABLE "$ENV{PKG_CONFIG_EXECUTABLE}" CACHE FILEPATH "pkg-config executable")
+  elseif(EXISTS "/usr/bin/pkg-config")
+    set(PKG_CONFIG_EXECUTABLE "/usr/bin/pkg-config" CACHE FILEPATH "pkg-config executable")
+  endif()
+endif()


### PR DESCRIPTION
## Summary

This PR improves cross-compilation support while keeping native/device builds simple and unchanged.

### What changed

- Added a dedicated cross toolchain file:
  - `cmake/toolchains/aarch64-modalix.cmake`
- Simplified `build.sh`:
  - Auto-detects cross environment (`SYSROOT`, `CROSS_COMPILE`, `CC`, `CXX`)
  - Auto-applies `-DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/aarch64-modalix.cmake` in cross mode
  - Leaves native/device builds untouched when cross signals are absent
- Updated build docs in `README.md` with cross-compilation usage

### Why

Cross builds were failing due to dependency/package discovery issues (`SimaNeat`, `pkg-config`, sysroot include paths).  
This change centralizes cross logic in a CMake toolchain file instead of scattering cross-specific flags through `build.sh`.

### Toolchain behavior (cross mode)

The new toolchain file configures:

- `CMAKE_SYSROOT` and `CMAKE_FIND_ROOT_PATH`
- `CMAKE_FIND_ROOT_PATH_MODE_*` for package/library/include/program lookup
- default cross `CMAKE_PREFIX_PATH` under `${SYSROOT}`
- `pkg-config` environment for target `.pc` resolution:
  - `PKG_CONFIG_SYSROOT_DIR`
  - `PKG_CONFIG_LIBDIR`
  - clears `PKG_CONFIG_DIR` to avoid host fallback

### Usage

```bash
# Native/device & Cross
./build.sh