### PR TITLE
Align apps neat-core manifest shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,12 @@ If you use host-streamed sources from a board/devkit, use the host IP in the RTS
 ## NEAT Core Dependency
 
 `deps/manifest.json` declares the Neat core dependency and the platform version.
-When `neat-core` is empty, `build.sh` resolves it from the dependency branch:
-`main` uses `main-latest`, `develop` uses `develop-latest`, and custom branches use
-a matching core branch when available or fall back to `develop-latest`. Explicit
-core pins use `branch-version`, matching the core repo's internals manifest shape.
+The normal value is `"neat-core": {"policy": "snap"}`. Snap resolves from the
+dependency branch: `main` uses `main-latest`, `develop` uses `develop-latest`,
+and custom branches use a matching core branch when available or fall back to
+`develop-latest`. Explicit manifest pins can use `{"branch": "...", "spec": "..."}`
+or `{"ref": "...", "spec": "..."}`. Legacy string pins and the
+`--neat-core-version <branch-version>` override remain supported.
 
 ## Support
 

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ Options:
 Environment:
   SIMA_CLI_BIN              Path to sima-cli binary (default: sima-cli)
   NEAT_APPS_DEPENDENCY_BRANCH
-                            Dependency branch for empty manifest neat-core
+                            Dependency branch for snap manifest neat-core
   NEAT_INSTALLER_URL        Hosted branch installer URL
   NEAT_ARTIFACTS_BASE_URL   Hosted NEAT core artifact index
   NEAT_APPS_CORE_INSTALL_DIR
@@ -256,14 +256,35 @@ except json.JSONDecodeError as exc:
 neat_core = data.get("neat-core")
 platform_version = data.get("platform-version")
 
-if not isinstance(neat_core, str):
-    print(f"ERROR: {path} must define neat-core as a string.", file=sys.stderr)
-    raise SystemExit(1)
 if not isinstance(platform_version, str) or not platform_version.strip():
     print(f"ERROR: {path} must define platform-version as a non-empty string.", file=sys.stderr)
     raise SystemExit(1)
 
-print(neat_core.strip())
+if isinstance(neat_core, str):
+    print("__SNAP__" if not neat_core.strip() else neat_core.strip())
+elif isinstance(neat_core, dict):
+    policy = str(neat_core.get("policy", "")).strip().lower()
+    if policy == "snap":
+        print("__SNAP__")
+    elif policy:
+        print(f"ERROR: unsupported neat-core.policy in {path}: {policy!r}", file=sys.stderr)
+        raise SystemExit(1)
+    else:
+        spec = str(neat_core.get("spec", "")).strip()
+        branch = str(neat_core.get("branch", neat_core.get("ref", ""))).strip()
+        if not branch:
+            print(
+                f"ERROR: {path} neat-core object must define policy=snap or branch/ref.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        print(f"{branch}:{spec or 'latest'}")
+else:
+    print(
+        f"ERROR: {path} must define neat-core as a string or dependency object.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 print(platform_version.strip())
 PY
 }
@@ -605,24 +626,34 @@ resolve_neat_core_target() {
     return 0
   fi
 
-  if [[ -n "${manifest_core}" ]]; then
-    if is_protected_manifest_context; then
-      echo "ERROR: ${APPS_MANIFEST} must keep neat-core empty on main/develop." >&2
-      return 1
-    fi
-    if ! ref_output="$(parse_core_ref "${manifest_core}" "${APPS_MANIFEST} neat-core")"; then
-      return 1
-    fi
-    branch="$(first_line "${ref_output}")"
-    version="$(second_line "${ref_output}")"
-    validate_explicit_core_ref "${branch}" "${version}" "${APPS_MANIFEST} neat-core" || return 1
+  if [[ "${manifest_core}" == "__SNAP__" ]]; then
+    branch="$(resolve_empty_neat_core_branch)"
+    version="latest"
     printf '%s\n%s\n' "${branch}" "${version}"
     return 0
   fi
 
-  branch="$(resolve_empty_neat_core_branch)"
-  version="latest"
-  printf '%s\n%s\n' "${branch}" "${version}"
+  if [[ -n "${manifest_core}" ]]; then
+    if is_protected_manifest_context; then
+      echo "ERROR: ${APPS_MANIFEST} must keep neat-core as policy=snap on main/develop." >&2
+      return 1
+    fi
+
+    if [[ "${manifest_core}" == *":"* ]]; then
+      branch="${manifest_core%%:*}"
+      version="${manifest_core#*:}"
+    else
+      if ! ref_output="$(parse_core_ref "${manifest_core}" "${APPS_MANIFEST} neat-core")"; then
+        return 1
+      fi
+      branch="$(first_line "${ref_output}")"
+      version="$(second_line "${ref_output}")"
+    fi
+
+    validate_explicit_core_ref "${branch}" "${version}" "${APPS_MANIFEST} neat-core" || return 1
+    printf '%s\n%s\n' "${branch}" "${version}"
+    return 0
+  fi
 }
 
 load_neat_core_target() {

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,5 +1,7 @@
 {
-  "neat-core": "",
+  "neat-core": {
+    "policy": "snap"
+  },
   "sdk": {
     "channel": "main"
   },

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -8,12 +8,14 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import pytest
+
 
 APPS_ROOT = Path(__file__).resolve().parents[2]
 BUILD_SH = APPS_ROOT / "build.sh"
 
 
-def _write_manifest(path: Path, neat_core: str = "", platform_version: str = "2.0.0") -> None:
+def _write_manifest(path: Path, neat_core: object = "", platform_version: str = "2.0.0") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
@@ -143,7 +145,7 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
 def _run_build(
     tmp_path: Path,
     *,
-    neat_core: str = "",
+    neat_core: object = "",
     platform_version: str = "2.0.0",
     args: list[str] | None = None,
     env: dict[str, str] | None = None,
@@ -253,6 +255,18 @@ def test_empty_manifest_resolves_from_dependency_branch_and_platform_version(tmp
     assert _curl_log(tmp_path).count("https://core.test/develop/latest.tag") == 1
 
 
+def test_snap_manifest_resolves_from_dependency_branch(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"policy": "snap"},
+        env={"NEAT_APPS_DEPENDENCY_BRANCH": "develop"},
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "NEAT core target      : develop:devsha1" in proc.stdout
+    assert _curl_log(tmp_path).count("https://core.test/develop/latest.tag") == 1
+
+
 def test_empty_manifest_custom_branch_uses_matching_core_artifact_once(tmp_path):
     proc = _run_build(
         tmp_path,
@@ -280,8 +294,35 @@ def test_empty_manifest_custom_branch_falls_back_to_develop(tmp_path):
     assert "using develop-latest" in proc.stderr
 
 
+def test_snap_manifest_custom_branch_falls_back_to_develop(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"policy": "snap"},
+        env={"NEAT_APPS_DEPENDENCY_BRANCH": "zz-missing-core-artifact-for-test"},
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "NEAT core target      : develop:devsha1" in proc.stdout
+    assert "using develop-latest" in proc.stderr
+
+
 def test_explicit_manifest_uses_valid_branch_version(tmp_path):
     proc = _run_build(tmp_path, neat_core="zz-core-artifact-for-test-pinnedsha1")
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "NEAT core target      : zz-core-artifact-for-test:pinnedsha1" in proc.stdout
+    assert (
+        "https://core.test/zz-core-artifact-for-test/pinnedsha1/metadata.json"
+        in _curl_log(tmp_path)
+    )
+
+
+@pytest.mark.parametrize("ref_key", ["branch", "ref"])
+def test_dependency_object_manifest_uses_valid_artifact(tmp_path, ref_key):
+    proc = _run_build(
+        tmp_path,
+        neat_core={ref_key: "zz-core-artifact-for-test", "spec": "pinnedsha1"},
+    )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert "NEAT core target      : zz-core-artifact-for-test:pinnedsha1" in proc.stdout
@@ -306,7 +347,25 @@ def test_protected_branch_rejects_explicit_manifest_value(tmp_path):
     )
 
     assert proc.returncode != 0
-    assert "must keep neat-core empty on main/develop" in proc.stderr
+    assert "must keep neat-core as policy=snap on main/develop" in proc.stderr
+
+
+def test_protected_branch_rejects_explicit_dependency_object_manifest(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"branch": "main", "spec": "mainsha1"},
+        env={"GITHUB_REF_NAME": "main"},
+    )
+
+    assert proc.returncode != 0
+    assert "must keep neat-core as policy=snap on main/develop" in proc.stderr
+
+
+def test_unsupported_manifest_object_fails(tmp_path):
+    proc = _run_build(tmp_path, neat_core={"policy": "latest"})
+
+    assert proc.returncode != 0
+    assert "unsupported neat-core.policy" in proc.stderr
 
 
 def test_core_installer_runs_from_deps_debs_scratch_dir(tmp_path):


### PR DESCRIPTION
## Summary

- Switch apps `deps/manifest.json` to the standardized `"neat-core": {"policy": "snap"}` shape.
- Teach `build.sh` to accept snap, `branch/spec`, `ref/spec`, and legacy string values.
- Update manifest contract tests and README coverage for the object-form dependency contract.

## Validation

```bash
python3 -m json.tool deps/manifest.json
bash -n build.sh scripts/install-neat-apps.sh scripts/install-vulcan-apps-package.sh tests/test.sh
git diff --check
python3 -m pytest -q tests/scripts/test_manifest_contract.py
python3 -m pytest -q tests/scripts
NEAT_APPS_DEPENDENCY_BRANCH=develop ./build.sh --no-cpp --build-dir /tmp/neat-apps-manifest-shape-check
```

Closes #167