### PR TITLE
added VS Code board test task helpers.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,119 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Apps: Test Unit C++",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "tests/scripts/testing/run_vscode_test_task.sh",
+        "--unit",
+        "--cpp"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Apps: Test Unit Python",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "tests/scripts/testing/run_vscode_test_task.sh",
+        "--unit",
+        "--python"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Apps: Test E2E C++",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "tests/scripts/testing/run_vscode_test_task.sh",
+        "--e2e",
+        "--cpp"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Apps: Test E2E Python",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "tests/scripts/testing/run_vscode_test_task.sh",
+        "--e2e",
+        "--python"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Apps: Test All",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "tests/scripts/testing/run_vscode_test_task.sh",
+        "--all"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/tests/scripts/testing/run_fix_devkit_runtime.py
+++ b/tests/scripts/testing/run_fix_devkit_runtime.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+
+
+def main() -> int:
+    return subprocess.run(["bash", "/usr/bin/fix_devkit_runtime.sh"]).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/testing/run_vscode_test_task.py
+++ b/tests/scripts/testing/run_vscode_test_task.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def root_dir() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def remove_stale_build_dir(apps_root: Path) -> None:
+    cache_path = apps_root / "build" / "CMakeCache.txt"
+    if not cache_path.exists():
+        return
+
+    expected = f"CMAKE_HOME_DIRECTORY:INTERNAL={apps_root}"
+    try:
+        cache_text = cache_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return
+
+    if expected not in cache_text:
+        print("[task] removing stale build directory created from a different checkout path", flush=True)
+        shutil.rmtree(apps_root / "build", ignore_errors=True)
+
+
+def build_command(argv: list[str]) -> str:
+    quoted_args = " ".join(shlex.quote(arg) for arg in argv)
+    return (
+        "./build.sh && "
+        "source tests/scripts/testing/setup_test_env.sh && "
+        f"./tests/test.sh {quoted_args}".rstrip()
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    apps_root = root_dir()
+    remove_stale_build_dir(apps_root)
+    command = build_command(args)
+    return subprocess.run(["bash", "-lc", command], cwd=apps_root).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/testing/run_vscode_test_task.sh
+++ b/tests/scripts/testing/run_vscode_test_task.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+workspace_root="/workspace"
+workspace_real="$(readlink -f "${workspace_root}" 2>/dev/null || true)"
+remote_root=""
+
+if [[ "${ROOT_DIR}" == "${workspace_root}"* ]]; then
+  remote_root="${ROOT_DIR}"
+elif [[ -n "${workspace_real}" && "${ROOT_DIR}" == "${workspace_real}"* ]]; then
+  remote_root="${workspace_root}${ROOT_DIR#${workspace_real}}"
+fi
+
+if [[ -z "${remote_root}" || "${remote_root}" != /workspace/* ]]; then
+  echo "[task] this VS Code task must be launched from the eLxr SDK workspace under /workspace" >&2
+  echo "[task] current repo path: ${ROOT_DIR}" >&2
+  exit 2
+fi
+
+remote_helper="${remote_root}/tests/scripts/testing/run_vscode_test_task.py"
+remote_recovery_helper="${remote_root}/tests/scripts/testing/run_fix_devkit_runtime.py"
+recovery_cmd="dk $(printf '%q' "${remote_recovery_helper}")"
+
+cmd="dk $(printf '%q' "${remote_helper}")"
+for arg in "$@"; do
+  cmd+=" $(printf '%q' "${arg}")"
+done
+
+if bash -ic 'type dk >/dev/null 2>&1'; then
+  :
+else
+  echo "[task] dk is not available in the current SDK shell" >&2
+  exit 2
+fi
+
+if ! bash -ic "${recovery_cmd}"; then
+  rc=$?
+  echo ""
+  echo "[task] board recovery failed. Press Enter to close this task terminal."
+  read -r
+  exit "${rc}"
+fi
+
+if bash -ic "${cmd}"; then
+  exit 0
+else
+  rc=$?
+  echo ""
+  echo "[task] board-side tests failed. Press Enter to close this task terminal."
+  read -r
+  exit "${rc}"
+fi


### PR DESCRIPTION
## Summary
Add shared VS Code tasks and helper scripts for board-side test execution in the `apps` repo.

This PR solves the repeated, error-prone workflow of manually running `./build.sh`, sourcing the test environment, and invoking the correct `tests/test.sh` arguments on the board. It also adds a small recovery helper so the task flow can recover the DevKit runtime before running tests.

---

## Type of Change
Please mark the relevant options with an `x`:

- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Refactor / code cleanup  
- [x] Tests / CI improvements  

---

## Testing & Verification
Describe how you tested your changes:  
- [ ] Unit tests added/updated  
- [ ] Built successfully on hardware (e.g., Modalix, Davinci DevKit)  
- [ ] Verified with Yocto/SDK build  
- [ ] Manual functional tests (describe below)  

Local verification performed:
- `python3 -m py_compile tests/scripts/testing/run_fix_devkit_runtime.py tests/scripts/testing/run_vscode_test_task.py`
- `bash -n tests/scripts/testing/run_vscode_test_task.sh`
- `python3 -m json.tool .vscode/tasks.json >/dev/null`

---

## Checklist
- [x] Code follows project style guidelines  
- [ ] Comments/documentation updated where needed  
- [ ] New dependencies documented in README or `requirements.txt`  
- [x] Related issues linked in PR description  
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)  

---

## Additional Notes
This PR adds:
- shared VS Code test tasks under `.vscode/tasks.json`
- a Python helper that removes a stale build directory when the checkout path changes
- a shell wrapper that ensures the task runs from the eLxr SDK `/workspace` path and uses `dk` for board-side execution
- a small recovery helper for `fix_devkit_runtime.sh`

I did not run the full board-side flow end-to-end in this turn.
