### PR TITLE
[codex] Update NEAT portal branding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,8 +48,8 @@ Paste the full error message, traceback, or relevant logs. Redact secrets if nee
 
 - Hardware platform:
 - Host OS:
-- SiMa NEAT apps branch or commit:
-- NEAT/core SDK version:
+- SiMa.ai Neat apps branch or commit:
+- Neat/core SDK version:
 - Python version, compiler, or toolchain:
 - Model, media, or RTSP source details:
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ portal/public/example-assets/
 install_neat_framework.sh
 neat-apps-runtime/
 docs/*
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Examples are organized under `examples/<category>/<example>`. Each example is so
 | `examples/<category>/<example>/common/` | Files shared by the C++ and Python implementations |
 
 > **IMPORTANT:** Use this structure when reading, extending, or adding examples.
-> Follow the instructions inside each example `README.md`, or visit the [SiMa NEAT Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
+> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai NEAT Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
 
 ### Contributor Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SiMa NEAT Apps
+# SiMa Neat Apps
 
 ![Standard Build & Archive](https://img.shields.io/badge/Standard%20Build%20%26%20Archive-TBA-lightgrey)
 ![Fuzz Nightly](https://img.shields.io/badge/Fuzz%20Nightly-TBA-lightgrey)
@@ -6,12 +6,12 @@
 ![SDK](https://img.shields.io/badge/SDK-2.0-green)
 ![Language](https://img.shields.io/badge/C%2B%2B-20-informational)
 
-NEAT Apps contains editable NEAT applications and reference examples built around real workflows such as detection, segmentation, and streaming pipelines. The goal is to make the apps easy to run, easy to modify, and easy to learn from.
+Neat Apps contains editable Neat applications and reference examples built around real workflows such as detection, segmentation, and streaming pipelines. The goal is to make the apps easy to run, easy to modify, and easy to learn from.
 
-The core idea is simple: `core` installs the NEAT SDK, runtime, and tooling, while `apps` shows how to use them in customer-facing C++ and Python examples where the important NEAT API calls stay visible in the source.
+The core idea is simple: `core` installs the Neat SDK, runtime, and tooling, while `apps` shows how to use them in customer-facing C++ and Python examples where the important Neat API calls stay visible in the source.
 
 This repo is intentionally separate from `core`:
-- `core` installs the NEAT SDK/runtime/tooling
+- `core` installs the Neat SDK/runtime/tooling
 - `apps` holds customer-facing applications and sample code
 
 ## Customer Workflow (Early Release)
@@ -32,7 +32,7 @@ This repo is intentionally separate from `core`:
 
    **Note:** After the initial setup completes, the default `pyneat` virtual environment is available at `~/pyneat`. Activate it with `source ~/pyneat/bin/activate` to run Python examples.
 
-3. For broader NEAT framework concepts and platform documentation, see:
+3. For broader Neat framework concepts and platform documentation, see:
    https://docs.sima-neat.com/
 
 This keeps examples editable and easy to customize.
@@ -43,7 +43,7 @@ This keeps examples editable and easy to customize.
 - `support/`: shared C++ helper code used by multiple examples
 - `assets/`: user-managed runtime assets (models under `assets/models/`, test media under `assets/test_images/`)
 - `tests/`: centralized test infrastructure (runner, env setup, pytest config/docs)
-- `neat-core.json`: NEAT core SDK dependency declaration (branch and version)
+- `neat-core.json`: Neat core SDK dependency declaration (branch and version)
 
 ## Example Structure
 
@@ -55,18 +55,18 @@ Examples are organized under `examples/<category>/<example>`. Each example is so
 | --- | --- |
 | `examples/<category>/<example>/README.md` | Example-specific usage and setup instructions |
 | `examples/<category>/<example>/cpp/CMakeLists.txt` | C++ example build configuration |
-| `examples/<category>/<example>/cpp/main.cpp` | C++ entrypoint with visible NEAT API flow |
+| `examples/<category>/<example>/cpp/main.cpp` | C++ entrypoint with visible Neat API flow |
 | `examples/<category>/<example>/cpp/tests/CMakeLists.txt` | C++ test build configuration |
 | `examples/<category>/<example>/cpp/tests/unit_test.cpp` | C++ unit tests |
 | `examples/<category>/<example>/cpp/tests/e2e_test.cpp` | C++ end-to-end tests |
-| `examples/<category>/<example>/python/main.py` | Python entrypoint with visible NEAT API flow |
+| `examples/<category>/<example>/python/main.py` | Python entrypoint with visible Neat API flow |
 | `examples/<category>/<example>/python/requirements.txt` | Python example dependencies |
 | `examples/<category>/<example>/python/tests/test_unit.py` | Python unit tests |
 | `examples/<category>/<example>/python/tests/test_e2e.py` | Python end-to-end tests |
 | `examples/<category>/<example>/common/` | Files shared by the C++ and Python implementations |
 
 > **IMPORTANT:** Use this structure when reading, extending, or adding examples.
-> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai NEAT Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
+> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
 
 ### Contributor Guidelines
 
@@ -77,8 +77,8 @@ For the full contributor rules, required layout, and authoring expectations, see
 `build.sh` has three main modes:
 
 - build/configure the apps locally
-- install the NEAT core SDK only
-- run the full first-time or release flow with `--all`, which installs NEAT core, builds the apps, builds the portal, and packages `neat-apps-runtime`
+- install the Neat core SDK only
+- run the full first-time or release flow with `--all`, which installs Neat core, builds the apps, builds the portal, and packages `neat-apps-runtime`
 
 It does not run tests.
 
@@ -94,10 +94,10 @@ Common commands:
 # Clean build directory then build
 ./build.sh --clean
 
-# Install NEAT core, build apps, build portal, then package
+# Install Neat core, build apps, build portal, then package
 ./build.sh --all
 
-# Install NEAT core only, no build
+# Install Neat core only, no build
 ./build.sh --only-install-neat-core
 
 # Override neat-core.json for one run (branch:version)
@@ -112,8 +112,8 @@ Common commands:
 
 Main `build.sh` args:
 
-- `--all`: install NEAT core SDK, build apps, build portal, then package
-- `--only-install-neat-core`: install NEAT core SDK and exit
+- `--all`: install Neat core SDK, build apps, build portal, then package
+- `--only-install-neat-core`: install Neat core SDK and exit
 - `--neat-core-version <branch:version>`: override `neat-core.json`
 - `--clean`: remove build dir before configure
 - `--debug` / `--release`: build type
@@ -128,7 +128,7 @@ When `--all` is used, the script also:
 - writes a packaged `neat-core.json` into that staged runtime
 - creates `neat-apps-<branch>-<sha>.tar.gz` at the repo root
 
-If NEAT is installed in a custom location and CMake cannot find it automatically, set `CMAKE_PREFIX_PATH`:
+If Neat is installed in a custom location and CMake cannot find it automatically, set `CMAKE_PREFIX_PATH`:
 
 ```bash
 CMAKE_PREFIX_PATH=/path/to/neat/install ./build.sh
@@ -175,7 +175,7 @@ If you use host-streamed sources from a board/devkit, use the host IP in the RTS
 
 ## NEAT Core Dependency
 
-`neat-core.json` declares which NEAT core SDK branch and version this repo depends on.
+`neat-core.json` declares which Neat core SDK branch and version this repo depends on.
 `./build.sh --all` reads this file and uses the hosted `install-neat.sh`
 installer to install the correct SDK before building, packaging, and writing the staged runtime metadata.
 

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -28,7 +28,7 @@ Download any variant into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get <model_variant_1> && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get <default_model_name> && cd ../..`

--- a/examples/classification/simple-image-classification-pipeline/README.md
+++ b/examples/classification/simple-image-classification-pipeline/README.md
@@ -25,7 +25,7 @@ Download into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get resnet_50 && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get resnet_50 && cd ../..`
 

--- a/examples/depth-estimation/live-rtsp-depth-estimation/README.md
+++ b/examples/depth-estimation/live-rtsp-depth-estimation/README.md
@@ -27,7 +27,7 @@ Pipeline:
 
 Both implementations keep source/session setup, model setup, processing loop, reconnect handling, and teardown as explicit lifecycle stages.
 
-## NEAT API Usage
+## Neat API Usage
 
 - RTSP source:
   Python: `RtspDecodedInputOptions` -> `Session.add(rtsp_decoded_input)` -> `build()`
@@ -63,7 +63,7 @@ Download into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - RTSP source reachable from runtime environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command (MiDaS): `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get midas_v21_small_256 && cd ../..`

--- a/examples/depth-estimation/offline-depth-map-generation/README.md
+++ b/examples/depth-estimation/offline-depth-map-generation/README.md
@@ -25,7 +25,7 @@ Download into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
 

--- a/examples/face-detection/retinaface-face-detection/README.md
+++ b/examples/face-detection/retinaface-face-detection/README.md
@@ -35,7 +35,7 @@ Download into `assets/models/`:
 - `./scripts/download_models.sh retinaface_mobilenet25`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Preferred download command: `./scripts/download_models.sh retinaface_mobilenet25`
 - Direct URL fallback:

--- a/examples/instance-segmentation/offline-instance-segmentation-overlay/README.md
+++ b/examples/instance-segmentation/offline-instance-segmentation-overlay/README.md
@@ -25,7 +25,7 @@ Download any variant into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n_seg && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n_seg && cd ../..`
 

--- a/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/README.md
+++ b/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/README.md
@@ -25,7 +25,7 @@ Download any variant into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolov5n && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolov5n && cd ../..`
 

--- a/examples/object-detection/detr-object-detection/README.md
+++ b/examples/object-detection/detr-object-detection/README.md
@@ -28,7 +28,7 @@ Download into `assets/models/`:
 - `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be placed under `assets/models/`.
 - Preferred download command: `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
 - Direct URL fallback:

--- a/examples/object-detection/multistream-object-detection-optiview/README.md
+++ b/examples/object-detection/multistream-object-detection-optiview/README.md
@@ -32,7 +32,7 @@ Video graph:
 - `Input(RGB) -> VideoConvert -> H264EncodeSima -> UdpH264OutputGroup`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - One or more reachable RTSP camera URLs.
 - A YOLOv8 model pack downloaded into `assets/models/`.
 - Edit `common/config.yaml` before running with real streams.

--- a/examples/object-detection/multistream-rtsp-detection-pipeline/README.md
+++ b/examples/object-detection/multistream-rtsp-detection-pipeline/README.md
@@ -35,12 +35,12 @@ Each RTSP stream gets its own set of producer, infer, and overlay worker threads
 Both implementations are intentionally kept in one file (`python/main.py`, `cpp/main.cpp`) but now follow the same high-level structure:
 
 1. CLI/config parsing and validation
-2. NEAT runtime builders (RTSP and model/infer)
+2. Neat runtime builders (RTSP and model/infer)
 3. Shared runtime state (stream state, packets, queues, profiling)
 4. Worker methods (producer, infer, overlay)
 5. Orchestration (thread startup, monitor loop, shutdown, summary)
 
-## NEAT API Usage
+## Neat API Usage
 
 **Python (`pyneat`)**
 - RTSP session build (`build_rtsp_run` in `python/main.py`):

--- a/examples/object-detection/simple-object-detection-overlay-pipeline/README.md
+++ b/examples/object-detection/simple-object-detection-overlay-pipeline/README.md
@@ -26,7 +26,7 @@ Download any variant into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n && cd ../..`
 - Labels file: `examples/object-detection/simple-object-detection-overlay-pipeline/common/coco_label.txt`

--- a/examples/object-detection/single-rtsp-object-detection-optiview/README.md
+++ b/examples/object-detection/single-rtsp-object-detection-optiview/README.md
@@ -51,7 +51,7 @@ The sample is split into three independent runtime stages:
 3. `OptiView output`
    The original decoded frame is copied into a second runtime path that re-encodes to H.264, packetizes to RTP, and sends video over UDP to OptiView. Detection results from the YOLO path are converted into OptiView JSON and sent on the JSON side channel.
 
-## NEAT API Usage
+## Neat API Usage
 
 - RTSP ingest: `RtspDecodedInputOptions` -> `Session.add(rtsp_decoded_input)` -> `Session.build(...)`
 - YOLO path:
@@ -70,7 +70,7 @@ The example uses a producer/consumer design:
 This separation keeps the RTSP session from being tightly coupled to the inference latency of each frame and makes timing/debug output easier to interpret.
 
 ## Prerequisites
-- Installed NEAT framework and OptiView on the DevKit
+- Installed Neat framework and OptiView on the DevKit
 - RTSP camera source or use OptiView to start RTSP source
 - SiMa.ai developer portal account so the sample can download the model from modelzoo
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
@@ -137,12 +137,12 @@ The resulting binary is:
 ./build/single-rtsp-object-detection-optiview
 ```
 
-Direct CMake builds use the shared example module support in the `apps` repo and link against the available NEAT/core installation or local core build.
+Direct CMake builds use the shared example module support in the `apps` repo and link against the available Neat/core installation or local core build.
 
 In practice:
 
 - on `eLxr SDK`, this is typically done after sourcing the SDK environment and then building from the repo or the example folder
-- on `DevKit`, this can be done directly on the target device as long as the required NEAT dependencies are installed
+- on `DevKit`, this can be done directly on the target device as long as the required Neat dependencies are installed
 
 ## RTSP Source
 

--- a/examples/object-detection/yolo26-object-detection-overlay/README.md
+++ b/examples/object-detection/yolo26-object-detection-overlay/README.md
@@ -28,7 +28,7 @@ Download into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26m_mod_mpk.tar.gz && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - yolo26m is not yet published in the SiMa modelzoo. Use the direct download URL below until a modelzoo entry is available.
 - Direct URL download:

--- a/examples/re-identification/simple-re-identification-pipeline/README.md
+++ b/examples/re-identification/simple-re-identification-pipeline/README.md
@@ -17,7 +17,7 @@
 ## Concept
 This example performs pairwise person re-identification by computing embeddings for two input images and comparing them with a selectable metric. It is designed as a minimal synchronous pipeline that focuses on practical runtime behavior: model warmup, deterministic preprocessing, inference, score computation, threshold-based decision, and artifact output.
 
-Both C++ and Python implementations follow the same user-facing flow and produce the same output artifacts (`comparison.jpg` and/or `result.json`). The sample demonstrates how to use NEAT for embedding extraction and how to build a lightweight post-processing layer for similarity-based identity matching.
+Both C++ and Python implementations follow the same user-facing flow and produce the same output artifacts (`comparison.jpg` and/or `result.json`). The sample demonstrates how to use Neat for embedding extraction and how to build a lightweight post-processing layer for similarity-based identity matching.
 
 ## Supported Models
 Also works with: other ReID variants compatible with 128x256 RGB input.
@@ -26,7 +26,7 @@ Download the default variant into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get reid && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get reid && cd ../..`
 

--- a/examples/semantic-segmentation/simple-semantic-segmentation-overlay-pipeline/README.md
+++ b/examples/semantic-segmentation/simple-semantic-segmentation-overlay-pipeline/README.md
@@ -25,7 +25,7 @@ Download any variant into `assets/models/`:
 - `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get fcn_hrnet48 && cd ../..`
 
 ## Prerequisites
-- Installed NEAT SDK.
+- Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get fcn_hrnet48 && cd ../..`
 

--- a/examples/tracking/multi-camera-people-detection-and-tracking-optiview/README.md
+++ b/examples/tracking/multi-camera-people-detection-and-tracking-optiview/README.md
@@ -42,7 +42,7 @@ cd ../..
 ```
 
 ## Prerequisites
-- A NEAT Python environment with `pyneat`, `numpy`, and OpenCV available.
+- A Neat Python environment with `pyneat`, `numpy`, and OpenCV available.
 - One or more reachable RTSP camera URLs.
 - A YOLOv8 detector model pack downloaded into `assets/models/`.
 - An OptiView viewer instance reachable from the board/host running this example.

--- a/guidelines.md
+++ b/guidelines.md
@@ -1,4 +1,4 @@
-# NEAT Apps Contributor Guidelines
+# Neat Apps Contributor Guidelines
 
 This document defines how contributors should add and maintain examples in `apps/examples`.
 

--- a/portal/index.html
+++ b/portal/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SiMa NEAT Apps Portal</title>
+    <title>SiMa.ai Neat Apps Portal</title>
     <link rel="icon" type="image/png" href="/sima-logo.png" />
   </head>
   <body>

--- a/portal/src/App.jsx
+++ b/portal/src/App.jsx
@@ -96,9 +96,9 @@ function CatalogPage({ catalog }) {
         <div className="hero-copy">
           <div className="brand-row">
             <img className="brand-logo" src="./sima-logo.png" alt="SiMa.ai" />
-            <p className="eyebrow">SiMa NEAT Apps Portal</p>
+            <p className="eyebrow">SiMa.ai NEAT Apps Portal</p>
           </div>
-          <h1>Discover SiMa NEAT reference examples that expedite the path from proof of concept to product.</h1>
+          <h1>Discover SiMa.ai Neat reference examples that expedite the path from proof of concept to product.</h1>
           <p className="hero-text">
             Browse source-first applications, search across tags and models, and drill into structured
             example documentation generated from the repo itself.


### PR DESCRIPTION
## Summary
- Updates portal-facing branding text from SiMa NEAT to SiMa.ai NEAT/Neat in README and app UI metadata.
- Adds `.vscode/` to `.gitignore`.

## Validation
- `npm run build` from `portal/`
