### PR TITLE
Fix portal GitHub links and detail navigation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ BUILD_CPP=ON
 BUILD_PYTHON=OFF
 INSTALL_CORE=0
 ONLY_INSTALL=0
+PORTAL_ONLY=0
 CLI_BIN="${SIMA_CLI_BIN:-sima-cli}"
 NEAT_CORE_OVERRIDE=""
 
@@ -29,6 +30,7 @@ Options:
   --no-cpp                  Skip C++ example build (layout/metadata only)
   --python                  Enable Python tooling (placeholder)
   --all                     Install NEAT core SDK, build apps, build portal, then package
+  --portal-only             Build portal only and exit
   --only-install-neat-core  Install NEAT core SDK and exit (no build)
   --neat-core-version <b:v> Override neat-core.json with branch:version (example: main:latest)
   -h, --help                Show help
@@ -202,6 +204,7 @@ while [[ $# -gt 0 ]]; do
     --no-cpp) BUILD_CPP=OFF; shift ;;
     --python) BUILD_PYTHON=ON; shift ;;
     --all) INSTALL_CORE=1; shift ;;
+    --portal-only) PORTAL_ONLY=1; shift ;;
     --only-install-neat-core) INSTALL_CORE=1; ONLY_INSTALL=1; shift ;;
     --neat-core-version) NEAT_CORE_OVERRIDE="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
@@ -446,6 +449,14 @@ if [[ "${INSTALL_CORE}" -eq 1 ]]; then
 fi
 
 if [[ "${ONLY_INSTALL}" -eq 1 ]]; then
+  exit 0
+fi
+
+if [[ "${PORTAL_ONLY}" -eq 1 ]]; then
+  echo ""
+  echo "  NEAT Apps Portal Build"
+  echo "  ======================"
+  build_portal
   exit 0
 fi
 

--- a/portal/src/App.jsx
+++ b/portal/src/App.jsx
@@ -287,6 +287,13 @@ function DetailPage({ catalog }) {
   }, [decodedId, sections]);
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+    if (docPanelRef.current) {
+      docPanelRef.current.scrollTo({ top: 0, behavior: "auto" });
+    }
+  }, [decodedId]);
+
+  useEffect(() => {
     if (!sections.length) {
       return undefined;
     }

--- a/portal/src/catalog.js
+++ b/portal/src/catalog.js
@@ -1,4 +1,4 @@
-const GITHUB_REPO_ROOT = "https://github.com/sima-neat/apps/tree/feat/decouple-neat-apps";
+const GITHUB_REPO_ROOT = "https://github.com/sima-neat/apps/tree/main";
 
 export async function loadCatalog() {
   const response = await fetch("./catalog.json");


### PR DESCRIPTION
## Summary
- update app-card GitHub links to point at `main` instead of the removed `feat/decouple-neat-apps` branch
- reset the detail view scroll position when switching between apps so the next app header is visible
- add `./build.sh --portal-only` to support building just the portal on macOS

## Details
### Portal GitHub links
The portal catalog source hardcoded the removed `feat/decouple-neat-apps` branch when building GitHub URLs for example cards. That caused 404s when opening source links from the portal. This change updates the root to `https://github.com/sima-neat/apps/tree/main`.

### Detail-page scroll reset
When a user scrolled down in one app detail page, returned to the portal, and then opened a different app, the new detail page inherited the previous scroll offset. This meant the hero/header could be off-screen on entry. The detail page now resets both the window scroll position and the internal document panel scroll position whenever the selected app changes.

### Portal-only build mode
`apps/build.sh` now supports `--portal-only`, which builds just the portal and exits before the NEAT core resolution and app-build flow. This gives a clean path for portal-only work, especially on macOS.

## Testing
- `/bin/bash -n build.sh`
