### PR TITLE
Fix develop portal asset base path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,7 @@ jobs:
       AWS_EC2_METADATA_DISABLED: "true"
       R2_ENDPOINT_URL: https://${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
       PORTAL_R2_PATH: ${{ github.ref_name == 'develop' && 's3://neat-artifacts/dev-portal/' || 's3://neat-artifacts/portal/' }}
-      PORTAL_BASE_URL: ${{ github.ref_name == 'develop' && vars.DEV_PORTAL_BASE_URL || 'https://apps.sima-neat.com/portal' }}
+      PORTAL_BASE_URL: ${{ github.ref_name == 'develop' && 'https://apps.sima-neat.com/dev-portal' || 'https://apps.sima-neat.com/portal' }}
 
     steps:
       - name: Checkout apps repo

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -49,6 +49,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1255,6 +1256,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1531,6 +1533,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1572,6 +1575,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1581,6 +1585,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1767,6 +1772,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/portal/public/category-assets/re-identification.svg
+++ b/portal/public/category-assets/re-identification.svg
@@ -1,0 +1,21 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="92" y="84" width="184" height="192" rx="16" stroke="#F7F8FF" stroke-width="2"/>
+  <rect x="364" y="84" width="184" height="192" rx="16" stroke="#F7F8FF" stroke-width="2" stroke-opacity="0.9"/>
+  <circle cx="184" cy="152" r="28" stroke="#F7F8FF" stroke-width="2"/>
+  <circle cx="456" cy="152" r="28" stroke="#F7F8FF" stroke-width="2" stroke-opacity="0.9"/>
+  <path d="M138 226C148 202 168 190 184 190C200 190 220 202 230 226" stroke="#F7F8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M410 226C420 202 440 190 456 190C472 190 492 202 502 226" stroke="#F7F8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.9"/>
+  <path d="M276 148H364" stroke="#F7F8FF" stroke-width="2" stroke-linecap="round" stroke-dasharray="8 8"/>
+  <path d="M330 132L364 148L330 164" stroke="#F7F8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="320" cy="148" r="16" fill="#F7F8FF" fill-opacity="0.12" stroke="#F7F8FF" stroke-width="2"/>
+  <path d="M312 148L318 154L330 142" stroke="#F7F8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M120 108H248" stroke="#F7F8FF" stroke-width="2" stroke-opacity="0.32"/>
+  <path d="M392 108H520" stroke="#F7F8FF" stroke-width="2" stroke-opacity="0.24"/>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#204176"/>
+      <stop offset="1" stop-color="#4EA9E1"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/portal/vite.config.js
+++ b/portal/vite.config.js
@@ -1,9 +1,26 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+function resolveBasePath() {
+  const raw = process.env.PORTAL_BASE_URL?.trim();
+  if (!raw) {
+    return "/portal/";
+  }
+
+  try {
+    const pathname = new URL(raw).pathname;
+    return pathname.endsWith("/") ? pathname : `${pathname}/`;
+  } catch {
+    if (raw.startsWith("/")) {
+      return raw.endsWith("/") ? raw : `${raw}/`;
+    }
+    return `/${raw.replace(/^\/+|\/+$/g, "")}/`;
+  }
+}
+
 export default defineConfig({
   plugins: [react()],
-  base: "/portal/",
+  base: resolveBasePath(),
   server: {
     host: "0.0.0.0",
     port: 5000,


### PR DESCRIPTION
## Summary
- derive Vite `base` from `PORTAL_BASE_URL` instead of hardcoding `/portal/`
- set develop workflow `PORTAL_BASE_URL` to `https://apps.sima-neat.com/dev-portal`
- keep main workflow path on `https://apps.sima-neat.com/portal`
- Added a missing catalog image

## Why
Develop deployments were emitting `/portal/assets/...` links and returning 404 under `/dev-portal/`.
