### PR TITLE
Remove DetessDequant scale workaround from examples

### DIFF
--- a/examples/face-detection/retinaface-face-detection/cpp/main.cpp
+++ b/examples/face-detection/retinaface-face-detection/cpp/main.cpp
@@ -142,7 +142,7 @@ static std::vector<simaai::neat::Tensor> collect_tensors(const simaai::neat::Sam
   throw std::runtime_error("unexpected sample kind");
 }
 
-static std::vector<float> tensor_to_f32(const simaai::neat::Tensor& t, float dq_scale) {
+static std::vector<float> tensor_to_f32(const simaai::neat::Tensor& t) {
   if (t.dtype != simaai::neat::TensorDType::Float32)
     throw std::runtime_error("expected Float32 tensor");
   const std::vector<uint8_t> raw = t.copy_dense_bytes_tight();
@@ -150,7 +150,6 @@ static std::vector<float> tensor_to_f32(const simaai::neat::Tensor& t, float dq_
     throw std::runtime_error("tensor raw byte size is not float-aligned");
   std::vector<float> out(raw.size() / sizeof(float));
   std::memcpy(out.data(), raw.data(), raw.size());
-  sima_examples::apply_detess_dequant_scale_correction(out, dq_scale);
   return out;
 }
 
@@ -263,10 +262,9 @@ static std::vector<float> reshape_rows_grouped(const std::vector<float>& transpo
 }
 
 static void append_rows_python_style(const simaai::neat::Tensor& tensor, int group_size,
-                                     const char* tensor_name, float dq_scale,
-                                     std::vector<float>& out_rows) {
+                                     const char* tensor_name, std::vector<float>& out_rows) {
   const TensorDims4 dims = get_tensor_dims_4d_batch1(tensor, tensor_name);
-  const std::vector<float> raw = tensor_to_f32(tensor, dq_scale);
+  const std::vector<float> raw = tensor_to_f32(tensor);
   const std::vector<float> transposed = transpose_0312_drop_batch(raw, dims, tensor_name);
   const std::vector<float> rows =
       reshape_rows_grouped(transposed, dims.d2, group_size, tensor_name);
@@ -275,14 +273,10 @@ static void append_rows_python_style(const simaai::neat::Tensor& tensor, int gro
 
 static void decode_outputs(const std::vector<simaai::neat::Tensor>& tensors,
                            std::vector<Detection>& out, const PreprocMeta& meta, float conf_thr,
-                           float nms_iou, int top_k, int keep_top_k, bool with_landmarks,
-                           const std::vector<float>& dq_scales) {
+                           float nms_iou, int top_k, int keep_top_k, bool with_landmarks) {
   if (tensors.size() != 9) {
     throw std::runtime_error("expected exactly 9 tensors for RetinaFace (got " +
                              std::to_string(tensors.size()) + ")");
-  }
-  if (dq_scales.size() != tensors.size()) {
-    throw std::runtime_error("RetinaFace DetessDequant scale count mismatch");
   }
 
   // Tensors arrive as [N,H,C,W]; transpose to [N,W,H,C], then group anchors in C.
@@ -292,17 +286,17 @@ static void decode_outputs(const std::vector<simaai::neat::Tensor>& tensors,
   std::vector<float> box_rows;  // flattened rows of 4
   std::vector<float> cls_rows;  // flattened rows of 2 (logits)
 
-  append_rows_python_style(tensors[2], /*group_size=*/10, "land0", dq_scales[2], land_rows);
-  append_rows_python_style(tensors[1], /*group_size=*/10, "land1", dq_scales[1], land_rows);
-  append_rows_python_style(tensors[0], /*group_size=*/10, "land2", dq_scales[0], land_rows);
+  append_rows_python_style(tensors[2], /*group_size=*/10, "land0", land_rows);
+  append_rows_python_style(tensors[1], /*group_size=*/10, "land1", land_rows);
+  append_rows_python_style(tensors[0], /*group_size=*/10, "land2", land_rows);
 
-  append_rows_python_style(tensors[5], /*group_size=*/4, "box0", dq_scales[5], box_rows);
-  append_rows_python_style(tensors[4], /*group_size=*/4, "box1", dq_scales[4], box_rows);
-  append_rows_python_style(tensors[3], /*group_size=*/4, "box2", dq_scales[3], box_rows);
+  append_rows_python_style(tensors[5], /*group_size=*/4, "box0", box_rows);
+  append_rows_python_style(tensors[4], /*group_size=*/4, "box1", box_rows);
+  append_rows_python_style(tensors[3], /*group_size=*/4, "box2", box_rows);
 
-  append_rows_python_style(tensors[8], /*group_size=*/2, "cls0", dq_scales[8], cls_rows);
-  append_rows_python_style(tensors[7], /*group_size=*/2, "cls1", dq_scales[7], cls_rows);
-  append_rows_python_style(tensors[6], /*group_size=*/2, "cls2", dq_scales[6], cls_rows);
+  append_rows_python_style(tensors[8], /*group_size=*/2, "cls0", cls_rows);
+  append_rows_python_style(tensors[7], /*group_size=*/2, "cls1", cls_rows);
+  append_rows_python_style(tensors[6], /*group_size=*/2, "cls2", cls_rows);
 
   const std::vector<Prior> priors = make_priors(kInferH, kInferW);
   if (priors.size() != 16800) {
@@ -561,8 +555,6 @@ int main(int argc, char** argv) {
     model_opt.preprocess.input_max_depth = 3;
 
     simaai::neat::Model model(args.model, model_opt);
-    const std::vector<float> dq_scales =
-        sima_examples::detess_dequant_scales(model, /*expected_count=*/9, "RetinaFace");
 
     simaai::neat::Session session;
     session.add(simaai::neat::nodes::Input(model.input_appsrc_options(true)));
@@ -601,7 +593,7 @@ int main(int argc, char** argv) {
         const std::vector<simaai::neat::Tensor> out_tensors = collect_tensors(*out_sample);
         dets.clear();
         decode_outputs(out_tensors, dets, meta, args.conf, args.nms, args.top_k, args.keep_top_k,
-                       args.landmarks, dq_scales);
+                       args.landmarks);
         const auto t3 = std::chrono::steady_clock::now();
 
         const std::chrono::duration<double> dt_session = t1 - t0;
@@ -676,7 +668,7 @@ int main(int argc, char** argv) {
       }
 
       decode_outputs(out_tensors, dets, meta, args.conf, args.nms, args.top_k, args.keep_top_k,
-                     args.landmarks, dq_scales);
+                     args.landmarks);
 
       std::cout << "Detections: " << dets.size() << "\n";
       for (size_t i = 0; i < std::min<size_t>(dets.size(), 20); ++i) {

--- a/examples/face-detection/retinaface-face-detection/python/main.py
+++ b/examples/face-detection/retinaface-face-detection/python/main.py
@@ -11,7 +11,6 @@ This script performs an end-to-end single-image RetinaFace pipeline:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import sys
 import time
@@ -55,13 +54,8 @@ class PreprocMeta(NamedTuple):
     pad_left: int
 
 
-def tensor_to_numpy(t: pyneat.Tensor, dq_scale: float | None = None) -> np.ndarray:
-    arr = np.asarray(t.to_numpy(copy=True))
-    if dq_scale is None:
-        return arr
-    if dq_scale <= 0.0:
-        raise ValueError(f"Invalid DetessDequant dq_scale: {dq_scale}")
-    return arr.astype(np.float32, copy=False) / (dq_scale * dq_scale)
+def tensor_to_numpy(t: pyneat.Tensor) -> np.ndarray:
+    return np.asarray(t.to_numpy(copy=True))
 
 
 def iter_tensors(sample: pyneat.Sample):
@@ -89,29 +83,8 @@ def tensor_from_hwc_f32(array: np.ndarray) -> pyneat.Tensor:
     )
 
 
-def detess_dequant_scales(model: pyneat.Model, expected_count: int, label: str) -> list[float]:
-    config_path = model.find_config_path_by_plugin("postproc")
-    if not config_path:
-        raise RuntimeError(f"{label}: DetessDequant postproc config is missing")
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    scales = config.get("dq_scale")
-    if not isinstance(scales, list):
-        raise RuntimeError(f"{label}: DetessDequant dq_scale array is missing")
-    if len(scales) != expected_count:
-        raise RuntimeError(
-            f"{label}: expected {expected_count} dq_scale values, got {len(scales)}"
-        )
-    return [float(x) for x in scales]
-
-
-def scaled_numpy_outputs(tensors: list[pyneat.Tensor], dq_scales: list[float]) -> list[np.ndarray]:
-    if len(tensors) != len(dq_scales):
-        raise ValueError(
-            f"RetinaFace output/scale count mismatch: {len(tensors)} tensors, "
-            f"{len(dq_scales)} scales"
-        )
-    return [tensor_to_numpy(t, scale) for t, scale in zip(tensors, dq_scales)]
+def tensor_numpy_outputs(tensors: list[pyneat.Tensor]) -> list[np.ndarray]:
+    return [tensor_to_numpy(t) for t in tensors]
 
 
 def pad_image_bgr(
@@ -451,7 +424,6 @@ def prepare_session_and_frame(
 
     _log("Creating pyneat.Model")
     model = pyneat.Model(str(model_path), opt)
-    dq_scales = detess_dequant_scales(model, 9, "RetinaFace")
 
     _log("Building Session pipeline: input -> quant_tess -> infer(MLA) -> detess_dequant -> output")
     sess = pyneat.Session()
@@ -466,15 +438,15 @@ def prepare_session_and_frame(
     dummy = tensor_from_hwc_f32(np.zeros((INFER_HEIGHT, INFER_WIDTH, 3), dtype=np.float32))
     run = sess.build(dummy, pyneat.RunMode.Async)
 
-    return run, tensor_from_hwc_f32(resized), bgr, meta, dq_scales
+    return run, tensor_from_hwc_f32(resized), bgr, meta
 
 
 def run_retinaface_inference(
     model_path: Path,
     image_path: Path,
-) -> tuple[list[pyneat.Tensor], list[float], np.ndarray, PreprocMeta]:
+) -> tuple[list[pyneat.Tensor], np.ndarray, PreprocMeta]:
     _log(f"Starting inference. model_path={model_path}, image_path={image_path}")
-    run, input_tensor, bgr, meta, dq_scales = prepare_session_and_frame(model_path, image_path)
+    run, input_tensor, bgr, meta = prepare_session_and_frame(model_path, image_path)
 
     _log("Pushing preprocessed frame into Session")
     if not run.push_tensor(input_tensor):
@@ -493,7 +465,7 @@ def run_retinaface_inference(
         # Best-effort cleanup: log and continue, do not mask inference result.
         logger.debug("Failed to close RetinaFace session cleanly", exc_info=exc)
 
-    return collect_tensors(samples), dq_scales, bgr, meta
+    return collect_tensors(samples), bgr, meta
 
 
 def main() -> int:
@@ -574,7 +546,7 @@ def main() -> int:
     # Profiling mode: reuse a single session/run and frame, and profile session vs postprocessing.
     if args.profile:
         try:
-            run, input_tensor, orig_bgr, meta, dq_scales = prepare_session_and_frame(
+            run, input_tensor, orig_bgr, meta = prepare_session_and_frame(
                 model_path, Path(args.image)
             )
         except Exception as e:
@@ -598,7 +570,7 @@ def main() -> int:
                 break
 
             tensors = collect_tensors(samples)
-            np_outs = scaled_numpy_outputs(tensors, dq_scales)
+            np_outs = tensor_numpy_outputs(tensors)
             bboxes, scores, landmarks = parse_retinaface_outputs(np_outs)
             t2 = time.perf_counter()
 
@@ -672,7 +644,7 @@ def main() -> int:
 
     try:
         _log("Invoking run_retinaface_inference()")
-        tensors, dq_scales, orig_bgr, meta = run_retinaface_inference(model_path, Path(args.image))
+        tensors, orig_bgr, meta = run_retinaface_inference(model_path, Path(args.image))
     except Exception as e:
         print(f"Error during inference: {e}", file=sys.stderr)
         return 3
@@ -682,7 +654,7 @@ def main() -> int:
         print("No tensors found in model output", file=sys.stderr)
         return 4
 
-    np_outs = scaled_numpy_outputs(tensors, dq_scales)
+    np_outs = tensor_numpy_outputs(tensors)
     print(f"Model produced {len(np_outs)} tensor(s):")
     for i, arr in enumerate(np_outs):
         print(f"  [{i}] shape={arr.shape}, dtype={arr.dtype}")

--- a/examples/instance-segmentation/offline-instance-segmentation-overlay/cpp/main.cpp
+++ b/examples/instance-segmentation/offline-instance-segmentation-overlay/cpp/main.cpp
@@ -153,7 +153,7 @@ inline float at_hwc(const TensorHWC& t, int y, int x, int c) {
   return t.data[idx];
 }
 
-TensorHWC tensor_to_hwc_f32(const simaai::neat::Tensor& t, float dq_scale) {
+TensorHWC tensor_to_hwc_f32(const simaai::neat::Tensor& t) {
   if (t.dtype != simaai::neat::TensorDType::Float32) {
     throw std::runtime_error("expected Float32 tensor");
   }
@@ -183,7 +183,6 @@ TensorHWC tensor_to_hwc_f32(const simaai::neat::Tensor& t, float dq_scale) {
 
   out.data.resize(elems);
   std::memcpy(out.data.data(), bytes.data(), elems * sizeof(float));
-  sima_examples::apply_detess_dequant_scale_correction(out.data, dq_scale);
   return out;
 }
 
@@ -208,24 +207,20 @@ float dfl_distance_16(const float* logits) {
 std::vector<Box>
 decode_yolov8_instances_from_detess(const std::vector<simaai::neat::Tensor>& tensors,
                                     int infer_size, float conf_thr, float nms_iou, int max_det,
-                                    TensorHWC& proto, const std::vector<float>& dq_scales) {
+                                    TensorHWC& proto) {
   if (tensors.size() < 10) {
     throw std::runtime_error("expected at least 10 tensors for instance-seg decode");
   }
-  if (dq_scales.size() != 10) {
-    throw std::runtime_error("instance-seg DetessDequant scale count mismatch");
-  }
-
-  const TensorHWC reg80 = tensor_to_hwc_f32(tensors[0], dq_scales[0]);
-  const TensorHWC reg40 = tensor_to_hwc_f32(tensors[1], dq_scales[1]);
-  const TensorHWC reg20 = tensor_to_hwc_f32(tensors[2], dq_scales[2]);
-  const TensorHWC cls80 = tensor_to_hwc_f32(tensors[3], dq_scales[3]);
-  const TensorHWC cls40 = tensor_to_hwc_f32(tensors[4], dq_scales[4]);
-  const TensorHWC cls20 = tensor_to_hwc_f32(tensors[5], dq_scales[5]);
-  const TensorHWC mk80 = tensor_to_hwc_f32(tensors[6], dq_scales[6]);
-  const TensorHWC mk40 = tensor_to_hwc_f32(tensors[7], dq_scales[7]);
-  const TensorHWC mk20 = tensor_to_hwc_f32(tensors[8], dq_scales[8]);
-  proto = tensor_to_hwc_f32(tensors[9], dq_scales[9]);
+  const TensorHWC reg80 = tensor_to_hwc_f32(tensors[0]);
+  const TensorHWC reg40 = tensor_to_hwc_f32(tensors[1]);
+  const TensorHWC reg20 = tensor_to_hwc_f32(tensors[2]);
+  const TensorHWC cls80 = tensor_to_hwc_f32(tensors[3]);
+  const TensorHWC cls40 = tensor_to_hwc_f32(tensors[4]);
+  const TensorHWC cls20 = tensor_to_hwc_f32(tensors[5]);
+  const TensorHWC mk80 = tensor_to_hwc_f32(tensors[6]);
+  const TensorHWC mk40 = tensor_to_hwc_f32(tensors[7]);
+  const TensorHWC mk20 = tensor_to_hwc_f32(tensors[8]);
+  proto = tensor_to_hwc_f32(tensors[9]);
   if (proto.c != 32) {
     throw std::runtime_error("unexpected prototype channels");
   }
@@ -448,8 +443,6 @@ int main(int argc, char** argv) {
     model_opt.preprocess.input_max_depth = 3;
 
     simaai::neat::Model model(tar_gz, model_opt);
-    const std::vector<float> dq_scales =
-        sima_examples::detess_dequant_scales(model, /*expected_count=*/10, "YOLOv8 instance");
 
     simaai::neat::Session session;
     session.add(simaai::neat::nodes::Input(model.input_appsrc_options(false)));
@@ -503,7 +496,7 @@ int main(int argc, char** argv) {
       TensorHWC proto;
       try {
         boxes = decode_yolov8_instances_from_detess(tensors, kInferSize, kScoreThr, kNmsIou,
-                                                    kMaxDet, proto, dq_scales);
+                                                    kMaxDet, proto);
       } catch (const std::exception& e) {
         std::cerr << "Decode failed for " << image_path.filename() << ": " << e.what() << "\n";
         continue;

--- a/examples/instance-segmentation/offline-instance-segmentation-overlay/python/main.py
+++ b/examples/instance-segmentation/offline-instance-segmentation-overlay/python/main.py
@@ -1,7 +1,6 @@
 """Minimal YOLOv8-seg pipeline using DetessDequant postprocess (no boxdecode)."""
 
 import argparse
-import json
 import math
 import sys
 from pathlib import Path
@@ -77,7 +76,7 @@ def iou_xyxy(a, b) -> float:
     return inter / uni if uni > 0 else 0.0
 
 
-def tensor_to_numpy(tensor: pyneat.Tensor, dq_scale: float | None = None) -> np.ndarray:
+def tensor_to_numpy(tensor: pyneat.Tensor) -> np.ndarray:
     dtype_map = {
         pyneat.TensorDType.UInt8: np.uint8,
         pyneat.TensorDType.Int8: np.int8,
@@ -94,29 +93,11 @@ def tensor_to_numpy(tensor: pyneat.Tensor, dq_scale: float | None = None) -> np.
     arr = np.frombuffer(tensor.copy_dense_bytes_tight(), dtype=np_dtype)
     if shape:
         arr = arr.reshape(shape)
-    if dq_scale is not None:
-        if dq_scale <= 0.0:
-            raise ValueError(f"invalid DetessDequant dq_scale: {dq_scale}")
-        arr = arr.astype(np.float32, copy=False) / (dq_scale * dq_scale)
     return arr
 
 
-def detess_dequant_scales(model: pyneat.Model, expected_count: int, label: str) -> list[float]:
-    config_path = model.find_config_path_by_plugin("postproc")
-    if not config_path:
-        raise RuntimeError(f"{label}: DetessDequant postproc config is missing")
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    scales = config.get("dq_scale")
-    if not isinstance(scales, list):
-        raise RuntimeError(f"{label}: DetessDequant dq_scale array is missing")
-    if len(scales) != expected_count:
-        raise RuntimeError(f"{label}: expected {expected_count} dq_scale values, got {len(scales)}")
-    return [float(x) for x in scales]
-
-
-def tensor_to_hwc_f32(tensor: pyneat.Tensor, dq_scale: float) -> np.ndarray:
-    arr = tensor_to_numpy(tensor, dq_scale).astype(np.float32)
+def tensor_to_hwc_f32(tensor: pyneat.Tensor) -> np.ndarray:
+    arr = tensor_to_numpy(tensor).astype(np.float32)
     if arr.ndim == 4:
         if arr.shape[0] != 1:
             raise ValueError("only batch=1 supported")
@@ -136,23 +117,20 @@ def dfl_distance_16(logits: np.ndarray) -> float:
     return float(numer / denom)
 
 
-def decode_yolov8_instances(tensors, dq_scales, infer_size, conf_thr, nms_iou, max_det):
+def decode_yolov8_instances(tensors, infer_size, conf_thr, nms_iou, max_det):
     """Decode YOLOv8 boxes and mask coefficients from DetessDequant outputs."""
     if len(tensors) < 10:
         raise ValueError("expected at least 10 tensors for instance-seg decode")
-    if len(dq_scales) != 10:
-        raise ValueError("expected 10 DetessDequant scales for instance-seg decode")
-
-    reg80 = tensor_to_hwc_f32(tensors[0], dq_scales[0])
-    reg40 = tensor_to_hwc_f32(tensors[1], dq_scales[1])
-    reg20 = tensor_to_hwc_f32(tensors[2], dq_scales[2])
-    cls80 = tensor_to_hwc_f32(tensors[3], dq_scales[3])
-    cls40 = tensor_to_hwc_f32(tensors[4], dq_scales[4])
-    cls20 = tensor_to_hwc_f32(tensors[5], dq_scales[5])
-    mk80 = tensor_to_hwc_f32(tensors[6], dq_scales[6])
-    mk40 = tensor_to_hwc_f32(tensors[7], dq_scales[7])
-    mk20 = tensor_to_hwc_f32(tensors[8], dq_scales[8])
-    proto = tensor_to_hwc_f32(tensors[9], dq_scales[9])
+    reg80 = tensor_to_hwc_f32(tensors[0])
+    reg40 = tensor_to_hwc_f32(tensors[1])
+    reg20 = tensor_to_hwc_f32(tensors[2])
+    cls80 = tensor_to_hwc_f32(tensors[3])
+    cls40 = tensor_to_hwc_f32(tensors[4])
+    cls20 = tensor_to_hwc_f32(tensors[5])
+    mk80 = tensor_to_hwc_f32(tensors[6])
+    mk40 = tensor_to_hwc_f32(tensors[7])
+    mk20 = tensor_to_hwc_f32(tensors[8])
+    proto = tensor_to_hwc_f32(tensors[9])
     if proto.shape[2] != 32:
         raise ValueError(f"unexpected proto channels: {proto.shape}")
 
@@ -296,7 +274,6 @@ def main() -> int:
         opt.preprocess.input_max_height = INFER_SIZE
         opt.preprocess.input_max_depth = 3
         model = pyneat.Model(args.model, opt)
-        dq_scales = detess_dequant_scales(model, 10, "YOLOv8 instance")
 
         dummy = np.zeros((INFER_SIZE, INFER_SIZE, 3), dtype=np.uint8)
         dummy_tensor = pyneat.Tensor.from_numpy(
@@ -333,9 +310,7 @@ def main() -> int:
             tensors = runner.run(input_tensor, timeout_ms=3000)
 
             try:
-                boxes, proto = decode_yolov8_instances(
-                    tensors, dq_scales, INFER_SIZE, SCORE_THR, NMS_IOU, MAX_DET
-                )
+                boxes, proto = decode_yolov8_instances(tensors, INFER_SIZE, SCORE_THR, NMS_IOU, MAX_DET)
             except Exception as e:
                 print(f"Decode failed for {image_path.name}: {e}", file=sys.stderr)
                 continue

--- a/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/cpp/main.cpp
+++ b/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/cpp/main.cpp
@@ -72,8 +72,7 @@ const std::vector<simaai::neat::Tensor> collect_tensors(const simaai::neat::Samp
   return out;
 }
 
-bool tensor_to_hwc(const simaai::neat::Tensor& t, float dq_scale, DenseTensor& out,
-                   std::string& err) {
+bool tensor_to_hwc(const simaai::neat::Tensor& t, DenseTensor& out, std::string& err) {
   if (!t.is_dense()) {
     err = "tensor is not dense";
     return false;
@@ -115,7 +114,6 @@ bool tensor_to_hwc(const simaai::neat::Tensor& t, float dq_scale, DenseTensor& o
 
   out.data.resize(elems);
   std::memcpy(out.data.data(), raw.data(), elems * sizeof(float));
-  sima_examples::apply_detess_dequant_scale_correction(out.data, dq_scale);
   return true;
 }
 
@@ -163,22 +161,16 @@ std::vector<Detection> nms_per_class(std::vector<Detection> dets, float iou_thr,
 }
 
 bool decode_yolov5_seg(const std::vector<simaai::neat::Tensor>& tensors, int infer_size,
-                       std::vector<Detection>& dets, DenseTensor& proto, std::string& err,
-                       const std::vector<float>& dq_scales) {
+                       std::vector<Detection>& dets, DenseTensor& proto, std::string& err) {
   if (tensors.size() < 13) {
     err = "expected 13 output tensors";
     return false;
   }
-  if (dq_scales.size() != 13) {
-    err = "DetessDequant scale count mismatch";
-    return false;
-  }
-
   // Expected order from MPK detessdequant:
   // 0 proto(160x160x32),
   // 1..4 stride8: xy(6), wh(6), cls+obj(243), coeff(96)
   // 5..8 stride16, 9..12 stride32.
-  if (!tensor_to_hwc(tensors[0], dq_scales[0], proto, err))
+  if (!tensor_to_hwc(tensors[0], proto, err))
     return false;
   if (proto.h != 160 || proto.w != 160 || proto.c != 32) {
     err = "unexpected proto shape";
@@ -188,10 +180,10 @@ bool decode_yolov5_seg(const std::vector<simaai::neat::Tensor>& tensors, int inf
   constexpr float kConfThr = 0.35f;
   for (int lvl = 0; lvl < 3; ++lvl) {
     DenseTensor txy, twh, tco, tmk;
-    if (!tensor_to_hwc(tensors[1 + lvl * 4], dq_scales[1 + lvl * 4], txy, err) ||
-        !tensor_to_hwc(tensors[2 + lvl * 4], dq_scales[2 + lvl * 4], twh, err) ||
-        !tensor_to_hwc(tensors[3 + lvl * 4], dq_scales[3 + lvl * 4], tco, err) ||
-        !tensor_to_hwc(tensors[4 + lvl * 4], dq_scales[4 + lvl * 4], tmk, err)) {
+    if (!tensor_to_hwc(tensors[1 + lvl * 4], txy, err) ||
+        !tensor_to_hwc(tensors[2 + lvl * 4], twh, err) ||
+        !tensor_to_hwc(tensors[3 + lvl * 4], tco, err) ||
+        !tensor_to_hwc(tensors[4 + lvl * 4], tmk, err)) {
       return false;
     }
 
@@ -435,8 +427,6 @@ int main(int argc, char** argv) {
     model_opt.preprocess.input_max_depth = 3;
 
     simaai::neat::Model model(model_path, model_opt);
-    const std::vector<float> dq_scales =
-        sima_examples::detess_dequant_scales(model, /*expected_count=*/13, "YOLOv5 seg");
 
     simaai::neat::Session session;
     session.add(model.session());
@@ -483,7 +473,7 @@ int main(int argc, char** argv) {
       std::vector<Detection> dets;
       DenseTensor proto;
       std::string err;
-      if (!decode_yolov5_seg(tensors, kInputW, dets, proto, err, dq_scales)) {
+      if (!decode_yolov5_seg(tensors, kInputW, dets, proto, err)) {
         std::cerr << "Decode failed for " << image_path.filename() << ": " << err << "\n";
         continue;
       }

--- a/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/python/main.py
+++ b/examples/instance-segmentation/simple-detess-segmentation-mask-overlay/python/main.py
@@ -1,7 +1,6 @@
 """Minimal YOLOv5 instance-segmentation overlay from DetessDequant outputs."""
 
 import argparse
-import json
 import math
 import sys
 from pathlib import Path
@@ -67,7 +66,7 @@ def class_name(cid: int) -> str:
     return f"class_{cid}"
 
 
-def tensor_to_numpy(tensor: pyneat.Tensor, dq_scale: float | None = None) -> np.ndarray:
+def tensor_to_numpy(tensor: pyneat.Tensor) -> np.ndarray:
     dtype_map = {
         pyneat.TensorDType.UInt8: np.uint8,
         pyneat.TensorDType.Int8: np.int8,
@@ -84,29 +83,11 @@ def tensor_to_numpy(tensor: pyneat.Tensor, dq_scale: float | None = None) -> np.
     arr = np.frombuffer(tensor.copy_dense_bytes_tight(), dtype=np_dtype)
     if shape:
         arr = arr.reshape(shape)
-    if dq_scale is not None:
-        if dq_scale <= 0.0:
-            raise ValueError(f"invalid DetessDeQuant dq_scale: {dq_scale}")
-        arr = arr.astype(np.float32, copy=False) / (dq_scale * dq_scale)
     return arr
 
 
-def detess_dequant_scales(model: pyneat.Model, expected_count: int, label: str) -> list[float]:
-    config_path = model.find_config_path_by_plugin("postproc")
-    if not config_path:
-        raise RuntimeError(f"{label}: DetessDeQuant postproc config is missing")
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    scales = config.get("dq_scale")
-    if not isinstance(scales, list):
-        raise RuntimeError(f"{label}: DetessDeQuant dq_scale array is missing")
-    if len(scales) != expected_count:
-        raise RuntimeError(f"{label}: expected {expected_count} dq_scale values, got {len(scales)}")
-    return [float(x) for x in scales]
-
-
-def tensor_to_hwc(tensor: pyneat.Tensor, dq_scale: float):
-    arr = tensor_to_numpy(tensor, dq_scale).astype(np.float32)
+def tensor_to_hwc(tensor: pyneat.Tensor):
+    arr = tensor_to_numpy(tensor).astype(np.float32)
     if arr.ndim == 4:
         if arr.shape[0] != 1:
             raise ValueError("only batch=1 is supported")
@@ -149,14 +130,11 @@ def nms_per_class(dets, iou_thr=0.5, max_det=100):
     return keep
 
 
-def decode_yolov5_seg(tensors, dq_scales, infer_size):
+def decode_yolov5_seg(tensors, infer_size):
     """Decode YOLOv5-seg DetessDequant outputs."""
     if len(tensors) < 13:
         raise ValueError("expected 13 output tensors")
-    if len(dq_scales) != 13:
-        raise ValueError("expected 13 DetessDeQuant scales")
-
-    proto = tensor_to_hwc(tensors[0], dq_scales[0])  # 160x160x32
+    proto = tensor_to_hwc(tensors[0])  # 160x160x32
     if proto.shape != (160, 160, 32):
         raise ValueError(f"unexpected proto shape: {proto.shape}")
 
@@ -164,10 +142,10 @@ def decode_yolov5_seg(tensors, dq_scales, infer_size):
 
     dets = []
     for lvl in range(3):
-        txy = tensor_to_hwc(tensors[1 + lvl * 4], dq_scales[1 + lvl * 4])
-        twh = tensor_to_hwc(tensors[2 + lvl * 4], dq_scales[2 + lvl * 4])
-        tco = tensor_to_hwc(tensors[3 + lvl * 4], dq_scales[3 + lvl * 4])
-        tmk = tensor_to_hwc(tensors[4 + lvl * 4], dq_scales[4 + lvl * 4])
+        txy = tensor_to_hwc(tensors[1 + lvl * 4])
+        twh = tensor_to_hwc(tensors[2 + lvl * 4])
+        tco = tensor_to_hwc(tensors[3 + lvl * 4])
+        tmk = tensor_to_hwc(tensors[4 + lvl * 4])
 
         gh, gw = txy.shape[0], txy.shape[1]
         for y in range(gh):
@@ -294,7 +272,6 @@ def main() -> int:
         opt.preprocess.input_max_height = INPUT_H
         opt.preprocess.input_max_depth = 3
         model = pyneat.Model(args.model, opt)
-        dq_scales = detess_dequant_scales(model, 13, "YOLOv5 seg")
 
         dummy = np.zeros((INPUT_H, INPUT_W, 3), dtype=np.uint8)
         dummy_tensor = pyneat.Tensor.from_numpy(
@@ -334,7 +311,7 @@ def main() -> int:
                 continue
 
             try:
-                dets, proto = decode_yolov5_seg(tensors, dq_scales, INPUT_W)
+                dets, proto = decode_yolov5_seg(tensors, INPUT_W)
             except Exception as e:
                 print(f"Decode failed for {image_path.name}: {e}", file=sys.stderr)
                 continue

--- a/examples/object-detection/detr-object-detection/cpp/main.cpp
+++ b/examples/object-detection/detr-object-detection/cpp/main.cpp
@@ -264,7 +264,7 @@ std::vector<simaai::neat::Tensor> collect_tensors(const simaai::neat::Sample& sa
   throw std::runtime_error("unexpected sample kind");
 }
 
-std::vector<float> tensor_to_f32(const simaai::neat::Tensor& t, float dq_scale) {
+std::vector<float> tensor_to_f32(const simaai::neat::Tensor& t) {
   if (t.dtype != simaai::neat::TensorDType::Float32) {
     throw std::runtime_error("expected Float32 tensor");
   }
@@ -274,11 +274,10 @@ std::vector<float> tensor_to_f32(const simaai::neat::Tensor& t, float dq_scale) 
   }
   std::vector<float> out(raw.size() / sizeof(float));
   std::memcpy(out.data(), raw.data(), raw.size());
-  sima_examples::apply_detess_dequant_scale_correction(out, dq_scale);
   return out;
 }
 
-Tensor2D tensor_to_2d_rows(const simaai::neat::Tensor& t, const char* name, float dq_scale) {
+Tensor2D tensor_to_2d_rows(const simaai::neat::Tensor& t, const char* name) {
   if (t.shape.empty()) {
     throw std::runtime_error(std::string(name) + ": empty tensor shape");
   }
@@ -299,7 +298,7 @@ Tensor2D tensor_to_2d_rows(const simaai::neat::Tensor& t, const char* name, floa
     throw std::runtime_error(std::string(name) + ": invalid row count");
   }
 
-  std::vector<float> data = tensor_to_f32(t, dq_scale);
+  std::vector<float> data = tensor_to_f32(t);
   const int64_t expected = rows64 * static_cast<int64_t>(cols);
   if (static_cast<int64_t>(data.size()) != expected) {
     throw std::runtime_error(std::string(name) + ": unexpected dense tensor size");
@@ -309,18 +308,12 @@ Tensor2D tensor_to_2d_rows(const simaai::neat::Tensor& t, const char* name, floa
 }
 
 std::pair<Tensor2D, Tensor2D>
-extract_logits_and_boxes(const std::vector<simaai::neat::Tensor>& tensors,
-                         const std::vector<float>& dq_scales) {
-  if (tensors.size() != dq_scales.size()) {
-    throw std::runtime_error("DETR output/scale count mismatch");
-  }
-
+extract_logits_and_boxes(const std::vector<simaai::neat::Tensor>& tensors) {
   std::optional<Tensor2D> logits;
   std::optional<Tensor2D> boxes;
 
   for (size_t i = 0; i < tensors.size(); ++i) {
-    Tensor2D flat =
-        tensor_to_2d_rows(tensors[i], ("tensor_" + std::to_string(i)).c_str(), dq_scales[i]);
+    Tensor2D flat = tensor_to_2d_rows(tensors[i], ("tensor_" + std::to_string(i)).c_str());
     if (flat.cols == 4) {
       boxes = std::move(flat);
     } else if (flat.cols > 4) {
@@ -489,8 +482,6 @@ int main(int argc, char** argv) {
     model_opt.preprocess.input_max_depth = 3;
 
     simaai::neat::Model model(args.model, model_opt);
-    const std::vector<float> dq_scales =
-        sima_examples::detess_dequant_scales(model, /*expected_count=*/2, "DETR");
 
     simaai::neat::Session session;
     session.add(simaai::neat::nodes::Input(model.input_appsrc_options(true)));
@@ -524,7 +515,7 @@ int main(int argc, char** argv) {
         }
 
         const std::vector<simaai::neat::Tensor> tensors = collect_tensors(*out_sample);
-        const auto [logits, boxes] = extract_logits_and_boxes(tensors, dq_scales);
+        const auto [logits, boxes] = extract_logits_and_boxes(tensors);
         const auto t2 = std::chrono::steady_clock::now();
         last_dets = decode_detr_outputs(logits, boxes, meta, args.conf, args.person_only);
         const auto t3 = std::chrono::steady_clock::now();
@@ -580,7 +571,7 @@ int main(int argc, char** argv) {
       std::cout << "] dtype=" << static_cast<int>(tensors[i].dtype) << "\n";
     }
 
-    const auto [logits, boxes] = extract_logits_and_boxes(tensors, dq_scales);
+    const auto [logits, boxes] = extract_logits_and_boxes(tensors);
     const std::vector<Detection> dets =
         decode_detr_outputs(logits, boxes, meta, args.conf, args.person_only);
 

--- a/examples/object-detection/detr-object-detection/python/main.py
+++ b/examples/object-detection/detr-object-detection/python/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import sys
 import time
@@ -155,13 +154,8 @@ def sigmoid(x: np.ndarray) -> np.ndarray:
     return 1.0 / (1.0 + np.exp(-x))
 
 
-def tensor_to_numpy(t: pyneat.Tensor, dq_scale: float | None = None) -> np.ndarray:
-    arr = np.asarray(t.to_numpy(copy=True))
-    if dq_scale is None:
-        return arr
-    if dq_scale <= 0.0:
-        raise ValueError(f"Invalid DetessDequant dq_scale: {dq_scale}")
-    return arr.astype(np.float32, copy=False) / (dq_scale * dq_scale)
+def tensor_to_numpy(t: pyneat.Tensor) -> np.ndarray:
+    return np.asarray(t.to_numpy(copy=True))
 
 
 def iter_tensors(sample: pyneat.Sample):
@@ -192,26 +186,8 @@ def tensor_from_hwc_f32(array: np.ndarray) -> pyneat.Tensor:
     )
 
 
-def detess_dequant_scales(model: pyneat.Model, expected_count: int, label: str) -> list[float]:
-    config_path = model.find_config_path_by_plugin("postproc")
-    if not config_path:
-        raise RuntimeError(f"{label}: DetessDequant postproc config is missing")
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    scales = config.get("dq_scale")
-    if not isinstance(scales, list):
-        raise RuntimeError(f"{label}: DetessDequant dq_scale array is missing")
-    if len(scales) != expected_count:
-        raise RuntimeError(f"{label}: expected {expected_count} dq_scale values, got {len(scales)}")
-    return [float(x) for x in scales]
-
-
-def scaled_numpy_outputs(tensors: list[pyneat.Tensor], dq_scales: list[float]) -> list[np.ndarray]:
-    if len(tensors) != len(dq_scales):
-        raise ValueError(
-            f"DETR output/scale count mismatch: {len(tensors)} tensors, {len(dq_scales)} scales"
-        )
-    return [tensor_to_numpy(t, scale) for t, scale in zip(tensors, dq_scales)]
+def tensor_numpy_outputs(tensors: list[pyneat.Tensor]) -> list[np.ndarray]:
+    return [tensor_to_numpy(t) for t in tensors]
 
 
 def class_name(class_id: int) -> str:
@@ -411,9 +387,7 @@ def build_session_runner(model: pyneat.Model) -> pyneat.Run:
     return sess.build(dummy, pyneat.RunMode.Async)
 
 
-def run_model_inference(
-    model: pyneat.Model, preprocessed: np.ndarray, dq_scales: list[float]
-) -> list[np.ndarray]:
+def run_model_inference(model: pyneat.Model, preprocessed: np.ndarray) -> list[np.ndarray]:
     runner = build_session_runner(model)
     tensor = tensor_from_hwc_f32(preprocessed)
     try:
@@ -422,7 +396,7 @@ def run_model_inference(
         samples = runner.pull_samples(timeout_ms=5000)
         if not samples:
             raise RuntimeError("Run.pull_samples() returned no samples")
-        return scaled_numpy_outputs(collect_tensors(samples), dq_scales)
+        return tensor_numpy_outputs(collect_tensors(samples))
     finally:
         runner.close()
 
@@ -507,7 +481,6 @@ def main() -> int:
     try:
         orig_bgr, preprocessed, meta = prepare_input(Path(args.image))
         model = load_tensor_model(model_path)
-        dq_scales = detess_dequant_scales(model, 2, "DETR")
     except FileNotFoundError as exc:
         print(str(exc), file=sys.stderr)
         return 2
@@ -534,7 +507,7 @@ def main() -> int:
                     print("Profiling failed: runner.pull_samples returned no samples", file=sys.stderr)
                     break
 
-                arrays = scaled_numpy_outputs(collect_tensors(samples), dq_scales)
+                arrays = tensor_numpy_outputs(collect_tensors(samples))
                 logits, boxes = extract_logits_and_boxes(arrays)
                 t2 = time.perf_counter()
                 detections = process_detr_output(
@@ -575,7 +548,7 @@ def main() -> int:
             return 4
 
     try:
-        arrays = run_model_inference(model, preprocessed, dq_scales)
+        arrays = run_model_inference(model, preprocessed)
     except Exception as exc:
         logger.debug("Inference failure", exc_info=exc)
         print(f"Error during inference: {exc}", file=sys.stderr)

--- a/examples/object-detection/yolo26-object-detection-overlay/cpp/main.cpp
+++ b/examples/object-detection/yolo26-object-detection-overlay/cpp/main.cpp
@@ -38,10 +38,6 @@ constexpr float kDefaultMinScore = 0.25f;
 constexpr float kDefaultNmsIou = 0.45f;
 constexpr int kMaxDet = 100;
 constexpr int kTimeoutMs = 5000;
-constexpr std::array<float, 3> kYolo26BoxScales = {0.39925800887880125f, 0.4013774459258692f,
-                                                   0.37927551510002144f};
-constexpr std::array<float, 3> kYolo26ClassScales = {8781.289874988339f, 370.5916340739125f,
-                                                     301.5390117926171f};
 
 struct Config {
   std::string model_path;
@@ -209,12 +205,8 @@ float iou_xyxy(const objdet::Box& a, const objdet::Box& b) {
   return den > 0.0f ? (inter / den) : 0.0f;
 }
 
-float package_dequant_value(float value, float scale) {
-  return value / (scale * scale);
-}
-
-float class_confidence(float value, size_t level) {
-  return std::clamp(package_dequant_value(value, kYolo26ClassScales.at(level)), 0.0f, 1.0f);
+float class_confidence(float value) {
+  return std::clamp(value, 0.0f, 1.0f);
 }
 
 // Decode YOLO26 detess/dequant output into the package's postprocess contract:
@@ -247,7 +239,7 @@ std::vector<objdet::Box> decode_yolo26_boxes(const simaai::neat::TensorList& ten
         int best_class = -1;
         float best_score = 0.0f;
         for (int c = 0; c < cls.c; ++c) {
-          const float s = class_confidence(cls.data[cls_base + c], lvl);
+          const float s = class_confidence(cls.data[cls_base + c]);
           if (s > best_score) {
             best_score = s;
             best_class = c;
@@ -257,11 +249,10 @@ std::vector<objdet::Box> decode_yolo26_boxes(const simaai::neat::TensorList& ten
           continue;
 
         const size_t reg_base = (static_cast<size_t>(y) * reg.w + x) * 4U;
-        const float box_scale = kYolo26BoxScales.at(lvl);
-        const float bcx = package_dequant_value(reg.data[reg_base + 0], box_scale);
-        const float bcy = package_dequant_value(reg.data[reg_base + 1], box_scale);
-        const float bw = package_dequant_value(reg.data[reg_base + 2], box_scale);
-        const float bh = package_dequant_value(reg.data[reg_base + 3], box_scale);
+        const float bcx = reg.data[reg_base + 0];
+        const float bcy = reg.data[reg_base + 1];
+        const float bw = reg.data[reg_base + 2];
+        const float bh = reg.data[reg_base + 3];
         objdet::Box box;
         box.x1 = std::max(0.0f, bcx - bw * 0.5f);
         box.y1 = std::max(0.0f, bcy - bh * 0.5f);

--- a/examples/object-detection/yolo26-object-detection-overlay/python/main.py
+++ b/examples/object-detection/yolo26-object-detection-overlay/python/main.py
@@ -16,9 +16,6 @@ INFER_SIZE = 640
 MIN_SCORE = 0.25
 NMS_IOU = 0.45
 MAX_DET = 100
-YOLO26_BOX_SCALES = (0.39925800887880125, 0.4013774459258692, 0.37927551510002144)
-YOLO26_CLASS_SCALES = (8781.289874988339, 370.5916340739125, 301.5390117926171)
-
 BOX_COLORS = [
     (0, 255, 0), (255, 0, 0), (0, 0, 255), (255, 255, 0),
     (255, 0, 255), (0, 255, 255), (128, 255, 0), (255, 128, 0),
@@ -49,10 +46,6 @@ def tensor_to_hwc_f32(t: pyneat.Tensor) -> np.ndarray:
     if arr.ndim != 3:
         raise ValueError(f"unexpected tensor rank {arr.ndim}")
     return arr
-
-
-def package_dequant_value(value: np.ndarray, scale: float) -> np.ndarray:
-    return value / (scale * scale)
 
 
 def nms_numpy(boxes_xyxy: np.ndarray, scores: np.ndarray, iou_threshold: float) -> np.ndarray:
@@ -89,12 +82,10 @@ def decode_yolo26m_boxes_from_tensors(
             raise ValueError(f"expected 4-channel regression tensor, got {reg.shape[2]}")
         if reg.shape[:2] != cls.shape[:2]:
             raise ValueError("regression/class spatial mismatch")
-        boxes_by_level.append(
-            package_dequant_value(reg.reshape(-1, reg.shape[2]), YOLO26_BOX_SCALES[level])
-        )
+        boxes_by_level.append(reg.reshape(-1, reg.shape[2]))
         probs_by_level.append(
             np.clip(
-                package_dequant_value(cls.reshape(-1, cls.shape[2]), YOLO26_CLASS_SCALES[level]),
+                cls.reshape(-1, cls.shape[2]),
                 0.0,
                 1.0,
             )

--- a/examples/pose-estimation/simple-pose-estimation-overlay-pipeline/cpp/main.cpp
+++ b/examples/pose-estimation/simple-pose-estimation-overlay-pipeline/cpp/main.cpp
@@ -172,7 +172,7 @@ std::vector<simaai::neat::Tensor> collect_tensors(const simaai::neat::Sample& sa
   throw std::runtime_error("unexpected sample kind");
 }
 
-TensorHWC tensor_to_hwc_f32(const simaai::neat::Tensor& t, float dq_scale) {
+TensorHWC tensor_to_hwc_f32(const simaai::neat::Tensor& t) {
   if (t.dtype != simaai::neat::TensorDType::Float32) {
     throw std::runtime_error("expected Float32 tensor");
   }
@@ -202,7 +202,6 @@ TensorHWC tensor_to_hwc_f32(const simaai::neat::Tensor& t, float dq_scale) {
 
   out.data.resize(elems);
   std::memcpy(out.data.data(), bytes.data(), elems * sizeof(float));
-  sima_examples::apply_detess_dequant_scale_correction(out.data, dq_scale);
   return out;
 }
 
@@ -650,8 +649,6 @@ int main(int argc, char** argv) {
     model_opt.preprocess.input_max_depth = 3;
 
     simaai::neat::Model model(model_path, model_opt);
-    const std::vector<float> dq_scales =
-        sima_examples::detess_dequant_scales(model, /*expected_count=*/2, "OpenPose");
 
     simaai::neat::Session session;
     session.add(model.session());
@@ -698,8 +695,8 @@ int main(int argc, char** argv) {
         continue;
       }
 
-      TensorHWC heatmap = tensor_to_hwc_f32(tensors[0], dq_scales[0]);
-      TensorHWC paf = tensor_to_hwc_f32(tensors[1], dq_scales[1]);
+      TensorHWC heatmap = tensor_to_hwc_f32(tensors[0]);
+      TensorHWC paf = tensor_to_hwc_f32(tensors[1]);
 
       // Upsample by configured factor using bicubic interpolation
       heatmap = upsample_tensor(heatmap, static_cast<float>(cfg.runtime.upsample_factor));

--- a/examples/pose-estimation/simple-pose-estimation-overlay-pipeline/python/main.py
+++ b/examples/pose-estimation/simple-pose-estimation-overlay-pipeline/python/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 import time
 from pathlib import Path
@@ -28,27 +27,8 @@ PAF_CHANNELS = [
 def is_image(path: Path) -> bool:
     return path.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
 
-def tensor_to_numpy(t: pyneat.Tensor, dq_scale: float | None = None) -> np.ndarray:
-    arr = np.asarray(t.to_numpy(copy=True))
-    if dq_scale is None:
-        return arr
-    if dq_scale <= 0.0:
-        raise ValueError(f"invalid DetessDequant dq_scale: {dq_scale}")
-    return arr.astype(np.float32, copy=False) / (dq_scale * dq_scale)
-
-
-def detess_dequant_scales(model: pyneat.Model, expected_count: int, label: str) -> list[float]:
-    config_path = model.find_config_path_by_plugin("postproc")
-    if not config_path:
-        raise RuntimeError(f"{label}: DetessDequant postproc config is missing")
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    scales = config.get("dq_scale")
-    if not isinstance(scales, list):
-        raise RuntimeError(f"{label}: DetessDequant dq_scale array is missing")
-    if len(scales) != expected_count:
-        raise RuntimeError(f"{label}: expected {expected_count} dq_scale values, got {len(scales)}")
-    return [float(scale) for scale in scales]
+def tensor_to_numpy(t: pyneat.Tensor) -> np.ndarray:
+    return np.asarray(t.to_numpy(copy=True))
 
 
 def iter_tensors(sample: pyneat.Sample):
@@ -67,8 +47,8 @@ def iter_tensors(sample: pyneat.Sample):
         yield from iter_tensors(field)
 
 
-def tensor_to_hwc_f32(t: pyneat.Tensor, dq_scale: float) -> np.ndarray:
-    arr = tensor_to_numpy(t, dq_scale).astype(np.float32)
+def tensor_to_hwc_f32(t: pyneat.Tensor) -> np.ndarray:
+    arr = tensor_to_numpy(t).astype(np.float32)
     if arr.ndim == 4 and arr.shape[0] == 1:
         arr = arr[0]
     if arr.ndim != 3:
@@ -407,7 +387,6 @@ def run_app(cfg: AppConfig, enable_profile: bool) -> int:
         opt.preprocess.input_max_depth = 3
 
         model = pyneat.Model(cfg.model.path, opt)
-        dq_scales = detess_dequant_scales(model, 2, "OpenPose")
 
         sess = pyneat.Session()
         sess.add(model.session())
@@ -465,8 +444,8 @@ def run_app(cfg: AppConfig, enable_profile: bool) -> int:
                     file=sys.stderr,
                 )
                 continue
-            heatmap_tensor = tensor_to_hwc_f32(tensors[0], dq_scales[0])
-            paf_tensor = tensor_to_hwc_f32(tensors[1], dq_scales[1])
+            heatmap_tensor = tensor_to_hwc_f32(tensors[0])
+            paf_tensor = tensor_to_hwc_f32(tensors[1])
 
             heatmap_tensor = cv2.resize(
                 heatmap_tensor,

--- a/support/runtime/example_utils.cpp
+++ b/support/runtime/example_utils.cpp
@@ -710,52 +710,6 @@ std::vector<float> tensor_to_floats(const simaai::neat::Tensor& t) {
   return out;
 }
 
-std::vector<float> detess_dequant_scales(const simaai::neat::Model& model,
-                                         std::size_t expected_count, const std::string& label) {
-  const simaai::neat::DetessDequantOptions options(model);
-  json config;
-  if (options.config_json.has_value()) {
-    config = *options.config_json;
-  } else {
-    std::string config_path = options.config_path;
-    if (config_path.empty()) {
-      config_path = model.find_config_path_by_plugin("postproc");
-    }
-    if (config_path.empty()) {
-      throw std::runtime_error(label + ": DetessDequant config JSON is missing");
-    }
-
-    std::ifstream input(config_path);
-    if (!input.is_open()) {
-      throw std::runtime_error(label + ": failed to open DetessDequant config: " + config_path);
-    }
-    input >> config;
-  }
-
-  if (!config.contains("dq_scale") || !config.at("dq_scale").is_array()) {
-    throw std::runtime_error(label + ": DetessDequant dq_scale array is missing");
-  }
-
-  const std::vector<float> scales = config.at("dq_scale").get<std::vector<float>>();
-  if (scales.size() != expected_count) {
-    throw std::runtime_error(label + ": expected " + std::to_string(expected_count) +
-                             " DetessDequant scales, got " + std::to_string(scales.size()));
-  }
-  return scales;
-}
-
-void apply_detess_dequant_scale_correction(std::vector<float>& values, float dq_scale) {
-  if (!(dq_scale > 0.0f)) {
-    throw std::runtime_error("invalid DetessDequant scale");
-  }
-
-  // beta_changes currently surfaces (q-zp)*scale; these app-side decoders need (q-zp)/scale.
-  const float inv_scale_sq = 1.0f / (dq_scale * dq_scale);
-  for (float& value : values) {
-    value *= inv_scale_sq;
-  }
-}
-
 std::vector<float> scores_from_tensor(const simaai::neat::Tensor& t, const std::string& label) {
   auto scores_full = tensor_to_floats(t);
   if (scores_full.empty()) {

--- a/support/runtime/example_utils.h
+++ b/support/runtime/example_utils.h
@@ -83,9 +83,6 @@ struct ScoredIndex {
 };
 
 std::vector<float> tensor_to_floats(const simaai::neat::Tensor& t);
-std::vector<float> detess_dequant_scales(const simaai::neat::Model& model,
-                                         std::size_t expected_count, const std::string& label);
-void apply_detess_dequant_scale_correction(std::vector<float>& values, float dq_scale);
 std::vector<float> scores_from_tensor(const simaai::neat::Tensor& t, const std::string& label);
 std::vector<ScoredIndex> topk_with_softmax(const std::vector<float>& v, int k);
 void check_top1(const std::vector<float>& scores, int expected_id, float min_prob,


### PR DESCRIPTION
## Summary
- Remove app-side DetessDequant scale correction helpers and dq_scale plumbing.
- Treat DetessDequant FP32 outputs as already dequantized by corrected internals.
- Update affected C++ and Python detection, segmentation, pose, and face examples.

## Core dependency
This PR targets `beta_changes` and depends on the corrected DetessDequant runtime scale emission from sima-neat/internals#17.

Current evidence checked on 2026-05-17:
- `https://artifacts.sima-neat.com/core/beta_changes/latest.tag` returns `02a4d9e`.
- `02a4d9e/metadata-minimal.json` installs internals packages at `8ba269aa3e6d`.
- The app examples no longer compensate for runtime scale behavior; DetessDequant is expected to emit correct FP32 tensors.

## Validation
- `clang-format -i` on changed C++ files
- `git diff --check`
- `cmake --build build --parallel "$(nproc)"` in Neat SDK
- Targeted C++ unit binaries for touched examples from apps repo root
- `python -m py_compile` for touched Python examples
- Targeted Python unit tests for touched examples
- `rg` confirmed no remaining app-side dq_scale workaround references in `examples/` or `support/`

Closes #115
