### PR TITLE
fix: pin apps modelzoo downloads to sdk 2.0.0

### DIFF
--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -25,13 +25,13 @@ Optional. If you have a demo screenshot for the portal detail page, place it her
 Also works with: `<model_variant_1>`, `<model_variant_2>`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get <model_variant_1> && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get <model_variant_1> && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get <default_model_name> && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get <default_model_name> && cd ../..`
 
 ## Important Behavior
 - This example expects the model path to be provided explicitly at runtime.

--- a/examples/classification/simple-image-classification-pipeline/README.md
+++ b/examples/classification/simple-image-classification-pipeline/README.md
@@ -22,12 +22,12 @@ The pipeline is trying to classify this goldfish image.
 Primary model: `resnet_50`
 
 Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get resnet_50 && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get resnet_50 && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get resnet_50 && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get resnet_50 && cd ../..`
 
 ## Important Behavior
 - `--model` is required in both C++ and Python.

--- a/examples/depth-estimation/live-rtsp-depth-estimation/README.md
+++ b/examples/depth-estimation/live-rtsp-depth-estimation/README.md
@@ -59,15 +59,15 @@ Both implementations keep source/session setup, model setup, processing loop, re
 Also works with: `depth_anything_v2_vits`
 
 Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get midas_v21_small_256 && cd ../..`
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get depth_anything_v2_vits && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get midas_v21_small_256 && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - RTSP source reachable from runtime environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command (MiDaS): `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get midas_v21_small_256 && cd ../..`
-- Download command (Depth Anything V2): `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get depth_anything_v2_vits && cd ../..`
+- Download command (MiDaS): `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get midas_v21_small_256 && cd ../..`
+- Download command (Depth Anything V2): `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 
 ## Important Behavior
 - `--model` is required for both C++ and Python.

--- a/examples/depth-estimation/offline-depth-map-generation/README.md
+++ b/examples/depth-estimation/offline-depth-map-generation/README.md
@@ -22,12 +22,12 @@ Snippet from a pipeline run:
 Primary model: `depth_anything_v2_vits`
 
 Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get depth_anything_v2_vits && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get depth_anything_v2_vits && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 
 ## Important Behavior
 - Model path is positional and required.

--- a/examples/instance-segmentation/offline-instance-segmentation-overlay/README.md
+++ b/examples/instance-segmentation/offline-instance-segmentation-overlay/README.md
@@ -22,12 +22,12 @@ Snippet from a pipeline run:
 Also works with: `yolo_v8s_seg`, `yolo_v8m_seg`, `yolo_v8l_seg`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8n_seg && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n_seg && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8n_seg && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n_seg && cd ../..`
 
 ## Important Behavior
 - Model path is positional and required.

--- a/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/README.md
+++ b/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/README.md
@@ -22,12 +22,12 @@ Snippet from a pipeline run:
 Also works with: `yolov5s`, `yolov5m`, `yolov5l`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolov5n && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolov5n && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolov5n && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolov5n && cd ../..`
 
 ## Important Behavior
 - Model path is positional and required.

--- a/examples/object-detection/multistream-object-detection-optiview/README.md
+++ b/examples/object-detection/multistream-object-detection-optiview/README.md
@@ -48,11 +48,11 @@ Video graph:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli modelzoo get yolo_v8n
-sima-cli modelzoo get yolo_v8s
-sima-cli modelzoo get yolo_v8m
-sima-cli modelzoo get yolo_v8l
-sima-cli modelzoo get yolo_v8x
+sima-cli modelzoo -v 2.0.0 get yolo_v8n
+sima-cli modelzoo -v 2.0.0 get yolo_v8s
+sima-cli modelzoo -v 2.0.0 get yolo_v8m
+sima-cli modelzoo -v 2.0.0 get yolo_v8l
+sima-cli modelzoo -v 2.0.0 get yolo_v8x
 ```
 
 ## Build

--- a/examples/object-detection/multistream-rtsp-detection-pipeline/README.md
+++ b/examples/object-detection/multistream-rtsp-detection-pipeline/README.md
@@ -83,13 +83,13 @@ In C++, producer start is intentionally gated until infer/overlay workers are li
 Also works with: `yolo_v8n`, `yolo_v8s`, `yolo_v8l`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8m && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8m && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - One or more RTSP camera sources.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8m && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8m && cd ../..`
 
 ## Important Behavior
 - `--model`, `--output`, and at least one `--rtsp` are required.

--- a/examples/object-detection/simple-object-detection-overlay-pipeline/README.md
+++ b/examples/object-detection/simple-object-detection-overlay-pipeline/README.md
@@ -23,12 +23,12 @@ Snippet from a pipeline run:
 Also works with: `yolo_v8s`, `yolo_v8m`, `yolo_v8l`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8n && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8n && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n && cd ../..`
 - Labels file: `examples/object-detection/simple-object-detection-overlay-pipeline/common/coco_label.txt`
 
 ## Important Behavior

--- a/examples/object-detection/single-rtsp-object-detection-optiview/README.md
+++ b/examples/object-detection/single-rtsp-object-detection-optiview/README.md
@@ -74,7 +74,7 @@ This separation keeps the RTSP session from being tightly coupled to the inferen
 - RTSP camera source or use OptiView to start RTSP source
 - SiMa.ai developer portal account so the sample can download the model from modelzoo
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get yolo_v8s && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8s && cd ../..`
 
 
 ## Important Behavior
@@ -193,7 +193,7 @@ Example workflow:
 Download the `yolo_v8s` model using `sima-cli`:
 
 ```bash
-sima-cli modelzoo get yolo_v8s
+sima-cli modelzoo -v 2.0.0 get yolo_v8s
 ```
 
 Then start the Python app:
@@ -206,7 +206,7 @@ python3 python/main.py --rtsp <rtsp-url> --model yolo_v8s_mpk.tar.gz
 
 Python-specific notes:
 
-- if `--model` is omitted, the Python version tries to locate `yolo_v8s` locally and then falls back to `sima-cli modelzoo get yolo_v8s`
+- if `--model` is omitted, the Python version tries to locate `yolo_v8s` locally and then falls back to `sima-cli modelzoo -v 2.0.0 get yolo_v8s`
 - it sends OptiView JSON directly over UDP and streams video to the OptiView UDP video port
 - it expects OpenCV to be built with GStreamer support for the UDP H.264 video path
 

--- a/examples/object-detection/single-rtsp-object-detection-optiview/python/main.py
+++ b/examples/object-detection/single-rtsp-object-detection-optiview/python/main.py
@@ -545,7 +545,7 @@ def resolve_yolov8s_model(root: Path) -> str:
 
     1. explicit environment override
     2. local/common modelzoo directories
-    3. `sima-cli modelzoo get yolo_v8s`
+    3. `sima-cli modelzoo -v 2.0.0 get yolo_v8s`
     """
     env_path = os.environ.get("SIMA_YOLO_TAR", "")
     if env_path and Path(env_path).exists():
@@ -603,7 +603,7 @@ def main() -> int:
     model_path = cfg.model or resolve_yolov8s_model(Path.cwd())
     if not model_path or not Path(model_path).is_file():
         print("Failed to locate yolo_v8s compiled model package.", file=sys.stderr)
-        print("Set --model or run 'sima-cli modelzoo get yolo_v8s'.", file=sys.stderr)
+        print("Set --model or run 'sima-cli modelzoo -v 2.0.0 get yolo_v8s'.", file=sys.stderr)
         return 2
 
     rtsp_session = None

--- a/examples/pose-estimation/simple-pose-estimation-overlay-pipeline/README.md
+++ b/examples/pose-estimation/simple-pose-estimation-overlay-pipeline/README.md
@@ -19,11 +19,11 @@ Minimal image-folder pose estimation pipeline. Each image is inferred to extract
 
 ## Supported Models
 Download variants into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get open_pose && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get open_pose && cd ../..`
 
 ## Prerequisites
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get open_pose && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get open_pose && cd ../..`
 - Shared runtime and decode parameters live in `common/config.yaml`.
 
 ## Important Behavior

--- a/examples/semantic-segmentation/simple-semantic-segmentation-overlay-pipeline/README.md
+++ b/examples/semantic-segmentation/simple-semantic-segmentation-overlay-pipeline/README.md
@@ -22,12 +22,12 @@ Snippet from a pipeline run:
 Also works with: `fcn_hrnet18`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get fcn_hrnet48 && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get fcn_hrnet48 && cd ../..`
 
 ## Prerequisites
 - Installed NEAT SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo get fcn_hrnet48 && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get fcn_hrnet48 && cd ../..`
 
 ## Important Behavior
 - Model path is positional and required.

--- a/examples/tracking/multi-camera-people-detection-and-tracking-optiview/README.md
+++ b/examples/tracking/multi-camera-people-detection-and-tracking-optiview/README.md
@@ -33,11 +33,11 @@ Download any variant into `assets/models/`:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli modelzoo get yolo_v8n
-sima-cli modelzoo get yolo_v8s
-sima-cli modelzoo get yolo_v8m
-sima-cli modelzoo get yolo_v8l
-sima-cli modelzoo get yolo_v8x
+sima-cli modelzoo -v 2.0.0 get yolo_v8n
+sima-cli modelzoo -v 2.0.0 get yolo_v8s
+sima-cli modelzoo -v 2.0.0 get yolo_v8m
+sima-cli modelzoo -v 2.0.0 get yolo_v8l
+sima-cli modelzoo -v 2.0.0 get yolo_v8x
 cd ../..
 ```
 

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -157,7 +157,7 @@ download_model() {
     before=$(ls "$MODELS_DIR"/*.tar.gz 2>/dev/null | wc -l)
 
     echo "[download] $model_name"
-    (cd "$MODELS_DIR" && "$SIMA_CLI_BIN" modelzoo get "$model_name")
+    (cd "$MODELS_DIR" && "$SIMA_CLI_BIN" modelzoo -v 2.0.0 get "$model_name")
 
     local after
     after=$(ls "$MODELS_DIR"/*.tar.gz 2>/dev/null | wc -l)

--- a/support/runtime/asset_utils.cpp
+++ b/support/runtime/asset_utils.cpp
@@ -118,7 +118,7 @@ std::string resolve_resnet50_tar(const fs::path& root_in) {
   if (fs::exists(local))
     return local.string();
 
-  const int rc = std::system("sima-cli modelzoo get resnet_50");
+  const int rc = std::system("sima-cli modelzoo -v 2.0.0 get resnet_50");
   if (rc != 0)
     return "";
 
@@ -186,7 +186,7 @@ std::string resolve_yolov8s_tar_local_first(const fs::path& root_in, bool skip_d
   }
 
   if (!skip_download) {
-    const int rc = std::system("sima-cli modelzoo get yolo_v8s");
+    const int rc = std::system("sima-cli modelzoo -v 2.0.0 get yolo_v8s");
     if (rc == 0 && fs::exists(tmp_tar))
       return tmp_tar.string();
   }
@@ -305,7 +305,7 @@ std::string resolve_modelzoo_tar(const std::string& model_name, const fs::path& 
     }
   }
 
-  const std::string cmd = "sima-cli modelzoo get " + shell_quote(model_name);
+  const std::string cmd = "sima-cli modelzoo -v 2.0.0 get " + shell_quote(model_name);
   if (std::system(cmd.c_str()) != 0)
     return "";
 

--- a/tests/scripts/test_modelzoo_version_pin.py
+++ b/tests/scripts/test_modelzoo_version_pin.py
@@ -1,0 +1,37 @@
+"""Regression tests for explicit apps-side modelzoo version pinning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+APPS_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _files_requiring_pinned_modelzoo_calls() -> list[Path]:
+    files = [
+        APPS_ROOT / "scripts" / "download_models.sh",
+        APPS_ROOT / "support" / "runtime" / "asset_utils.cpp",
+        APPS_ROOT / "examples" / "TEMPLATE_README.md",
+    ]
+    files.extend(sorted((APPS_ROOT / "examples").glob("*/*/README.md")))
+    files.append(
+        APPS_ROOT
+        / "examples"
+        / "object-detection"
+        / "single-rtsp-object-detection-optiview"
+        / "python"
+        / "main.py"
+    )
+    return files
+
+
+def test_apps_surfaces_do_not_use_unpinned_modelzoo_get():
+    offenders: list[str] = []
+
+    for path in _files_requiring_pinned_modelzoo_calls():
+        text = path.read_text(encoding="utf-8")
+        if "modelzoo get" in text:
+            offenders.append(str(path.relative_to(APPS_ROOT)))
+
+    assert offenders == []


### PR DESCRIPTION
# Pull Request Template

## Summary
Pin apps-side `sima-cli modelzoo` usage to SDK `2.0.0` so examples, packaged installs, and runtime fallback downloads do not drift to `2.1.0` when that release becomes the GA default.

Fixes #89.

---

## Type of Change
Please mark the relevant options with an `x`:

- [x] Bug fix  
- [ ] New feature  
- [x] Documentation update  
- [ ] Refactor / code cleanup  
- [x] Tests / CI improvements  

---

## Testing & Verification
Describe how you tested your changes:  
- [x] Unit tests added/updated  
- [ ] Built successfully on hardware (e.g., Modalix, Davinci DevKit)  
- [ ] Verified with Yocto/SDK build  
- [x] Manual functional tests (describe below)  

Commands run:
- `uv run --with pytest pytest tests/scripts/test_modelzoo_version_pin.py -q`
- `python3 scripts/validate_readmes.py`
- `bash -n scripts/download_models.sh`
- `python3 -m py_compile examples/object-detection/single-rtsp-object-detection-optiview/python/main.py`
- `git diff --check`

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Comments/documentation updated where needed  
- [x] New dependencies documented in README or `requirements.txt`  
- [x] Related issues linked in PR description  
- [x] Planned merge method matches the target branch policy in `CONTRIBUTING.md`  
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)  

---

## Additional Notes
- Updated apps README/template examples to use `sima-cli modelzoo -v 2.0.0 get ...` while leaving `modalix` implicit.
- Updated `scripts/download_models.sh` and `support/runtime/asset_utils.cpp` so packaged installs and apps runtime fallback paths use the same explicit version pin.
- Added a regression test that fails if a bare `modelzoo get` call is reintroduced in the apps surfaces covered by this patch.
- For a PR targeting `develop`, the intended merge method is `Squash and merge`, matching the org contribution guidance.
