### PR TITLE
feat(genai): add multimodal assistant model selection

### DIFF
--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -16,8 +16,8 @@ This example hosts SiMa-supported GenAI models through Neat's OpenAI-compatible 
 
 The phase-1 target is one configured chat model, one configured ASR model, image/text chat, audio transcription, Piper TTS, system prompt control, chat history, voice selection, and abort.
 
-The demo runs as two processes. `python/main.py` reads the `server` section of
-`common/config.yaml` and starts the Neat OpenAI-compatible server.
+The demo runs as two processes. `python/serve_models.py` reads the `server`
+section of `common/config.yaml` and starts the Neat OpenAI-compatible server.
 `python/serve_web.py` reads the `app` section of `common/config.yaml` and starts
 the existing Flask UI.
 
@@ -81,9 +81,8 @@ the pyneat environment:
 
 ```bash
 source ~/pyneat/bin/activate
-python3 examples/genai/multimodal-assistant/python/main.py \
-  --config examples/genai/multimodal-assistant/common/config.yaml \
-  --server-only
+python3 examples/genai/multimodal-assistant/python/serve_models.py \
+  --config examples/genai/multimodal-assistant/common/config.yaml
 ```
 
 In a second terminal, start the Flask UI from the web environment:
@@ -93,7 +92,7 @@ python3 examples/genai/multimodal-assistant/python/serve_web.py \
   --config examples/genai/multimodal-assistant/common/config.yaml
 ```
 
-The supported phase-1 entrypoints are `python/main.py` for model hosting and
+The supported phase-1 entrypoints are `python/serve_models.py` for model hosting and
 `python/serve_web.py` for the UI. The imported sandbox scripts under `python/`
 are kept as source provenance during migration.
 
@@ -113,9 +112,8 @@ http://127.0.0.1:9998
 To test only the Neat OpenAI-compatible server:
 
 ```bash
-python3 examples/genai/multimodal-assistant/python/main.py \
-  --config examples/genai/multimodal-assistant/common/config.yaml \
-  --server-only
+python3 examples/genai/multimodal-assistant/python/serve_models.py \
+  --config examples/genai/multimodal-assistant/common/config.yaml
 ```
 
 ## Configuration
@@ -130,8 +128,10 @@ server:
 
   models:
     chat:
-      name: gemma4
-      path: assets/models/genai/gemma4-E2B-it
+      - name: gemma4
+        path: assets/models/genai/gemma4-E2B-it
+      - name: qwen3-vl-2b
+        path: assets/models/genai/Qwen3-VL-2B-Instruct-GPTQ-a16w4
     asr:
       name: whisper-small
       path: assets/models/genai/whisper-small-a16w8
@@ -146,10 +146,6 @@ app:
     client_host: 127.0.0.1
     port: 9998
 
-  models:
-    chat: gemma4
-    asr: whisper-small
-
   request:
     max_tokens: 128
     system_prompt: Answer clearly and concisely.
@@ -162,12 +158,13 @@ app:
     enabled: false
 ```
 
-The served model names in the `app` section must match the names registered by
-the `server` section. Server model paths are resolved relative to the apps
-repository root unless they are absolute paths.
+The Flask UI derives selectable chat models and the ASR model name from
+`server.models`. The first chat model is the default selected model. Server
+model paths are resolved relative to the apps repository root unless they are
+absolute paths.
 
 ## Source Files
-- Python source: `python/main.py`, `python/serve_web.py`, `python/app.py`, `python/app_config.py`, `python/pipertts.py`
+- Python source: `python/serve_models.py`, `python/serve_web.py`, `python/app.py`, `python/app_config.py`, `python/pipertts.py`
 - Python dependencies: `python/requirements.txt`
 - Web UI assets: `python/templates/`, `python/static/`, `python/assets/`, `python/certs/`
 - Shared config: `common/config.yaml`

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -14,7 +14,7 @@
 ## Concept
 This example hosts SiMa-supported GenAI models through Neat's OpenAI-compatible server and uses the imported Flask demo UI as the interactive assistant surface.
 
-The phase-1 target is one configured chat model, one configured ASR model, image/text chat, audio transcription, Piper TTS, system prompt control, chat history, voice selection, and abort.
+The example supports one or more configured chat models, one configured ASR model, image/text chat, audio transcription, Piper TTS, system prompt control, chat history, voice selection, and abort.
 
 The demo runs as two processes. `python/serve_models.py` reads the `server`
 section of `common/config.yaml` and starts the Neat OpenAI-compatible server.
@@ -28,11 +28,10 @@ Runtime ownership is split deliberately:
 - Neat hosts the OpenAI-compatible `/v1/audio/transcriptions` endpoint for ASR.
 - The Flask app owns UI state, system prompt handling, chat history, abort
   requests, uploaded images, microphone recordings, and Piper TTS playback.
-- Piper TTS is app-side and part of phase 1. The default requirements install
-  Piper; TTS produces audio when the configured voice assets are present under
-  `python/assets/`.
+- Piper TTS is app-side. The default requirements install Piper; TTS produces
+  audio when the configured voice assets are present under `python/assets/`.
 - RAG source is preserved from the sandbox import, but RAG is disabled by
-  default in phase 1 through `common/config.yaml`.
+  default through `common/config.yaml`.
 
 ## Preview
 Multimodal assistant web UI:
@@ -43,7 +42,7 @@ Multimodal assistant web UI:
 - Installed Neat runtime with GenAI and `pyneat` support.
 - A VLM or LLM model directory configured in `common/config.yaml`.
 - A Whisper ASR model directory configured in `common/config.yaml`.
-- Phase-1 Python packages from `python/requirements.txt`.
+- Python packages from `python/requirements.txt`.
 
 Model directories must contain `devkit/` and `elf_files/`. Chat models use `devkit/vlm_config.json`; ASR models use `devkit/whisper_config.json`.
 
@@ -92,7 +91,7 @@ python3 examples/genai/multimodal-assistant/python/serve_web.py \
   --config examples/genai/multimodal-assistant/common/config.yaml
 ```
 
-The supported phase-1 entrypoints are `python/serve_models.py` for model hosting and
+The supported entrypoints are `python/serve_models.py` for model hosting and
 `python/serve_web.py` for the UI. The imported sandbox scripts under `python/`
 are kept as source provenance during migration.
 

--- a/examples/genai/multimodal-assistant/common/config.yaml
+++ b/examples/genai/multimodal-assistant/common/config.yaml
@@ -5,8 +5,10 @@ server:
 
   models:
     chat:
-      name: gemma4
-      path: assets/models/genai/gemma4-E2B-it
+      - name: gemma4
+        path: assets/models/genai/gemma4-E2B-it
+      - name: qwen3-vl-2b
+        path: assets/models/genai/Qwen3-VL-2B-Instruct-GPTQ-a16w4
     asr:
       name: whisper-small
       path: assets/models/genai/whisper-small-a16w8
@@ -15,10 +17,6 @@ app:
   openai:
     client_host: 127.0.0.1
     port: 9998
-
-  models:
-    chat: gemma4
-    asr: whisper-small
 
   request:
     max_tokens: 128

--- a/examples/genai/multimodal-assistant/python/app.py
+++ b/examples/genai/multimodal-assistant/python/app.py
@@ -451,6 +451,8 @@ class AppContext:
         self.system_prompt = None
         self.model_display_name = ""
         self.chat_model_name = "model"
+        self.chat_model_names = ("model",)
+        self.active_chat_model_name = "model"
         self.asr_model_name = "whisper-small"
         self.max_tokens = None
         self.rag_enabled = True
@@ -579,11 +581,13 @@ class AppContext:
             self._active_generation_id = None
             return had_active_generation
 
-    def begin_generation(self):
+    def begin_generation(self, chat_model_name=None):
         with self._state_lock:
             self._generation_counter += 1
             generation_id = self._generation_counter
             self._active_generation_id = generation_id
+            if chat_model_name:
+                self.active_chat_model_name = chat_model_name
             self.current_response = ""
             return generation_id
 
@@ -603,6 +607,12 @@ class AppContext:
         if system_message:
             with self._state_lock:
                 self.conversation_history.insert(0, system_message)
+
+    def resolve_chat_model(self, requested_model=None):
+        model_name = str(requested_model or self.chat_model_name).strip()
+        if model_name in self.chat_model_names:
+            return model_name
+        raise ValueError(f"Unknown chat model: {model_name}")
 
     def get_conversation_history(self):
         """Get the current conversation history."""
@@ -629,7 +639,9 @@ class AppContext:
 
     def update_from_config(self, app_cfg):
         model_server = f"{app_cfg.openai.client_host}:{app_cfg.openai.port}"
-        self.chat_model_name = app_cfg.chat_model.name
+        self.chat_model_names = tuple(model.name for model in app_cfg.chat_models)
+        self.chat_model_name = self.chat_model_names[0]
+        self.active_chat_model_name = self.chat_model_name
         self.asr_model_name = app_cfg.asr_model.name
         self.max_tokens = app_cfg.request.max_tokens
         self.rag_enabled = app_cfg.rag.enabled
@@ -653,6 +665,7 @@ class AppContext:
         self.app.config['UPLOAD_FOLDER'] = AppConstants.DEFAULT_UPLOADS_DIR
         self.app.config['MODEL_DISPLAY_NAME'] = self.model_display_name
         self.app.config['CHAT_MODEL_NAME'] = self.chat_model_name
+        self.app.config['CHAT_MODEL_NAMES'] = list(self.chat_model_names)
         self.app.config['ASR_MODEL_NAME'] = self.asr_model_name
         self.app.config['MAX_TOKENS'] = self.max_tokens
         self.app.config['RAG_ENABLED'] = self.rag_enabled
@@ -685,6 +698,8 @@ class AppContext:
                 "window.SIMA_CONFIG=window.SIMA_CONFIG||{};"
                 f"window.SIMA_CONFIG.llmOnly='{llm_only_val}';"
                 f"window.SIMA_CONFIG.ragEnabled='{str(self.rag_enabled).lower()}';"
+                f"window.SIMA_CONFIG.chatModels={json.dumps(list(self.chat_model_names))};"
+                f"window.SIMA_CONFIG.defaultChatModel={json.dumps(self.chat_model_name)};"
                 f"window.SIMA_CONFIG.visionImageHeight='{height_val}';"
                 f"window.SIMA_CONFIG.visionImageWidth='{width_val}';"
             )
@@ -711,7 +726,7 @@ class AppContext:
         self.interrupt_active_generation(preserve_partial=True)
 
         try:
-            success = post_stop_to_sima(self.chat_model_name)
+            success = post_stop_to_sima(self.active_chat_model_name)
             if not success:
                 return jsonify({'status': 'error', 'message': 'Failed to send stop signal to SiMa.ai server.'}), 500
         except Exception as e:
@@ -858,6 +873,11 @@ class AppContext:
             search_rag = request.form.get('searchRag', 'false').lower() == 'true'
             include_chat_history = request.form.get('includeChatHistory', 'true').lower() == 'true'
             cfg = genai_app.get_config()
+            try:
+                selected_model = self.resolve_chat_model(request.form.get('chatModel'))
+            except ValueError as e:
+                return jsonify({'error': str(e)}), 400
+
             self.talk_ctrl.reset()
             self.talk_ctrl.set_language(language)
             had_active_generation = self.interrupt_active_generation(
@@ -865,7 +885,7 @@ class AppContext:
             )
             if had_active_generation:
                 try:
-                    post_stop_to_sima(cfg.get('CHAT_MODEL_NAME'))
+                    post_stop_to_sima(self.active_chat_model_name)
                 except Exception as e:
                     logging.error(f"Failed to stop previous generation before new request: {e}")
 
@@ -920,7 +940,7 @@ class AppContext:
             # Add user message to conversation history (detect if image is present)
             has_image = image_file is not None
             self.add_user_message(full_query_str, has_image=has_image, image_base64=image_base64)
-            generation_id = self.begin_generation()
+            generation_id = self.begin_generation(selected_model)
 
             ttfs = 0
             logging.info(f"Query string: {full_query_str}")
@@ -948,7 +968,7 @@ class AppContext:
 
             thread = threading.Thread(
                 target=stream_chat_request,
-                args=[conversation_history, cfg.get('CHAT_MODEL_NAME', 'model'), cfg, generation_id]
+                args=[conversation_history, selected_model, cfg, generation_id]
             )
             thread.start()
 
@@ -1050,10 +1070,15 @@ class AppContext:
                     image_file = request.files['image_data']
 
                 cfg = genai_app.get_config()
+                try:
+                    selected_model = self.resolve_chat_model(request.form.get('chatModel'))
+                except ValueError as e:
+                    return jsonify({'error': str(e)}), 400
+
                 had_active_generation = self.interrupt_active_generation(preserve_partial=True)
                 if had_active_generation:
                     try:
-                        post_stop_to_sima(cfg.get('CHAT_MODEL_NAME'))
+                        post_stop_to_sima(self.active_chat_model_name)
                     except Exception as e:
                         logging.error(f"Failed to stop previous generation before image request: {e}")
 
@@ -1069,13 +1094,13 @@ class AppContext:
 
                 # Add to conversation history and start assistant response (always has image)
                 self.add_user_message(query_str, has_image=True, image_base64=image_base64)
-                generation_id = self.begin_generation()
+                generation_id = self.begin_generation(selected_model)
 
                 logging.info(f"Query string {query_str}")
                 conversation_history = self.get_conversation_history()
                 thread = threading.Thread(
                     target=stream_chat_request,
-                    args=[conversation_history, cfg.get('CHAT_MODEL_NAME', 'model'), cfg, generation_id]
+                    args=[conversation_history, selected_model, cfg, generation_id]
                 )
                 thread.start()
                 return {'question' : query_str}

--- a/examples/genai/multimodal-assistant/python/app_config.py
+++ b/examples/genai/multimodal-assistant/python/app_config.py
@@ -142,19 +142,7 @@ def _load_required_chat_models(models: dict, apps_root: Path) -> tuple[ServedMod
             for index, entry in enumerate(raw)
         )
 
-    if not isinstance(raw, dict):
-        return (_load_required_model(models, "chat", apps_root),)
-
-    entries = raw.get("entries")
-    if entries is None:
-        return (_load_required_model(models, "chat", apps_root),)
-    if not isinstance(entries, list) or not entries:
-        raise ValueError("models.chat.entries must be a non-empty list")
-
-    return tuple(
-        _load_required_model_entry(entry, f"models.chat.entries[{index}]", apps_root)
-        for index, entry in enumerate(entries)
-    )
+    return (_load_required_model(models, "chat", apps_root),)
 
 
 def _load_required_model(models: dict, key: str, apps_root: Path) -> ServedModel:
@@ -181,15 +169,7 @@ def _load_required_model_entry(raw: object, label: str, apps_root: Path) -> Serv
 
 def _load_chat_model_names(models: dict) -> tuple[ServedModel, ...]:
     raw = models.get("chat", {})
-
-    if isinstance(raw, dict):
-        entries = raw.get("entries")
-        if entries is None:
-            entries = [raw.get("name", "")]
-    elif isinstance(raw, list):
-        entries = raw
-    else:
-        entries = [raw]
+    entries = raw if isinstance(raw, list) else [raw]
 
     names = tuple(_load_model_entry_name(entry) for entry in entries)
     names = tuple(name for name in names if name)

--- a/examples/genai/multimodal-assistant/python/app_config.py
+++ b/examples/genai/multimodal-assistant/python/app_config.py
@@ -54,6 +54,7 @@ class RagConfig:
 class AppConfig:
     openai: OpenAIConfig
     chat_model: ServedModel
+    chat_models: tuple[ServedModel, ...]
     asr_model: ServedModel
     request: RequestConfig
     web: WebConfig
@@ -73,6 +74,7 @@ def load_server_config(path: Path = DEFAULT_SERVER_CONFIG, apps_root: Path = APP
     request = raw.get("request", {})
     web = raw.get("web", {})
     rag = raw.get("rag", {})
+    chat_models = _load_required_chat_models(models, apps_root)
 
     return AppConfig(
         openai=OpenAIConfig(
@@ -80,7 +82,8 @@ def load_server_config(path: Path = DEFAULT_SERVER_CONFIG, apps_root: Path = APP
             client_host=str(openai.get("client_host", "127.0.0.1") or "127.0.0.1"),
             port=int(openai.get("port", 9998)),
         ),
-        chat_model=_load_required_model(models, "chat", apps_root),
+        chat_model=chat_models[0],
+        chat_models=chat_models,
         asr_model=_load_required_model(models, "asr", apps_root),
         request=RequestConfig(
             max_tokens=int(request.get("max_tokens", 128)),
@@ -96,14 +99,16 @@ def load_server_config(path: Path = DEFAULT_SERVER_CONFIG, apps_root: Path = APP
 
 
 def load_web_config(path: Path = DEFAULT_WEB_CONFIG) -> AppConfig:
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    raw = raw.get("app", raw)
+    config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    raw = config.get("app", config)
+    server = config.get("server", {})
 
     openai = raw.get("openai", {})
-    models = raw.get("models", {})
+    server_models = server.get("models", {})
     request = raw.get("request", {})
     web = raw.get("web", {})
     rag = raw.get("rag", {})
+    chat_models = _load_chat_model_names(server_models)
 
     return AppConfig(
         openai=OpenAIConfig(
@@ -111,8 +116,9 @@ def load_web_config(path: Path = DEFAULT_WEB_CONFIG) -> AppConfig:
             client_host=str(openai.get("client_host", "127.0.0.1") or "127.0.0.1"),
             port=int(openai.get("port", 9998)),
         ),
-        chat_model=_load_model_name(models, "chat"),
-        asr_model=_load_model_name(models, "asr"),
+        chat_model=chat_models[0],
+        chat_models=chat_models,
+        asr_model=_load_model_name(server_models, "asr"),
         request=RequestConfig(
             max_tokens=int(request.get("max_tokens", 128)),
             system_prompt=str(request.get("system_prompt", "") or ""),
@@ -126,22 +132,76 @@ def load_web_config(path: Path = DEFAULT_WEB_CONFIG) -> AppConfig:
     )
 
 
+def _load_required_chat_models(models: dict, apps_root: Path) -> tuple[ServedModel, ...]:
+    raw = models.get("chat", {})
+    if isinstance(raw, list):
+        if not raw:
+            raise ValueError("models.chat must contain at least one model")
+        return tuple(
+            _load_required_model_entry(entry, f"models.chat[{index}]", apps_root)
+            for index, entry in enumerate(raw)
+        )
+
+    if not isinstance(raw, dict):
+        return (_load_required_model(models, "chat", apps_root),)
+
+    entries = raw.get("entries")
+    if entries is None:
+        return (_load_required_model(models, "chat", apps_root),)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("models.chat.entries must be a non-empty list")
+
+    return tuple(
+        _load_required_model_entry(entry, f"models.chat.entries[{index}]", apps_root)
+        for index, entry in enumerate(entries)
+    )
+
+
 def _load_required_model(models: dict, key: str, apps_root: Path) -> ServedModel:
     raw = models.get(key, {})
+    return _load_required_model_entry(raw, f"models.{key}", apps_root)
+
+
+def _load_required_model_entry(raw: object, label: str, apps_root: Path) -> ServedModel:
     if not isinstance(raw, dict):
-        raise ValueError(f"models.{key} must be a mapping")
+        raise ValueError(f"{label} must be a mapping")
 
     name = str(raw.get("name", "")).strip()
     path_text = str(raw.get("path", "")).strip()
     if not name:
-        raise ValueError(f"models.{key}.name is required")
+        raise ValueError(f"{label}.name is required")
     if not path_text:
-        raise ValueError(f"models.{key}.path is required")
+        raise ValueError(f"{label}.path is required")
 
     model_path = Path(path_text).expanduser()
     if not model_path.is_absolute():
         model_path = apps_root / model_path
     return ServedModel(name=name, path=model_path)
+
+
+def _load_chat_model_names(models: dict) -> tuple[ServedModel, ...]:
+    raw = models.get("chat", {})
+
+    if isinstance(raw, dict):
+        entries = raw.get("entries")
+        if entries is None:
+            entries = [raw.get("name", "")]
+    elif isinstance(raw, list):
+        entries = raw
+    else:
+        entries = [raw]
+
+    names = tuple(_load_model_entry_name(entry) for entry in entries)
+    names = tuple(name for name in names if name)
+    if not names:
+        raise ValueError("models.chat requires at least one model name")
+    return tuple(ServedModel(name=name, path=None) for name in names)
+
+
+def _load_model_entry_name(entry: object) -> str:
+    if isinstance(entry, dict):
+        entry = entry.get("name", "")
+    return str(entry).strip()
 
 
 def _load_model_name(models: dict, key: str) -> ServedModel:

--- a/examples/genai/multimodal-assistant/python/serve_models.py
+++ b/examples/genai/multimodal-assistant/python/serve_models.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 import sys
 import time
@@ -15,11 +14,6 @@ from app_config import AppConfig, DEFAULT_SERVER_CONFIG, load_server_config
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path, default=DEFAULT_SERVER_CONFIG)
-    parser.add_argument(
-        "--server-only",
-        action="store_true",
-        help="Start only the Neat OpenAI-compatible server and skip the Flask UI.",
-    )
     return parser
 
 
@@ -37,10 +31,11 @@ def start_openai_server(cfg: AppConfig):
     options.port = cfg.openai.port
 
     server = pyneat.OpenAIServer(options)
-    chat_name = server.add_model(cfg.chat_model.path, cfg.chat_model.name)
+    for model in cfg.chat_models:
+        chat_name = server.add_model(model.path, model.name)
+        print(f"added chat model: {chat_name} -> {model.path}", flush=True)
     asr_name = server.add_model(cfg.asr_model.path, cfg.asr_model.name)
 
-    print(f"added chat model: {chat_name} -> {cfg.chat_model.path}", flush=True)
     print(f"added ASR model: {asr_name} -> {cfg.asr_model.path}", flush=True)
     print(f"available models: {', '.join(server.model_names())}", flush=True)
     print(
@@ -66,7 +61,7 @@ def main() -> int:
 
     missing = [
         str(model.path)
-        for model in (cfg.chat_model, cfg.asr_model)
+        for model in (*cfg.chat_models, cfg.asr_model)
         if model.path is None or not model.path.is_dir()
     ]
     if missing:
@@ -78,16 +73,8 @@ def main() -> int:
     server = None
     try:
         server = start_openai_server(cfg)
-        if args.server_only:
-            while True:
-                time.sleep(1)
-
-        app_dir = Path(__file__).resolve().parent
-        os.chdir(app_dir)
-        from app import run_app
-
-        run_app(cfg)
-        return 0
+        while True:
+            time.sleep(1)
     except KeyboardInterrupt:
         print("\nstopping OpenAI-compatible API server...", flush=True)
         return 0

--- a/examples/genai/multimodal-assistant/python/static/newui.js
+++ b/examples/genai/multimodal-assistant/python/static/newui.js
@@ -52,6 +52,38 @@ function isRagEnabled() {
   return config.ragEnabled === true || config.ragEnabled === 'true';
 }
 
+function getConfiguredChatModels() {
+  const config = window.SIMA_CONFIG || {};
+  return Array.isArray(config.chatModels) ? config.chatModels.filter(Boolean) : [];
+}
+
+function getSelectedChatModel() {
+  const select = document.getElementById('chatModelSelect');
+  const models = getConfiguredChatModels();
+  return (select && select.value) || window.SIMA_CONFIG?.defaultChatModel || models[0] || '';
+}
+
+function initializeChatModelSelect() {
+  const row = document.getElementById('chatModelRow');
+  const select = document.getElementById('chatModelSelect');
+  const models = getConfiguredChatModels();
+
+  if (!row || !select || models.length === 0) return;
+
+  while (select.firstChild) {
+    select.removeChild(select.firstChild);
+  }
+  models.forEach(model => {
+    const option = document.createElement('option');
+    option.value = model;
+    option.textContent = model;
+    select.appendChild(option);
+  });
+
+  select.value = window.SIMA_CONFIG?.defaultChatModel || models[0];
+  row.style.display = models.length > 1 ? 'block' : 'none';
+}
+
 function hideRagControlsIfDisabled() {
   if (isRagEnabled()) return;
 
@@ -364,6 +396,7 @@ window.onload = function () {
 
   // Initialize dashboard functionality
   initializeVoiceSync();
+  initializeChatModelSelect();
   hideRagControlsIfDisabled();
   if (isRagEnabled()) {
     initializeRagHealth();
@@ -1119,6 +1152,7 @@ async function startProcessingInternal(resultMessage, textchat = null, waitForTr
 
   formData.append('searchRag', isRagEnabled() && searchRag ? searchRag.checked : false);
   formData.append('includeChatHistory', includeChatHistory ? includeChatHistory.checked : true);
+  formData.append('chatModel', getSelectedChatModel());
 
   const sendRequest = async () => {
     activeGeneration = true;

--- a/examples/genai/multimodal-assistant/python/templates/newui.html
+++ b/examples/genai/multimodal-assistant/python/templates/newui.html
@@ -45,6 +45,12 @@
             <!-- Left Container: Conversation & Voice -->
             <div class="settings-left-container">
               <div class="setting-group-title">Conversation Settings</div>
+              <div class="setting-row" id="chatModelRow" style="display: none;">
+                <label for="chatModelSelect" class="setting-label">
+                  Model:
+                </label>
+                <select id="chatModelSelect" class="setting-select"></select>
+              </div>
               <div class="setting-row">
                 <label class="setting-label">
                   <input type="checkbox" id="toggleImagePrompt" checked>


### PR DESCRIPTION
## Summary

Phase 2 adds chat model selection for the Multimodal Assistant.

- Configures multiple chat/VLM models directly under `server.models.chat`.
- Uses the first configured chat model as the default.
- Registers all configured chat models with `pyneat.OpenAIServer`.
- Derives UI chat model choices and ASR model name from the server model config.
- Adds one model selector to the existing Flask UI.
- Sends the selected model with chat/image requests and routes it to `/v1/chat/completions`.
- Keeps ASR, TTS, RAG-disabled behavior, system prompt, chat history, and abort flows intact.
- Renames the model-hosting entrypoint from `python/main.py` to `python/serve_models.py` and makes it always serve only the OpenAI-compatible model server.

## Scope

This PR targets #176 and is based on `feat/multimodal-assistant` after Phase 1 landed.

## Runtime Validation

Validated on Modalix:

- `serve_models.py` starts the OpenAI-compatible model server.
- `/v1/models` lists `gemma4`, `qwen3-vl-2b`, and `whisper-small`.
- `/v1/chat/completions` works with `model=gemma4`.
- `/v1/chat/completions` works with `model=qwen3-vl-2b`.

Still pending before marking ready:

- Start `serve_web.py` and confirm the UI selector shows both chat models.
- Confirm selecting each model routes chat/image requests to the selected model.
- Confirm abort still stops the active selected model.

## Local Validation

```bash
python3 -m py_compile \
  examples/genai/multimodal-assistant/python/app_config.py \
  examples/genai/multimodal-assistant/python/serve_models.py \
  examples/genai/multimodal-assistant/python/app.py \
  examples/genai/multimodal-assistant/python/serve_web.py

node --check examples/genai/multimodal-assistant/python/static/newui.js
python3 scripts/validate_readmes.py examples/genai/multimodal-assistant/README.md
git diff --check origin/feat/multimodal-assistant..HEAD
```
