### PR TITLE
Clean up Jira labels safely on issue close

### DIFF
--- a/.github/workflows/issues-jira-sync.yml
+++ b/.github/workflows/issues-jira-sync.yml
@@ -649,22 +649,52 @@ jobs:
             --data "${payload}" \
             "${JIRA_BASE_URL}/rest/api/3/issue/${JIRA_KEY}/comment"
 
-      - name: Remove Jira key label from closed GitHub issue
-        if: steps.jira-key.outputs.key != '' && steps.ctx.outputs.action == 'closed' && github.event_name == 'issues' && steps.ctx.outputs.dry_run != 'true'
+      - name: Remove Jira labels from closed GitHub issue and repo
+        if: steps.ctx.outputs.action == 'closed' && github.event_name == 'issues' && steps.ctx.outputs.dry_run != 'true'
         uses: actions/github-script@v7
-        env:
-          JIRA_KEY: ${{ steps.jira-key.outputs.key }}
         with:
           script: |
-            try {
-              await github.rest.issues.removeLabel({
+            const jiraLabels = (context.payload.issue.labels || [])
+              .map((label) => typeof label === "string" ? label : label.name)
+              .filter((label) => /^[A-Z][A-Z0-9]*-\d+$/.test(label));
+
+            for (const label of jiraLabels) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  name: label
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+
+              const { data: matchingIssues } = await github.rest.issues.listForRepo({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                name: process.env.JIRA_KEY
+                state: "all",
+                labels: label,
+                per_page: 100
               });
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
+              const labelStillUsedElsewhere = matchingIssues.some(
+                (issue) => issue.number !== context.payload.issue.number
+              );
+              if (labelStillUsedElsewhere) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.deleteLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
               }
             }


### PR DESCRIPTION
## Summary
- remove Jira-style labels from a GitHub issue when that issue is closed
- delete the corresponding repository label only if no other issue still uses it
- keep the cleanup scoped to Jira-style labels such as AUTO-1910

## Why
The previous cleanup direction risked deleting repository labels even if the same Jira label was still attached to other issues. This change makes label cleanup safe and prevents the repo label list from growing unnecessarily.

## Validation
- actionlint .github/workflows/issues-jira-sync.yml