### PR TITLE
Resolve apps runtime runner from platform version

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -194,12 +194,19 @@ jobs:
     with:
       vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env == 'prod' && 'staging' || needs.resolve-vulcan-config.outputs.vulcan_env }}
 
+  resolve-test-runner:
+    name: Resolve Test Runner
+    uses: sima-neat/.github/.github/workflows/vulcan-resolve-modalix-runner.yml@main
+
   test-runtime:
     name: Test Apps Runtime
     needs:
       - resolve-vulcan-config
+      - resolve-test-runner
       - publish-vulcan-artifacts
-    runs-on: [self-hosted, Linux, ARM64, modalix, "vulcan-${{ needs.resolve-vulcan-config.outputs.vulcan_env }}"]
+    runs-on:
+      group: ${{ needs.resolve-test-runner.outputs.modalix_runner_group }}
+      labels: [self-hosted, Linux, ARM64, modalix, "vulcan-${{ needs.resolve-vulcan-config.outputs.vulcan_env }}"]
     env:
       VULCAN_ENV: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
       SIMA_CLI_CHECK_FOR_UPDATE: "0"


### PR DESCRIPTION
## Summary

- Add the shared Modalix runner resolver to Apps Vulcan CI.
- Run `test-runtime` on the runner group resolved from `deps/manifest.json` `platform-version`.
- Leave SDK cache behavior unchanged; no `sdk.channel` is added.

## Why

Apps runtime CI was selecting Modalix runners by broad labels only. A `platform-version: "2.0.0"` branch could land on the `modalix-devkit-2.1.1` pool, which caused package compatibility failures before the app tests ran.

The reusable resolver reads the caller repo manifest and maps `platform-version: "2.0.0"` to `modalix-devkit`, matching the Core Vulcan CI pattern.

Reusable workflow: https://github.com/sima-neat/.github/blob/main/.github/workflows/vulcan-resolve-modalix-runner.yml

## Validation

```text
git diff --check
YAML parse: OK
python3 -m pytest -q tests/scripts/test_manifest_contract.py
9 passed
python3 -m pytest -q tests/scripts
17 passed
```

Closes #165
