### PR TITLE
Update apps portal search indexing

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -287,43 +287,6 @@ jobs:
         run: |
           rm -rf _vulcan-test
 
-  build-portal:
-    name: Build Apps Portal
-    if: ${{ github.ref_type == 'branch' }}
-    needs:
-      - resolve-portal-publish-config
-      - test-runtime
-    runs-on: ubuntu-latest
-    env:
-      PORTAL_BASE_URL: ${{ needs.resolve-portal-publish-config.outputs.apps_portal_base_url }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          clean: true
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install portal dependencies
-        working-directory: portal
-        run: npm ci
-
-      - name: Build portal
-        working-directory: portal
-        run: npm run build
-
-      - name: Upload portal artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: neat-apps-portal
-          path: portal/dist/
-          if-no-files-found: error
-          retention-days: 3
-
   build-sysdoc-examples:
     name: Build SysDoc Examples Route
     if: ${{ github.ref_type == 'branch' }}
@@ -361,25 +324,6 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
-  publish-portal:
-    name: Publish Apps Portal
-    if: ${{ github.ref_type == 'branch' }}
-    needs:
-      - resolve-portal-publish-config
-      - build-portal
-    uses: sima-neat/.github/.github/workflows/vulcan-publish-static-site.yml@main
-    with:
-      aws_region: ${{ needs.resolve-portal-publish-config.outputs.aws_region }}
-      environment_name: ${{ needs.resolve-portal-publish-config.outputs.vulcan_env }}
-      site_key: APPS_PORTAL
-      bucket: ${{ needs.resolve-portal-publish-config.outputs.apps_portal_bucket }}
-      role_to_assume: ${{ needs.resolve-portal-publish-config.outputs.apps_portal_publisher_role_arn }}
-      sse_kms_key_id: ${{ needs.resolve-portal-publish-config.outputs.apps_portal_kms_key_id }}
-      cloudfront_distribution_id: ${{ needs.resolve-portal-publish-config.outputs.apps_portal_cloudfront_distribution_id }}
-      artifact_pattern: neat-apps-portal
-      delete_removed: false
-      cloudfront_paths: "/ /index.html /catalog.json"
-
   publish-sysdoc-examples:
     name: Publish SysDoc Examples Route
     if: ${{ github.ref_type == 'branch' }}
@@ -398,6 +342,130 @@ jobs:
       artifact_pattern: neat-apps-sysdoc-examples
       s3_prefix: examples
       cloudfront_paths: "/examples /examples/*"
+
+  publish-apps-algolia:
+    name: Publish Apps Algolia Index
+    if: ${{ github.ref_type == 'branch' }}
+    needs:
+      - resolve-portal-publish-config
+      - publish-sysdoc-examples
+    runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-portal-publish-config.outputs.vulcan_env }}
+    env:
+      AWS_REGION: ${{ needs.resolve-portal-publish-config.outputs.aws_region }}
+      VULCAN_CONFIG_S3_URI: ${{ needs.resolve-portal-publish-config.outputs.config_s3_uri }}
+      SYSDOC_EXAMPLES_URL: ${{ format('{0}/examples', needs.resolve-portal-publish-config.outputs.sysdoc_base_url) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          clean: true
+
+      - name: Configure AWS credentials for Vulcan config
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ needs.resolve-portal-publish-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-portal-publish-config.outputs.config_reader_role_arn }}
+          role-session-name: vulcan-apps-algolia-config-${{ github.run_id }}
+
+      - name: Generate Apps Algolia records
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          config_file="${RUNNER_TEMP}/vulcan-environment.json"
+          aws s3 cp "${VULCAN_CONFIG_S3_URI}" "${config_file}" --only-show-errors
+          mkdir -p _algolia
+
+          CONFIG_FILE="${config_file}" python3 - <<'PY'
+          import json
+          import os
+
+          with open(os.environ["CONFIG_FILE"], encoding="utf-8") as handle:
+              config = json.load(handle)
+
+          algolia = config.get("algolia") or {}
+          base_index_name = algolia.get("index_name") or ""
+          apps_index_name = algolia.get("apps_index_name") or (f"{base_index_name}-apps" if base_index_name else "")
+
+          publish = {
+              "schemaVersion": 1,
+              "source": "examples",
+              "app_id": algolia.get("app_id"),
+              "index_name": apps_index_name,
+              "write_api_key_secret_arn": algolia.get("write_api_key_secret_arn"),
+          }
+
+          with open("_algolia/publish.json", "w", encoding="utf-8") as handle:
+              json.dump(publish, handle, indent=2)
+              handle.write("\n")
+          PY
+
+          python3 scripts/generate_catalog.py > portal/public/catalog.json
+          python3 scripts/sync_algolia_apps_index.py \
+            --catalog-json portal/public/catalog.json \
+            --site-base-url "${SYSDOC_EXAMPLES_URL}" \
+            --records-json _algolia/records.json \
+            --summary-json _algolia/summary.json \
+            --generate-only
+
+          python3 -m json.tool _algolia/publish.json >/dev/null
+          python3 -m json.tool _algolia/records.json >/dev/null
+          python3 -m json.tool _algolia/summary.json >/dev/null
+
+      - name: Configure AWS credentials for Algolia secret
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ needs.resolve-portal-publish-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-portal-publish-config.outputs.apps_portal_publisher_role_arn }}
+          role-session-name: vulcan-apps-algolia-${{ github.run_id }}
+
+      - name: Push Apps Algolia records
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          readarray -t algolia_values < <(python3 - <<'PY'
+          import json
+
+          with open("_algolia/publish.json", encoding="utf-8") as handle:
+              config = json.load(handle)
+
+          values = [
+              config.get("app_id") or "",
+              config.get("index_name") or "",
+              config.get("write_api_key_secret_arn") or "",
+          ]
+          print("\n".join(values))
+          PY
+          )
+
+          app_id="${algolia_values[0]:-}"
+          index_name="${algolia_values[1]:-}"
+          write_key_secret_arn="${algolia_values[2]:-}"
+
+          if [[ -z "${app_id}" && -z "${index_name}" && -z "${write_key_secret_arn}" ]]; then
+            echo "No Algolia config for this Vulcan environment; skipping apps search index sync."
+            exit 0
+          fi
+
+          if [[ -z "${app_id}" || -z "${index_name}" || -z "${write_key_secret_arn}" ]]; then
+            echo "Incomplete Algolia config; app_id, index_name, and write_api_key_secret_arn are required." >&2
+            exit 1
+          fi
+
+          write_api_key="$(aws secretsmanager get-secret-value \
+            --secret-id "${write_key_secret_arn}" \
+            --query SecretString \
+            --output text)"
+
+          python3 scripts/sync_algolia_apps_index.py \
+            --site-base-url "${SYSDOC_EXAMPLES_URL}" \
+            --input-records-json _algolia/records.json \
+            --app-id "${app_id}" \
+            --api-key "${write_api_key}" \
+            --index-name "${index_name}" \
+            --sync
 
   promote-latest-tag:
     name: Promote Vulcan latest tag

--- a/portal/src/App.jsx
+++ b/portal/src/App.jsx
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import { useDeferredValue, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, Route, Routes, useNavigate, useParams } from "react-router-dom";
 import {
   extractFilterOptions,
@@ -327,7 +327,6 @@ function DeveloperCenterShellFallback({ theme, onToggleTheme }) {
 }
 
 function CatalogPage({ catalog }) {
-  const [query, setQuery] = useState("");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [filters, setFilters] = useState({
     category: "",
@@ -337,21 +336,16 @@ function CatalogPage({ catalog }) {
     model: "",
     tag: "",
   });
-  const deferredQuery = useDeferredValue(query);
   const options = extractFilterOptions(catalog.examples);
-  const filtered = catalog.examples.filter((example) => matchesFilters(example, filters, deferredQuery));
+  const filtered = catalog.examples.filter((example) => matchesFilters(example, filters, ""));
 
   return (
     <div className="portal-shell">
       <header className="hero">
         <div className="hero-copy">
-          <div className="brand-row">
-            <img className="brand-logo" src={portalAssetUrl("sima-logo.png")} alt="SiMa.ai" />
-            <p className="eyebrow">Examples</p>
-          </div>
-          <h1>Neat examples</h1>
+          <h1>Neat Examples</h1>
           <p className="hero-text">
-            Search reference applications by category, model, tag, and runtime notes.
+            Learn how to build production-grade applications by exploring these examples.
           </p>
           <div className="hero-actions">
             <a className="hero-action" href="https://github.com/sima-neat/apps" target="_blank" rel="noreferrer">
@@ -378,16 +372,9 @@ function CatalogPage({ catalog }) {
             </button>
           </div>
         </div>
-        <div className="hero-search">
-          <input
-            id="catalog-search"
-            className="search-input"
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search by app name, tag, model, or category"
-          />
-          <p className="search-meta">{filtered.length} of {catalog.examples.length} examples</p>
+        <div className="hero-stat">
+          <span>{filtered.length}</span>
+          <p>{filtered.length === catalog.examples.length ? "examples" : `of ${catalog.examples.length} examples`}</p>
         </div>
       </header>
 
@@ -398,8 +385,8 @@ function CatalogPage({ catalog }) {
           ))}
           {filtered.length === 0 ? (
             <div className="empty-state">
-              <h2>No examples matched the current search.</h2>
-              <p>Try clearing a filter or using a broader search term.</p>
+              <h2>No examples matched the current filters.</h2>
+              <p>Try clearing a filter.</p>
             </div>
           ) : null}
         </main>
@@ -536,9 +523,6 @@ function DetailPage({ catalog }) {
   const modelLabel = example?.model || "";
   const modelUrl = example?.model_url || "";
   const summaryHtml = marked.parseInline(example?.summary || "No summary available.");
-  const pathLabel = decodedId
-    .split("/")
-    .join(" / ");
   const docPanelRef = useRef(null);
   const [activeSection, setActiveSection] = useState(sections[0]?.slug || "");
 
@@ -620,7 +604,6 @@ function DetailPage({ catalog }) {
         >
           <span aria-hidden="true">⌂</span>
         </button>
-        <div className="detail-path">{pathLabel}</div>
       </div>
 
       <section className="detail-hero">

--- a/portal/src/styles.css
+++ b/portal/src/styles.css
@@ -10,9 +10,10 @@
   --line: rgba(28, 47, 58, 0.12);
   --text: #1c1e21;
   --muted: #606770;
-  --accent: #1d5f73;
-  --accent-soft: rgba(29, 95, 115, 0.1);
-  --warm: #1d5f73;
+  --accent: #5998dd;
+  --accent-soft: rgba(89, 152, 221, 0.12);
+  --accent-glow: #5998dd;
+  --warm: #5998dd;
   --shadow: none;
 }
 
@@ -25,9 +26,10 @@
   --line: rgba(240, 246, 252, 0.14);
   --text: #f5f6f7;
   --muted: #b0b3b8;
-  --accent: #71c1d4;
-  --accent-soft: rgba(113, 193, 212, 0.16);
-  --warm: #71c1d4;
+  --accent: #8fc0f0;
+  --accent-soft: rgba(143, 192, 240, 0.18);
+  --accent-glow: #8fc0f0;
+  --warm: #8fc0f0;
   --shadow: none;
 }
 
@@ -227,7 +229,14 @@ select {
 .detail-shell {
   width: min(1280px, calc(100vw - 32px));
   margin: 0 auto;
-  padding: 24px 0 48px;
+  padding: 32px 0 48px;
+}
+
+#developer-center-shell + .portal-shell,
+#developer-center-shell + .detail-shell,
+.developer-center-fallback-shell + .portal-shell,
+.developer-center-fallback-shell + .detail-shell {
+  padding-top: 44px;
 }
 
 .hero,
@@ -252,27 +261,6 @@ select {
   color: var(--warm);
 }
 
-.brand-row {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-bottom: 12px;
-}
-
-.brand-row .eyebrow {
-  margin: 0;
-}
-
-.brand-logo {
-  width: 28px;
-  height: 28px;
-  flex: 0 0 auto;
-  object-fit: contain;
-  object-position: center;
-  border-radius: 0;
-  display: block;
-}
-
 .hero h1,
 .detail-hero h1 {
   margin: 0;
@@ -288,9 +276,7 @@ select {
   color: var(--text);
 }
 
-.hero-text,
-.search-meta,
-.detail-path {
+.hero-text {
   color: var(--muted);
 }
 
@@ -306,10 +292,10 @@ select {
   align-items: center;
   gap: 10px;
   padding: 9px 14px;
-  border: 1px solid var(--line);
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, transparent);
   border-radius: 999px;
-  background: var(--panel-strong);
-  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 8%, var(--panel-strong));
+  color: var(--accent);
   box-shadow: var(--shadow);
   cursor: pointer;
   transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
@@ -317,8 +303,8 @@ select {
 
 .hero-action:hover {
   transform: translateY(-2px);
-  border-color: rgba(14, 122, 109, 0.28);
-  background: rgba(14, 122, 109, 0.08);
+  border-color: color-mix(in srgb, var(--accent) 58%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel-strong));
 }
 
 .hero-action-icon {
@@ -335,13 +321,11 @@ select {
   height: 18px;
 }
 
-:root[data-theme="dark"] .hero-text,
-:root[data-theme="dark"] .search-meta,
-:root[data-theme="dark"] .detail-path {
+:root[data-theme="dark"] .hero-text {
   color: var(--muted);
 }
 
-.hero-search,
+.hero-stat,
 .detail-hero-card {
   display: flex;
   flex-direction: column;
@@ -350,6 +334,23 @@ select {
   border-radius: 8px;
   background: var(--panel-strong);
   border: 1px solid var(--line);
+}
+
+.hero-stat {
+  align-items: flex-start;
+  min-height: 134px;
+}
+
+.hero-stat span {
+  font-size: clamp(2.35rem, 5vw, 4rem);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.hero-stat p {
+  margin: 10px 0 0;
+  color: var(--muted);
 }
 
 .search-label,
@@ -493,8 +494,8 @@ select {
 .modal-close:hover {
   transform: translateY(-1px);
   color: var(--text);
-  border-color: rgba(14, 122, 109, 0.28);
-  background: rgba(14, 122, 109, 0.08);
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  background: var(--accent-soft);
 }
 
 .modal-close svg {
@@ -514,7 +515,7 @@ select {
   border-radius: 8px;
   background: var(--panel);
   box-shadow: var(--shadow);
-  transition: transform 160ms ease, border-color 160ms ease;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
 }
 
 :root[data-theme="dark"] .app-card {
@@ -558,14 +559,22 @@ select {
 :root[data-theme="dark"] .empty-state,
 :root[data-theme="dark"] .hero,
 :root[data-theme="dark"] .detail-hero,
-:root[data-theme="dark"] .hero-search,
+:root[data-theme="dark"] .hero-stat,
 :root[data-theme="dark"] .detail-hero-card {
   background: var(--panel);
 }
 
 .app-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(14, 122, 109, 0.35);
+  border-color: color-mix(in srgb, var(--accent-glow) 72%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-glow) 48%, transparent),
+    0 0 24px color-mix(in srgb, var(--accent-glow) 36%, transparent);
+}
+
+.app-card:focus-visible {
+  outline: 2px solid var(--accent-glow);
+  outline-offset: 4px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-glow) 48%, transparent),
+    0 0 24px color-mix(in srgb, var(--accent-glow) 36%, transparent);
 }
 
 .card-image {
@@ -691,8 +700,8 @@ select {
 }
 
 .chip-status {
-  background: rgba(14, 122, 109, 0.12);
-  color: #0d675d;
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .chip-languages {
@@ -722,13 +731,13 @@ select {
 
 .chip-github:hover {
   transform: translateY(-1px);
-  background: rgba(14, 122, 109, 0.12);
+  background: var(--accent-soft);
 }
 
 .chip-link:hover {
   transform: translateY(-1px);
-  background: rgba(14, 122, 109, 0.12);
-  color: #0d675d;
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 :root[data-theme="dark"] .chip-model,
@@ -749,8 +758,8 @@ select {
 }
 
 :root[data-theme="dark"] .chip-link:hover {
-  background: rgba(14, 122, 109, 0.22);
-  color: #eef8f5;
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .filter-panel,
@@ -801,14 +810,14 @@ select {
   line-height: 1;
   background: transparent;
   color: var(--accent);
-  border: 1px solid rgba(14, 122, 109, 0.18);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
   box-shadow: none;
 }
 
 .icon-link:hover {
   transform: translateY(-1px);
-  border-color: rgba(14, 122, 109, 0.38);
-  background: rgba(14, 122, 109, 0.08);
+  border-color: color-mix(in srgb, var(--accent) 52%, transparent);
+  background: var(--accent-soft);
 }
 
 .detail-topbar {
@@ -816,10 +825,6 @@ select {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 18px;
-}
-
-.detail-path {
-  font-size: 0.92rem;
 }
 
 .detail-layout {

--- a/scripts/sync_algolia_apps_index.py
+++ b/scripts/sync_algolia_apps_index.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Generate and sync Apps Portal Algolia records."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+SOURCE = "examples"
+DEFAULT_MAX_RECORD_BYTES = 9_500
+DEFAULT_BATCH_SIZE = 500
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate or sync Apps Portal Algolia records.")
+    parser.add_argument("--catalog-json", default="portal/public/catalog.json", help="Portal catalog JSON path.")
+    parser.add_argument("--site-base-url", required=True, help="Public examples route base URL.")
+    parser.add_argument("--records-json", help="Write generated records to this JSON file.")
+    parser.add_argument("--input-records-json", help="Read records from this JSON file instead of generating them.")
+    parser.add_argument("--summary-json", help="Write generation summary to this JSON file.")
+    parser.add_argument("--app-id", help="Algolia app ID.")
+    parser.add_argument("--api-key", help="Algolia write API key.")
+    parser.add_argument("--index-name", help="Algolia index name.")
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-record-bytes", type=int, default=DEFAULT_MAX_RECORD_BYTES)
+    parser.add_argument("--generate-only", action="store_true", help="Only generate records; do not upload.")
+    parser.add_argument("--sync", action="store_true", help="Upload records and remove stale records for this source.")
+    return parser.parse_args()
+
+
+def clean_markdown(text: str) -> str:
+    text = re.sub(r"```[\s\S]*?```", " ", text)
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = html.unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def record_size(record: dict) -> int:
+    return len(json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+
+
+def fit_record(record: dict, max_record_bytes: int) -> tuple[dict, bool]:
+    if record_size(record) <= max_record_bytes:
+        return record, False
+
+    content = str(record.get("content", ""))
+    lo = 0
+    hi = len(content)
+    best = ""
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        candidate = dict(record)
+        candidate["content"] = content[:mid]
+        candidate["content_truncated"] = True
+        if record_size(candidate) <= max_record_bytes:
+            best = candidate["content"]
+            lo = mid + 1
+        else:
+            hi = mid - 1
+
+    record["content"] = best
+    record["content_truncated"] = True
+    if record_size(record) > max_record_bytes:
+        record["title"] = str(record.get("title", ""))[:120]
+        record["content"] = str(record.get("content", ""))[:400]
+        record["content_truncated"] = True
+    if record_size(record) > max_record_bytes:
+        raise RuntimeError(f"unable to fit record under {max_record_bytes} bytes: {record.get('path')}")
+    return record, True
+
+
+def app_url(site_base_url: str, app_id: str) -> str:
+    encoded_id = urllib.parse.quote(app_id, safe="/")
+    return f"{site_base_url.rstrip('/')}/app/{encoded_id}"
+
+
+def generate_records(catalog_path: Path, site_base_url: str, max_record_bytes: int) -> tuple[list[dict], dict]:
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    examples = catalog.get("examples") or []
+    records: list[dict] = []
+    by_category: dict[str, int] = {}
+    trimmed = 0
+    max_seen = 0
+
+    for example in examples:
+        app_id = str(example.get("id") or "")
+        if not app_id:
+            continue
+
+        title = str(example.get("name") or example.get("binary_name") or app_id)
+        category = str(example.get("category") or "Examples")
+        section_text = " ".join(
+            clean_markdown(section.get("markdown") or "")
+            for section in example.get("sections") or []
+            if isinstance(section, dict)
+        )
+        tags = [str(tag) for tag in example.get("tags") or []]
+        content = " ".join(
+            part
+            for part in [
+                str(example.get("summary") or ""),
+                str(example.get("binary_name") or ""),
+                str(example.get("model") or ""),
+                str(example.get("languages") or ""),
+                " ".join(tags),
+                section_text,
+            ]
+            if part
+        )
+        url = app_url(site_base_url, app_id)
+        route = urllib.parse.urlparse(url).path
+        record = {
+            "objectID": f"{SOURCE}:{hashlib.sha1(app_id.encode('utf-8')).hexdigest()}",
+            "source": SOURCE,
+            "url": url,
+            "route": route,
+            "path": str(example.get("readme_path") or example.get("source_path") or app_id),
+            "section": category,
+            "category": category,
+            "title": title,
+            "content": clean_markdown(content)[:20_000],
+            "hierarchy": {"lvl0": "Examples", "lvl1": category, "lvl2": title},
+            "app_id": app_id,
+            "tags": tags,
+            "model": str(example.get("model") or ""),
+            "languages": str(example.get("languages") or ""),
+        }
+        record, was_trimmed = fit_record(record, max_record_bytes)
+        trimmed += int(was_trimmed)
+        max_seen = max(max_seen, record_size(record))
+        records.append(record)
+        by_category[category] = by_category.get(category, 0) + 1
+
+    summary = {
+        "source": SOURCE,
+        "count": len(records),
+        "by_category": by_category,
+        "trimmed_records": trimmed,
+        "max_record_bytes": max_seen,
+    }
+    return records, summary
+
+
+class AlgoliaClient:
+    def __init__(self, app_id: str, api_key: str, index_name: str) -> None:
+        self.host = f"https://{app_id}.algolia.net"
+        self.index = urllib.parse.quote(index_name, safe="")
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Algolia-Application-Id": app_id,
+            "X-Algolia-API-Key": api_key,
+        }
+
+    def post(self, path: str, payload: dict) -> dict:
+        request = urllib.request.Request(
+            self.host + path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=self.headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            if error.code == 404 and path.endswith("/browse"):
+                return {"hits": []}
+            raise SystemExit(f"Algolia API error: HTTP {error.code} on {path}\n{body}") from error
+
+    def browse_source_object_ids(self, source: str) -> list[str]:
+        object_ids: list[str] = []
+        payload = {"query": "", "attributesToRetrieve": ["objectID", "source"], "hitsPerPage": 1000}
+        while True:
+            result = self.post(f"/1/indexes/{self.index}/browse", payload)
+            for hit in result.get("hits", []):
+                if hit.get("source") == source and hit.get("objectID"):
+                    object_ids.append(hit["objectID"])
+            cursor = result.get("cursor")
+            if not cursor:
+                return object_ids
+            payload = {"cursor": cursor}
+
+    def batch(self, requests: list[dict]) -> None:
+        if not requests:
+            return
+        result = self.post(f"/1/indexes/{self.index}/batch", {"requests": requests})
+        print(f"[algolia-index] taskID={result.get('taskID')} requests={len(requests)}")
+
+
+def sync_records(args: argparse.Namespace, records: list[dict]) -> None:
+    if not args.app_id or not args.api_key or not args.index_name:
+        raise SystemExit("--app-id, --api-key, and --index-name are required for --sync")
+
+    client = AlgoliaClient(args.app_id, args.api_key, args.index_name)
+    desired_ids = {record["objectID"] for record in records}
+    existing_ids = set(client.browse_source_object_ids(SOURCE))
+    stale_ids = sorted(existing_ids - desired_ids)
+
+    print(f"[algolia-index] existing {SOURCE} records={len(existing_ids)} stale={len(stale_ids)}")
+    for start in range(0, len(stale_ids), args.batch_size):
+        chunk = stale_ids[start : start + args.batch_size]
+        client.batch([{"action": "deleteObject", "body": {"objectID": object_id}} for object_id in chunk])
+
+    print(f"[algolia-index] uploading {len(records)} {SOURCE} records...")
+    for start in range(0, len(records), args.batch_size):
+        chunk = records[start : start + args.batch_size]
+        client.batch([{"action": "addObject", "body": record} for record in chunk])
+
+
+def main() -> int:
+    args = parse_args()
+    if args.batch_size < 1:
+        raise SystemExit("--batch-size must be positive")
+    if args.max_record_bytes < 2_000:
+        raise SystemExit("--max-record-bytes must be at least 2000")
+    if not args.generate_only and not args.sync:
+        args.generate_only = True
+
+    if args.input_records_json:
+        records = json.loads(Path(args.input_records_json).read_text(encoding="utf-8"))
+        if not isinstance(records, list):
+            raise SystemExit("--input-records-json must contain a JSON list")
+        summary = {"source": SOURCE, "count": len(records), "from": args.input_records_json}
+        print("[algolia-index] loaded records:")
+    else:
+        records, summary = generate_records(Path(args.catalog_json), args.site_base_url, args.max_record_bytes)
+        print("[algolia-index] generated records:")
+    print(json.dumps(summary, indent=2))
+
+    if args.records_json and not args.input_records_json:
+        Path(args.records_json).write_text(json.dumps(records, ensure_ascii=True), encoding="utf-8")
+    if args.summary_json:
+        Path(args.summary_json).write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    if args.sync:
+        sync_records(args, records)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_portal_asset_contract.py
+++ b/tests/scripts/test_portal_asset_contract.py
@@ -21,8 +21,15 @@ def _load_module(name: str, path: Path):
 def test_portal_cards_always_use_category_asset_cover():
     app_jsx = (APPS_ROOT / "portal" / "src" / "App.jsx").read_text()
 
-    assert 'src={fallbackImage}' in app_jsx
+    assert 'event.currentTarget.src = fallbackImage' in app_jsx
     assert 'src={example.image_path ? `./${example.image_path}` : fallbackImage}' not in app_jsx
+
+
+def test_portal_page_uses_global_search_only():
+    app_jsx = (APPS_ROOT / "portal" / "src" / "App.jsx").read_text()
+
+    assert 'id="catalog-search"' not in app_jsx
+    assert 'type="search"' not in app_jsx
 
 
 def test_generate_catalog_uses_repo_level_portal_assets_for_example():
@@ -194,3 +201,51 @@ def test_sync_portal_assets_copies_readme_linked_assets(tmp_path):
 
     synced_image = asset_root / "tracking" / "demo-example" / "image.png"
     assert synced_image.read_bytes() == b"png"
+
+
+def test_algolia_apps_records_use_examples_source_and_route(tmp_path):
+    module = _load_module(
+        "sync_algolia_apps_index_for_test",
+        APPS_ROOT / "scripts" / "sync_algolia_apps_index.py",
+    )
+
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(
+        json.dumps(
+            {
+                "examples": [
+                    {
+                        "id": "tracking/demo-example",
+                        "name": "Demo Example",
+                        "category": "tracking",
+                        "summary": "Tracks people.",
+                        "binary_name": "demo-example",
+                        "model": "yolo_v8m",
+                        "languages": "C++, Python",
+                        "tags": ["tracking", "rtsp"],
+                        "readme_path": "examples/tracking/demo-example/README.md",
+                        "sections": [
+                            {
+                                "title": "Concept",
+                                "slug": "concept",
+                                "markdown": "Use **Neat** to track detections.",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+
+    records, summary = module.generate_records(
+        catalog_path,
+        "https://build.neat.sima.ai/examples",
+        module.DEFAULT_MAX_RECORD_BYTES,
+    )
+
+    assert summary["count"] == 1
+    assert records[0]["source"] == "examples"
+    assert records[0]["url"] == "https://build.neat.sima.ai/examples/app/tracking/demo-example"
+    assert records[0]["route"] == "/examples/app/tracking/demo-example"
+    assert records[0]["hierarchy"]["lvl1"] == "tracking"
+    assert "tracking rtsp" in records[0]["content"]


### PR DESCRIPTION
## Summary

This PR updates the apps/examples portal to work as part of the shared Developer Center experience and adds environment-aware Algolia indexing for apps search.

The main intent is to remove duplicated local search from the apps portal, make global Developer Center search cover apps/examples content, publish the portal only under the sysdoc `/examples` route, and keep the apps Algolia index in sync after that publish succeeds.

## Portal UX Changes

- Removed the search box inside the apps portal page because search now lives in the shared Developer Center title bar.
- Updated the portal headline treatment to show `Neat Examples` without the extra SiMa logo/examples eyebrow that duplicated the global title bar.
- Refined the intro copy to make the page more inviting for production-grade application examples.
- Removed the detail-page breadcrumb/path text such as `classification / simple-image-classification-pipeline`.
- Replaced the card hover movement with an accent-color glow effect so cards do not shift position on hover.
- Standardized portal buttons, example count styling, and related accents on the shared Developer Center blue.

## Publishing Flow

- Removed the legacy root apps portal build/publish jobs (`build-portal` and `publish-portal`).
- The portal is now built and published only through the sysdoc examples path using `build-sysdoc-examples` and `publish-sysdoc-examples`.
- The sysdoc publish keeps the `/examples` S3 prefix and invalidates `/examples` paths through the sysdoc CloudFront distribution.
- This avoids continuing to publish a separate standalone apps portal root now that users access examples through Developer Center/sysdoc.

## Algolia Apps Indexing

- Added `scripts/sync_algolia_apps_index.py` to generate Algolia records from the apps catalog.
- The generated records include app/example metadata needed by global search, including title, description, category, model/runtime fields, tags, slug, URL, and hierarchy metadata.
- The script resolves the correct target configuration by environment so staging and production can publish to their respective apps indexes.
- The apps index can be configured explicitly through runtime/build config, or derived from the docs base index by appending `-apps`.

## CI / Search Publish Flow

- Added a `publish-apps-algolia` job to the Vulcan CI workflow.
- The Algolia job depends on `publish-sysdoc-examples`, so the search index tracks the successfully published sysdoc examples content.
- The workflow generates the catalog, builds Algolia records, resolves the environment config, retrieves the environment-specific Algolia write key, and pushes records to the apps index.

## Tests

- Extended `tests/scripts/test_portal_asset_contract.py` to cover the new Algolia record generation behavior.
- Verified that generated records preserve expected portal URLs and searchable app metadata.

## Validation

Validated locally from a clean branch based on `origin/develop`:

- `PORTAL_BASE_URL=/examples npm run build`
- `pytest -q tests/scripts/test_portal_asset_contract.py`
- Parsed `.github/workflows/vulcan-ci.yml` with Ruby YAML and confirmed `build-portal` / `publish-portal` are removed while sysdoc examples jobs remain.

Also manually pushed and verified the staging apps index during local Developer Center testing.
