### PR TITLE
Fix Nightly e2e Modalix runner selection

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -6,15 +6,22 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to test"
+        description: "Branch artifact to install. Runner selection uses the workflow run ref."
         required: true
         default: main
         type: string
 
 jobs:
+  resolve-test-runner:
+    name: Resolve Test Runner
+    uses: sima-neat/.github/.github/workflows/vulcan-resolve-modalix-runner.yml@main
+
   modalix-nightly-e2e:
     if: github.event_name == 'schedule'
-    runs-on: [self-hosted, Linux, ARM64, modalix]
+    needs: resolve-test-runner
+    runs-on:
+      group: ${{ needs.resolve-test-runner.outputs.modalix_runner_group }}
+      labels: [self-hosted, Linux, ARM64, modalix]
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +69,10 @@ jobs:
 
   modalix-manual-e2e:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, Linux, ARM64, modalix]
+    needs: resolve-test-runner
+    runs-on:
+      group: ${{ needs.resolve-test-runner.outputs.modalix_runner_group }}
+      labels: [self-hosted, Linux, ARM64, modalix]
 
     steps:
       - name: Install apps runtime for latest branch build


### PR DESCRIPTION
## Summary
- add the shared Modalix runner resolver to Apps Nightly E2E
- run scheduled and manual Nightly E2E jobs on the resolved Modalix runner group
- clarify that manual `branch` input selects the installed apps artifact, while runner selection uses the workflow run ref

## Why
Nightly E2E previously used a fixed Modalix runner label. That could let a 2.0.0 apps run land on an incompatible runner pool when the fleet contains newer Modalix runners. The reusable resolver reads `deps/manifest.json` from the workflow run ref and resolves the runner group from `platform-version`.

For manual runs, use a matching workflow ref when branch-specific manifest behavior is required, for example:

```bash
gh workflow run nightly-e2e.yml \
  --ref <branch-with-manifest> \
  -f branch=<published-apps-artifact-branch>
```

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `python3 tests/utils/test_scope.py --scope-file examples validate --quiet`
- `python3 -m pytest tests/scripts/test_scope_contract.py -q`
- `bash -n tests/test.sh scripts/download_models.sh tests/scripts/testing/run_vscode_test_task.sh`
- Vulcan CI passed: https://github.com/sima-neat/apps/actions/runs/27092494134

## Nightly E2E Check
Manual Nightly runs were triggered with `--ref ci/nightly-e2e-runner-selection` and `branch=develop`:

- https://github.com/sima-neat/apps/actions/runs/27092743148
- https://github.com/sima-neat/apps/actions/runs/27093089591

Both runs verified the new resolver path: `Resolve Test Runner / Resolve Modalix runner` passed, runtime install passed, and the manual e2e job started on the resolved runner. The e2e step then failed because `/usr/bin/fix_devkit_runtime.sh` could not restart `simaai-appcomplex.service`; downstream tests failed with `Dispatcher unavailable` / `Connecting to server failed`. That failure is a board/runtime health issue, not runner selection.

Refs #182
