### PR TITLE
Build: make Core install deterministic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ tmp/
 sandbox/
 tests/.env.local
 .neat-core-installed
-deps/.neat_core
 deps/debs/
 portal/node_modules/
 portal/.vite/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,79 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Apps: Build All",
+      "type": "shell",
+      "command": "./build.sh",
+      "args": [
+        "--all",
+        "--clean"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "NEAT_CORE_INSTALL_MODE": "vulcan",
+          "NEAT_VULCAN_ENV": "production"
+        }
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Apps Portal: Build and Preview",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-lc",
+        "npm run build && npm run preview -- --host 0.0.0.0"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/portal"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Apps Portal: Run Dev Server",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "dev",
+        "--",
+        "--host",
+        "0.0.0.0"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/portal"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Apps: Test Unit C++",
       "type": "shell",
       "command": "bash",

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPS_DIR="${NEAT_APPS_TEST_DEPS_DIR:-${ROOT_DIR}/deps}"
 APPS_MANIFEST="${DEPS_DIR}/manifest.json"
 NEAT_DEBS_DIR="${DEPS_DIR}/debs"
-NEAT_CORE_MARKER="${DEPS_DIR}/.neat_core"
 NEAT_INSTALLER_URL="${NEAT_INSTALLER_URL:-https://tools.sima-neat.com/install-neat.sh}"
 NEAT_ARTIFACTS_BASE_URL="${NEAT_ARTIFACTS_BASE_URL:-https://artifacts.neat.sima.ai/core}"
+NEAT_CORE_INSTALL_DIR=""
+NEAT_CORE_INSTALL_DIR_OWNED=0
 LATEST_TAG_CACHE_DIR="$(mktemp -d /tmp/neat-apps-latest.XXXXXX)"
 
 cleanup_latest_tag_cache() {
@@ -50,6 +51,9 @@ Environment:
                             Dependency branch for empty manifest neat_core
   NEAT_INSTALLER_URL        Hosted branch installer URL
   NEAT_ARTIFACTS_BASE_URL   Hosted NEAT core artifact index
+  NEAT_APPS_CORE_INSTALL_DIR
+                            Scratch directory override for Vulcan core installs
+                            (default: fresh /tmp/neat-apps-core-install.XXXXXX)
   NEAT_CORE_INSTALL_MODE    legacy or vulcan. Defaults to vulcan when NEAT_VULCAN_ENV is set.
   NEAT_VULCAN_ENV           Vulcan artifact environment for sima-cli core installs
   CMAKE_TOOLCHAIN_FILE      Optional CMake toolchain file (auto-detected for cross)
@@ -352,37 +356,74 @@ core_artifact_version_exists() {
   download_text "${NEAT_ARTIFACTS_BASE_URL}/${branch_key}/${version}/metadata.json" >/dev/null 2>&1
 }
 
-neat_core_available() {
-  # Prefer an actual package/config probe over the repo-local marker file so a
-  # reused checkout does not incorrectly skip install in a fresh container.
-  if [[ -f "${ROOT_DIR}/../core/build/libsima_neat.a" && -d "${ROOT_DIR}/../core/include" ]]; then
-    return 0
-  fi
+normalize_vulcan_env() {
+  local env_name="$1"
+  case "${env_name}" in
+    production|prod|prd) printf '%s\n' "prod" ;;
+    staging|stg) printf '%s\n' "stg" ;;
+    development|dev) printf '%s\n' "dev" ;;
+    *) printf '%s\n' "${env_name}" ;;
+  esac
+}
 
-  if ! command -v cmake >/dev/null 2>&1; then
+neat_core_installed_matches() {
+  local expected_branch="$1"
+  local expected_version="$2"
+  local expected_env="${3:-}"
+  local expected_branch_key expected_env_key status_json
+
+  if ! command -v neat >/dev/null 2>&1; then
+    return 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
     return 1
   fi
 
-  local probe_dir
-  probe_dir="$(mktemp -d /tmp/simaneat-probe.XXXXXX)"
-  cat > "${probe_dir}/CMakeLists.txt" <<'EOF'
-cmake_minimum_required(VERSION 3.16)
-project(SimaNeatProbe LANGUAGES CXX)
-find_package(SimaNeat CONFIG QUIET)
-if (TARGET SimaNeat::sima_neat)
-  message(STATUS "SimaNeat package found")
-else()
-  message(FATAL_ERROR "SimaNeat package not found")
-endif()
-EOF
+  expected_branch_key="$(sanitize_branch_key "${expected_branch}")"
+  expected_env_key="$(normalize_vulcan_env "${expected_env}")"
+  status_json="$(neat --json 2>/dev/null)" || return 1
 
-  if cmake -S "${probe_dir}" -B "${probe_dir}/build" >/dev/null 2>&1; then
-    rm -rf "${probe_dir}"
-    return 0
+  if ! NEAT_STATUS_JSON="${status_json}" python3 - "${expected_branch}" "${expected_branch_key}" "${expected_version}" "${expected_env_key}" <<'PY'
+import json
+import os
+import sys
+
+expected_branch = sys.argv[1]
+expected_branch_key = sys.argv[2]
+expected_version = sys.argv[3]
+expected_env = sys.argv[4]
+
+try:
+    data = json.loads(os.environ["NEAT_STATUS_JSON"])
+except json.JSONDecodeError:
+    raise SystemExit(1)
+
+core = data.get("components", {}).get("core", {})
+channel = str(core.get("channel", "")).strip()
+tag = str(core.get("tag", "")).strip()
+actual_env = str(core.get("provenance", {}).get("vulcanEnvironment", "")).strip()
+
+def normalize_env(value: str) -> str:
+    if value in {"production", "prod", "prd"}:
+        return "prod"
+    if value in {"staging", "stg"}:
+        return "stg"
+    if value in {"development", "dev"}:
+        return "dev"
+    return value
+
+if channel not in {expected_branch, expected_branch_key}:
+    raise SystemExit(1)
+if tag != expected_version:
+    raise SystemExit(1)
+if expected_env and normalize_env(actual_env) != expected_env:
+    raise SystemExit(1)
+PY
+  then
+    return 1
   fi
 
-  rm -rf "${probe_dir}"
-  return 1
+  return 0
 }
 
 download_file() {
@@ -596,6 +637,48 @@ load_neat_core_target() {
   NEAT_CORE_TARGET_VERSION="$(second_line "${target_output}")"
 }
 
+prepare_vulcan_core_install_dir() {
+  NEAT_CORE_INSTALL_DIR_OWNED=0
+  if [[ -z "${NEAT_APPS_CORE_INSTALL_DIR:-}" ]]; then
+    NEAT_CORE_INSTALL_DIR="$(mktemp -d /tmp/neat-apps-core-install.XXXXXX)"
+    NEAT_CORE_INSTALL_DIR_OWNED=1
+    return 0
+  fi
+
+  NEAT_CORE_INSTALL_DIR="${NEAT_APPS_CORE_INSTALL_DIR}"
+  if [[ -z "${NEAT_CORE_INSTALL_DIR}" || "${NEAT_CORE_INSTALL_DIR}" == "/" ]]; then
+    echo "ERROR: unsafe NEAT_APPS_CORE_INSTALL_DIR: ${NEAT_CORE_INSTALL_DIR}" >&2
+    exit 1
+  fi
+  rm -rf "${NEAT_CORE_INSTALL_DIR}"
+  mkdir -p "${NEAT_CORE_INSTALL_DIR}"
+}
+
+cleanup_vulcan_core_install_dir() {
+  if [[ "${NEAT_CORE_INSTALL_DIR_OWNED}" == "1" && -n "${NEAT_CORE_INSTALL_DIR}" ]]; then
+    rm -rf "${NEAT_CORE_INSTALL_DIR}"
+  fi
+  NEAT_CORE_INSTALL_DIR=""
+  NEAT_CORE_INSTALL_DIR_OWNED=0
+}
+
+run_sima_cli_core_install() {
+  local sima_cli_bin="$1"
+  shift
+  local log_path
+  log_path="$(mktemp /tmp/neat-apps-sima-cli-install.XXXXXX.log)"
+  if ! "${sima_cli_bin}" neat install "$@" 2>&1 | tee "${log_path}"; then
+    rm -f "${log_path}"
+    return 1
+  fi
+  if grep -Fq "Installation script exited" "${log_path}"; then
+    echo "ERROR: sima-cli reported a NEAT core installer failure." >&2
+    rm -f "${log_path}"
+    return 1
+  fi
+  rm -f "${log_path}"
+}
+
 ensure_neat_core() {
   local branch version install_mode sima_cli_bin vulcan_env
   mkdir -p "${DEPS_DIR}" "${NEAT_DEBS_DIR}"
@@ -610,40 +693,46 @@ ensure_neat_core() {
       install_mode="legacy"
     fi
   fi
+  if [[ "${install_mode}" == "vulcan" ]]; then
+    vulcan_env="${NEAT_VULCAN_ENV:-dev}"
+  fi
 
-  # Resolve "latest" to the actual commit tag so the marker is precise.
+  # Resolve "latest" to an exact tag before checking installed state.
   if [[ "${version}" == "latest" ]]; then
     version="$(resolve_latest_version "${branch}")"
   fi
 
-  # Check marker file — but only trust it if the current environment can also
-  # resolve a usable SimaNeat package/build.
   local expected_tag="${branch}/${version}"
-  if [[ -f "${NEAT_CORE_MARKER}" ]]; then
-    local current_tag
-    current_tag="$(tr -d '[:space:]' < "${NEAT_CORE_MARKER}")"
-    if [[ "${current_tag}" == "${expected_tag}" ]] && neat_core_available; then
-      echo "NEAT core already installed (${expected_tag}). Skipping install."
-      return 0
-    fi
+  if neat_core_installed_matches "${branch}" "${version}" "${vulcan_env:-}"; then
+    echo "NEAT core already installed (${expected_tag}). Skipping install."
+    return 0
   fi
 
   echo "Installing NEAT core (${expected_tag})..."
 
   if [[ "${install_mode}" == "vulcan" ]]; then
+    local install_status
     if ! sima_cli_bin="$(resolve_sima_cli_bin)"; then
       echo "ERROR: NEAT_CORE_INSTALL_MODE=vulcan requires sima-cli on PATH or SIMA_CLI_BIN." >&2
       exit 1
     fi
-    vulcan_env="${NEAT_VULCAN_ENV:-dev}"
     echo "Installing NEAT core from Vulcan env ${vulcan_env} using sima-cli."
-    "${sima_cli_bin}" neat install \
-      --env "${vulcan_env}" \
-      -d "${ROOT_DIR}" \
-      -t all \
-      "core@${branch}:${version}"
+    prepare_vulcan_core_install_dir
+    echo "  Scratch dir: ${NEAT_CORE_INSTALL_DIR}"
+    install_status=0
+    (
+      cd "${NEAT_CORE_INSTALL_DIR}"
+      run_sima_cli_core_install "${sima_cli_bin}" \
+        --env "${vulcan_env}" \
+        -d . \
+        -t minimal \
+        "core@${branch}:${version}"
+    ) || install_status=$?
+    cleanup_vulcan_core_install_dir
+    if [[ "${install_status}" -ne 0 ]]; then
+      exit "${install_status}"
+    fi
 
-    printf '%s\n' "${expected_tag}" > "${NEAT_CORE_MARKER}"
     echo "NEAT core installed successfully (${expected_tag})."
     return 0
   fi
@@ -672,8 +761,6 @@ ensure_neat_core() {
   trap - RETURN
   find "${NEAT_DEBS_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 
-  # Write marker on success.
-  printf '%s\n' "${expected_tag}" > "${NEAT_CORE_MARKER}"
   echo "NEAT core installed successfully (${expected_tag})."
 }
 

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,4 +1,4 @@
 {
-  "neat_core": "",
+  "neat_core": "onat_handover_tmp-9c436d53b64b",
   "platform-version": "2.0.0"
 }

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -5,6 +5,8 @@ DEST_DIR="${NEAT_APPS_INSTALL_DIR:-neat-apps}"
 RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-neat-apps-runtime}"
 RUNTIME_DST="${DEST_DIR}/neat-apps-runtime"
 VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-dev}}"
+NEAT_CORE_INSTALL_DIR=""
+NEAT_CORE_INSTALL_DIR_OWNED=0
 
 resolve_sima_cli_bin() {
   if [[ -n "${SIMA_CLI_BIN:-}" && -x "${SIMA_CLI_BIN}" ]]; then
@@ -51,8 +53,53 @@ print(version)
 PY
 }
 
+prepare_vulcan_core_install_dir() {
+  NEAT_CORE_INSTALL_DIR_OWNED=0
+  if [[ -z "${NEAT_APPS_CORE_INSTALL_DIR:-}" ]]; then
+    NEAT_CORE_INSTALL_DIR="$(mktemp -d /tmp/neat-apps-core-install.XXXXXX)"
+    NEAT_CORE_INSTALL_DIR_OWNED=1
+    return 0
+  fi
+
+  NEAT_CORE_INSTALL_DIR="${NEAT_APPS_CORE_INSTALL_DIR}"
+  if [[ -z "${NEAT_CORE_INSTALL_DIR}" || "${NEAT_CORE_INSTALL_DIR}" == "/" ]]; then
+    echo "ERROR: unsafe NEAT_APPS_CORE_INSTALL_DIR: ${NEAT_CORE_INSTALL_DIR}" >&2
+    exit 1
+  fi
+  rm -rf "${NEAT_CORE_INSTALL_DIR}"
+  mkdir -p "${NEAT_CORE_INSTALL_DIR}"
+}
+
+cleanup_vulcan_core_install_dir() {
+  if [[ "${NEAT_CORE_INSTALL_DIR_OWNED}" == "1" && -n "${NEAT_CORE_INSTALL_DIR}" ]]; then
+    rm -rf "${NEAT_CORE_INSTALL_DIR}"
+  fi
+  NEAT_CORE_INSTALL_DIR=""
+  NEAT_CORE_INSTALL_DIR_OWNED=0
+}
+
+run_sima_cli_core_install() {
+  local sima_cli_bin="$1"
+  shift
+  local log_path
+  log_path="$(mktemp /tmp/neat-apps-sima-cli-install.XXXXXX.log)"
+  if ! "${sima_cli_bin}" neat install "$@" 2>&1 | tee "${log_path}"; then
+    rm -f "${log_path}"
+    return 1
+  fi
+  if grep -Fq "Installation script exited" "${log_path}"; then
+    echo "ERROR: sima-cli reported a NEAT core installer failure." >&2
+    rm -f "${log_path}"
+    return 1
+  fi
+  rm -f "${log_path}"
+}
+
 if [[ ! -d "${RUNTIME_SRC}" ]]; then
-  mapfile -t runtime_candidates < <(find . -mindepth 1 -maxdepth 3 -type d -name "${RUNTIME_SRC}" | sort)
+  runtime_candidates=()
+  while IFS= read -r candidate; do
+    runtime_candidates+=("${candidate}")
+  done < <(find . -mindepth 1 -maxdepth 3 -type d -name "${RUNTIME_SRC}" | sort)
   if [[ "${#runtime_candidates[@]}" -eq 1 ]]; then
     RUNTIME_SRC="${runtime_candidates[0]}"
   else
@@ -78,7 +125,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! mapfile -t NEAT_CORE_TARGET < <(extract_neat_core_target "${NEAT_CORE_JSON_PATH}"); then
+if ! NEAT_CORE_TARGET_OUTPUT="$(extract_neat_core_target "${NEAT_CORE_JSON_PATH}")"; then
   echo "ERROR: failed to parse NEAT core dependency from ${NEAT_CORE_JSON_PATH}." >&2
   exit 1
 fi
@@ -88,19 +135,29 @@ SIMA_CLI_RESOLVED="$(resolve_sima_cli_bin)" || {
   exit 1
 }
 
-NEAT_CORE_BRANCH="${NEAT_CORE_TARGET[0]}"
-NEAT_CORE_VERSION="${NEAT_CORE_TARGET[1]}"
+NEAT_CORE_BRANCH="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '1p')"
+NEAT_CORE_VERSION="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '2p')"
 
 echo
 echo "Installing matching NEAT core from Vulcan:"
 echo "  Environment: ${VULCAN_ENV}"
 echo "  Branch     : ${NEAT_CORE_BRANCH}"
 echo "  Version    : ${NEAT_CORE_VERSION}"
-"${SIMA_CLI_RESOLVED}" neat install \
-  --env "${VULCAN_ENV}" \
-  -d . \
-  -t all \
-  "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
+prepare_vulcan_core_install_dir
+echo "  Scratch dir: ${NEAT_CORE_INSTALL_DIR}"
+INSTALL_STATUS=0
+(
+  cd "${NEAT_CORE_INSTALL_DIR}"
+  run_sima_cli_core_install "${SIMA_CLI_RESOLVED}" \
+    --env "${VULCAN_ENV}" \
+    -d . \
+    -t minimal \
+    "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
+) || INSTALL_STATUS=$?
+cleanup_vulcan_core_install_dir
+if [[ "${INSTALL_STATUS}" -ne 0 ]]; then
+  exit "${INSTALL_STATUS}"
+fi
 
 DOWNLOAD_MODELS_SCRIPT="${RUNTIME_DST}/scripts/download_models.sh"
 if [[ "${NEAT_APPS_SKIP_MODEL_DOWNLOAD:-0}" == "1" ]]; then

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -30,7 +30,7 @@ def _write_manifest(path: Path, neat_core: str = "", platform_version: str = "2.
 
 def _write_fake_curl(tmp_path: Path) -> tuple[Path, Path]:
     bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
+    bin_dir.mkdir(exist_ok=True)
     log_path = tmp_path / "curl.log"
     curl_path = bin_dir / "curl"
     curl_path.write_text(
@@ -120,6 +120,26 @@ def _write_fake_curl(tmp_path: Path) -> tuple[Path, Path]:
     return bin_dir, log_path
 
 
+def _write_fake_sima_cli(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    sima_cli_path = bin_dir / "sima-cli"
+    sima_cli_path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '%s\\n' "$PWD" > "${NEAT_APPS_TEST_SIMA_CLI_CWD}"
+            printf '%s\\n' "$*" > "${NEAT_APPS_TEST_SIMA_CLI_ARGS}"
+            touch sima-cli-ran.txt
+            """
+        ),
+        encoding="utf-8",
+    )
+    sima_cli_path.chmod(0o755)
+    return bin_dir
+
+
 def _run_build(
     tmp_path: Path,
     *,
@@ -187,6 +207,38 @@ def _curl_log(tmp_path: Path) -> list[str]:
     if not path.exists():
         return []
     return path.read_text(encoding="utf-8").splitlines()
+
+
+def _write_fake_neat_json(tmp_path: Path, *, channel: str, tag: str, env: str) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    neat_path = bin_dir / "neat"
+    payload = {
+        "components": {
+            "core": {
+                "channel": channel,
+                "tag": tag,
+                "provenance": {"vulcanEnvironment": env},
+            }
+        }
+    }
+    neat_path.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            if [[ "${{1:-}}" == "--json" ]]; then
+              cat <<'EOF'
+            {json.dumps(payload)}
+            EOF
+              exit 0
+            fi
+            exit 1
+            """
+        ),
+        encoding="utf-8",
+    )
+    neat_path.chmod(0o755)
+    return bin_dir
 
 
 def test_empty_manifest_resolves_from_dependency_branch_and_platform_version(tmp_path):
@@ -278,10 +330,56 @@ def test_core_installer_runs_from_deps_debs_scratch_dir(tmp_path):
     assert installer_args.read_text(encoding="utf-8").strip() == (
         "--minimum scratch-core-for-test scratchsha1"
     )
-    assert (deps_dir / ".neat_core").read_text(encoding="utf-8").strip() == (
-        "scratch-core-for-test/scratchsha1"
-    )
     assert list((deps_dir / "debs").iterdir()) == []
     assert not (APPS_ROOT / "sima-neat-test-Linux-core.deb").exists()
     assert not (APPS_ROOT / "neat-test.deb").exists()
     assert not (APPS_ROOT / "pyneat-test.whl").exists()
+
+
+def test_vulcan_core_install_uses_minimal_temp_dir(tmp_path):
+    sima_cli_cwd = tmp_path / "sima-cli-cwd.txt"
+    sima_cli_args = tmp_path / "sima-cli-args.txt"
+    _write_fake_sima_cli(tmp_path)
+
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env={
+            "NEAT_APPS_DEPENDENCY_BRANCH": "scratch-core-for-test",
+            "NEAT_CORE_INSTALL_MODE": "vulcan",
+            "NEAT_VULCAN_ENV": "production",
+            "NEAT_APPS_TEST_SIMA_CLI_CWD": str(sima_cli_cwd),
+            "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(sima_cli_args),
+        },
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    install_dir = Path(sima_cli_cwd.read_text(encoding="utf-8").strip())
+    assert str(install_dir).startswith("/tmp/neat-apps-core-install.")
+    assert sima_cli_args.read_text(encoding="utf-8").strip() == (
+        "neat install --env production -d . -t minimal "
+        "core@scratch-core-for-test:scratchsha1"
+    )
+    assert not install_dir.exists()
+
+
+def test_vulcan_core_install_skips_when_neat_json_matches(tmp_path):
+    _write_fake_neat_json(
+        tmp_path,
+        channel="scratch-core-for-test",
+        tag="scratchsha1",
+        env="prod",
+    )
+
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env={
+            "NEAT_APPS_DEPENDENCY_BRANCH": "scratch-core-for-test",
+            "NEAT_CORE_INSTALL_MODE": "vulcan",
+            "NEAT_VULCAN_ENV": "production",
+        },
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "NEAT core already installed (scratch-core-for-test/scratchsha1)" in proc.stdout


### PR DESCRIPTION
## Summary

- add VS Code tasks for building apps and running the portal preview
- install Core with the minimal Vulcan artifact variant instead of extras
- run Core artifact installs from a temporary install directory instead of the apps repo root
- skip Core reinstall when `neat --json` already reports the requested branch, tag, and Vulcan env
- remove the stale `deps/.neat_core` marker path and keep `deps/manifest.json` pinned to `onat_handover_tmp-9c436d53b64b`

## Validation

- `bash -n build.sh scripts/install-vulcan-apps-package.sh`
- `python3 -m pytest -q tests/scripts/test_manifest_contract.py`
- `./build.sh --no-cpp --build-dir /tmp/neat-apps-manifest-smoke`

Not run: `./build.sh --all --clean`; this is the SDK/Core install path Onat will run manually.

Refs: https://github.com/sima-neat/apps/issues/163
