### PR TITLE
Multimodal Assistant Phase 3: RAG support

### DIFF
--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -53,10 +53,11 @@ environment where `pyneat` is available. The examples below assume:
 Visit the [SiMa.ai Hugging Face page](https://huggingface.co/simaai) to see the
 officially supported model artifacts. Download the chat/VLM and ASR artifacts
 you want to run, then update `common/config.yaml` so each model path points to
-the downloaded directory.
+the downloaded directory. Model paths can be absolute or relative to the `apps`
+repository root.
 
 ```bash
-hf download simaai/<model-repo> --local-dir assets/models/genai/<model-dir>
+hf download simaai/<model-repo> --local-dir <local-model-dir>
 ```
 
 Model directories must contain `devkit/` and `elf_files/`. Chat models use
@@ -187,7 +188,7 @@ Edit `examples/genai/multimodal-assistant/common/config.yaml`:
 app:
   rag:
     enabled: true
-    embedding_model_dir: assets/models/genai/gte-small
+    embedding_model_dir: <path-to-embedding-model-dir>
 ```
 
 ### 2. Install RAG Dependencies
@@ -202,10 +203,11 @@ python3 -m pip install -r examples/genai/multimodal-assistant/python/requirement
 
 ### 3. Download The Embedding Model
 Place the local embedding model at the path configured by
-`app.rag.embedding_model_dir`.
+`app.rag.embedding_model_dir`. The path can be absolute or relative to the
+`apps` repository root.
 
 ```bash
-hf download <embedding-model-repo> --local-dir assets/models/genai/gte-small
+hf download <embedding-model-repo> --local-dir <local-embedding-model-dir>
 ```
 
 ### 4. Create A RAG Database From Markdown
@@ -224,7 +226,7 @@ source ~/multimodal-assistant-app/bin/activate
 python vectordb/create_db.py \
   --input /workspace/sima-neat/apps/examples/genai/multimodal-assistant/common/rag/neat.md \
   --output ./milvus.db \
-  --embedding-model /workspace/sima-neat/apps/assets/models/genai/gte-small
+  --embedding-model <path-to-embedding-model-dir>
 ```
 
 Do not commit generated files:

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -30,8 +30,8 @@ Runtime ownership is split deliberately:
   requests, uploaded images, microphone recordings, and Piper TTS playback.
 - Piper TTS is app-side. The default requirements install Piper; TTS produces
   audio when the configured voice assets are present under `python/assets/`.
-- RAG source is preserved from the sandbox import, but RAG is disabled by
-  default through `common/config.yaml`.
+- RAG is app-side and optional. It uses the Flask UI, local VectorDB service,
+  and the same chat model hosted by the Neat OpenAI-compatible server.
 
 ## Preview
 Multimodal assistant web UI:
@@ -39,85 +39,31 @@ Multimodal assistant web UI:
 ![Multimodal Assistant preview](../../../assets/portal/genai/multimodal-assistant/image.png)
 
 ## Prerequisites
-- Installed Neat runtime with GenAI and `pyneat` support.
-- A VLM or LLM model directory configured in `common/config.yaml`.
-- A Whisper ASR model directory configured in `common/config.yaml`.
-- Python packages from `python/requirements.txt`.
+Run the commands from the `apps` repository root on the target system.
 
-Model directories must contain `devkit/` and `elf_files/`. Chat models use `devkit/vlm_config.json`; ASR models use `devkit/whisper_config.json`.
-
-The default `common/config.yaml` expects:
+### 1. Install Neat
+Install Neat before running the demo. The model server must use a Python
+environment where `pyneat` is available. The examples below assume:
 
 ```text
-assets/models/genai/gemma4-E2B-it
-assets/models/genai/whisper-small-a16w8
+~/pyneat/bin/python
 ```
 
-Install the app packages in the web environment:
+### 2. Download Model Artifacts
+Visit the [SiMa.ai Hugging Face page](https://huggingface.co/simaai) to see the
+officially supported model artifacts. Download the chat/VLM and ASR artifacts
+you want to run, then update `common/config.yaml` so each model path points to
+the downloaded directory.
 
 ```bash
-python3 -m pip install -r examples/genai/multimodal-assistant/python/requirements.txt
+hf download simaai/<model-repo> --local-dir assets/models/genai/<model-dir>
 ```
 
-Install Piper voice assets for TTS:
+Model directories must contain `devkit/` and `elf_files/`. Chat models use
+`devkit/vlm_config.json`; ASR models use `devkit/whisper_config.json`.
 
-```bash
-cd examples/genai/multimodal-assistant/python
-bash voice_install.sh
-```
-
-The script downloads selected Piper `.onnx` voice models from
-`rhasspy/piper-voices` into `python/assets/`. Each voice must have both files:
-
-```text
-python/assets/<voice>.onnx
-python/assets/<voice>.onnx.json
-```
-
-## Run
-From the `apps` repository root, start the Neat OpenAI-compatible server from
-the pyneat environment:
-
-```bash
-source ~/pyneat/bin/activate
-python3 examples/genai/multimodal-assistant/python/serve_models.py \
-  --config examples/genai/multimodal-assistant/common/config.yaml
-```
-
-In a second terminal, start the Flask UI from the web environment:
-
-```bash
-python3 examples/genai/multimodal-assistant/python/serve_web.py \
-  --config examples/genai/multimodal-assistant/common/config.yaml
-```
-
-The supported entrypoints are `python/serve_models.py` for model hosting and
-`python/serve_web.py` for the UI. The imported sandbox scripts under `python/`
-are kept as source provenance during migration.
-
-By default, the Flask UI preserves the sandbox HTTPS behavior and listens on the
-configured web port:
-
-```text
-https://<host>:5000
-```
-
-The Neat OpenAI-compatible server listens on the configured API port:
-
-```text
-http://127.0.0.1:9998
-```
-
-To test only the Neat OpenAI-compatible server:
-
-```bash
-python3 examples/genai/multimodal-assistant/python/serve_models.py \
-  --config examples/genai/multimodal-assistant/common/config.yaml
-```
-
-## Configuration
-The `server` section of `common/config.yaml` controls the Neat OpenAI server
-binding and model directories.
+### 3. Configure Models
+Edit `examples/genai/multimodal-assistant/common/config.yaml`:
 
 ```yaml
 server:
@@ -127,44 +73,203 @@ server:
 
   models:
     chat:
-      - name: gemma4
-        path: assets/models/genai/gemma4-E2B-it
-      - name: qwen3-vl-2b
-        path: assets/models/genai/Qwen3-VL-2B-Instruct-GPTQ-a16w4
+      - name: <chat-model-name>
+        path: <path-to-llm-or-vlm-model>
+      - name: <another-chat-model-name>
+        path: <path-to-another-llm-or-vlm-model>
     asr:
-      name: whisper-small
-      path: assets/models/genai/whisper-small-a16w8
+      name: <asr-model-name>
+      path: <path-to-asr-model>
 ```
 
-The `app` section of `common/config.yaml` controls the Flask UI and the served
-model names used in OpenAI requests.
+The first chat model in the list is selected by default. Additional chat models
+appear in the UI model selector.
+
+### 4. Create The Web Environment
+Keep the Flask UI dependencies separate from the `pyneat` environment:
+
+```bash
+python3 -m venv ~/multimodal-assistant-app
+source ~/multimodal-assistant-app/bin/activate
+python3 -m pip install -r examples/genai/multimodal-assistant/python/requirements.txt
+```
+
+### 5. Install Piper Voices For TTS
+If you need text-to-speech playback, install the Piper voice assets:
+
+```bash
+cd examples/genai/multimodal-assistant/python
+bash voice_install.sh
+cd /workspace/sima-neat/apps
+```
+
+The script downloads selected Piper `.onnx` voice models into `python/assets/`.
+Each voice needs both files:
+
+```text
+python/assets/<voice>.onnx
+python/assets/<voice>.onnx.json
+```
+
+## Run
+For the general demo, start both processes with the wrapper script:
+
+```bash
+cd /workspace/sima-neat/apps
+
+APP_PYTHON=~/multimodal-assistant-app/bin/python \
+PYNEAT_PYTHON=~/pyneat/bin/python \
+bash examples/genai/multimodal-assistant/run.sh
+```
+
+`run.sh` is a convenience wrapper. It starts:
+
+- `python/serve_models.py` with `PYNEAT_PYTHON`
+- `python/serve_web.py` with `APP_PYTHON`
+
+Set `PYNEAT_PYTHON` to the Python interpreter that has `pyneat` installed. Set
+`APP_PYTHON` to the web environment that has `python/requirements.txt`
+installed. If `PYNEAT_PYTHON` is not set, the script uses `~/pyneat/bin/python`
+when it exists. If `APP_PYTHON` is not set, it uses `python3`.
+
+Open the Flask UI:
+
+```text
+https://<target-ip>:5000
+```
+
+The Neat OpenAI-compatible server listens on:
+
+```text
+http://127.0.0.1:9998
+```
+
+Check that the configured models are hosted:
+
+```bash
+curl -s http://127.0.0.1:9998/v1/models | python3 -m json.tool
+```
+
+### Manual Process Start
+Use this only when you want two explicit terminals.
+
+Terminal 1, model server:
+
+```bash
+cd /workspace/sima-neat/apps
+source ~/pyneat/bin/activate
+
+python /workspace/sima-neat/apps/examples/genai/multimodal-assistant/python/serve_models.py \
+  --config /workspace/sima-neat/apps/examples/genai/multimodal-assistant/common/config.yaml
+```
+
+Terminal 2, Flask UI:
+
+```bash
+cd /workspace/sima-neat/apps
+source ~/multimodal-assistant-app/bin/activate
+
+python /workspace/sima-neat/apps/examples/genai/multimodal-assistant/python/serve_web.py \
+  --config /workspace/sima-neat/apps/examples/genai/multimodal-assistant/common/config.yaml
+```
+
+The supported entrypoints are `python/serve_models.py` for model hosting and
+`python/serve_web.py` for the UI. The imported sandbox scripts under `python/`
+are kept as source provenance during migration.
+
+## Optional RAG Setup
+RAG is optional. If you do not need RAG, skip this section.
+
+### 1. Enable RAG
+Edit `examples/genai/multimodal-assistant/common/config.yaml`:
 
 ```yaml
 app:
-  openai:
-    client_host: 127.0.0.1
-    port: 9998
-
-  request:
-    max_tokens: 128
-    system_prompt: Answer clearly and concisely.
-
-  web:
-    port: 5000
-    https: true
-
   rag:
-    enabled: false
+    enabled: true
+    embedding_model_dir: assets/models/genai/gte-small
 ```
 
-The Flask UI derives selectable chat models and the ASR model name from
-`server.models`. The first chat model is the default selected model. Server
-model paths are resolved relative to the apps repository root unless they are
-absolute paths.
+### 2. Install RAG Dependencies
+Install the RAG packages into the web environment:
+
+```bash
+cd /workspace/sima-neat/apps
+source ~/multimodal-assistant-app/bin/activate
+
+python3 -m pip install -r examples/genai/multimodal-assistant/python/requirements-rag.txt
+```
+
+### 3. Download The Embedding Model
+Place the local embedding model at the path configured by
+`app.rag.embedding_model_dir`.
+
+```bash
+hf download <embedding-model-repo> --local-dir assets/models/genai/gte-small
+```
+
+### 4. Create A RAG Database From Markdown
+The example includes a small Markdown document for smoke testing:
+
+```text
+examples/genai/multimodal-assistant/common/rag/neat.md
+```
+
+Create `milvus.db`:
+
+```bash
+cd /workspace/sima-neat/apps/examples/genai/multimodal-assistant/python
+source ~/multimodal-assistant-app/bin/activate
+
+python vectordb/create_db.py \
+  --input /workspace/sima-neat/apps/examples/genai/multimodal-assistant/common/rag/neat.md \
+  --output ./milvus.db \
+  --embedding-model /workspace/sima-neat/apps/assets/models/genai/gte-small
+```
+
+Do not commit generated files:
+
+```text
+examples/genai/multimodal-assistant/python/milvus.db
+examples/genai/multimodal-assistant/python/milvus.meta.json
+```
+
+### 5. Run And Test RAG
+Start the demo normally. The Flask app starts the local VectorDB service when
+RAG is enabled.
+
+```bash
+cd /workspace/sima-neat/apps
+
+APP_PYTHON=~/multimodal-assistant-app/bin/python \
+PYNEAT_PYTHON=~/pyneat/bin/python \
+bash examples/genai/multimodal-assistant/run.sh
+```
+
+Check VectorDB directly:
+
+```bash
+curl -sG http://127.0.0.1:9100/search \
+  --data-urlencode "query=What is the canonical RAG validation phrase?" \
+  --data "k=3" \
+  --data "min_score=-1" | python3 -m json.tool
+```
+
+In the UI, enable `Search RAG Database` and ask:
+
+```text
+What is the canonical RAG validation phrase?
+```
+
+The RAG status area should report whether RAG was used and how many hits were
+retrieved.
 
 ## Source Files
+- Run wrapper: `run.sh`
 - Python source: `python/serve_models.py`, `python/serve_web.py`, `python/app.py`, `python/app_config.py`, `python/pipertts.py`
-- Python dependencies: `python/requirements.txt`
+- Python dependencies: `python/requirements.txt`, `python/requirements-rag.txt`
+- RAG helper: `python/vectordb/create_db.py`
+- RAG sample document: `common/rag/neat.md`
 - Web UI assets: `python/templates/`, `python/static/`, `python/assets/`, `python/certs/`
 - Shared config: `common/config.yaml`
 - Test scope: `test-scope.yaml`

--- a/examples/genai/multimodal-assistant/common/config.yaml
+++ b/examples/genai/multimodal-assistant/common/config.yaml
@@ -5,13 +5,14 @@ server:
 
   models:
     chat:
-      - name: gemma4
-        path: assets/models/genai/gemma4-E2B-it
-      - name: qwen3-vl-2b
-        path: assets/models/genai/Qwen3-VL-2B-Instruct-GPTQ-a16w4
+      # The first chat model is selected by default in the UI.
+      - name: <primary-chat-model-name>
+        path: <path-to-primary-chat-model-dir>
+      - name: <secondary-chat-model-name>
+        path: <path-to-secondary-chat-model-dir>
     asr:
-      name: whisper-small
-      path: assets/models/genai/whisper-small-a16w8
+      name: <asr-model-name>
+      path: <path-to-asr-model-dir>
 
 app:
   openai:
@@ -30,4 +31,4 @@ app:
 
   rag:
     enabled: false
-    embedding_model_dir: assets/models/genai/gte-small
+    embedding_model_dir: <path-to-embedding-model-dir>

--- a/examples/genai/multimodal-assistant/common/config.yaml
+++ b/examples/genai/multimodal-assistant/common/config.yaml
@@ -29,5 +29,5 @@ app:
     https: true
 
   rag:
-    enabled: true
+    enabled: false
     embedding_model_dir: assets/models/genai/gte-small

--- a/examples/genai/multimodal-assistant/common/config.yaml
+++ b/examples/genai/multimodal-assistant/common/config.yaml
@@ -29,4 +29,5 @@ app:
     https: true
 
   rag:
-    enabled: false
+    enabled: true
+    embedding_model_dir: assets/models/genai/gte-small

--- a/examples/genai/multimodal-assistant/common/rag/neat.md
+++ b/examples/genai/multimodal-assistant/common/rag/neat.md
@@ -1,0 +1,65 @@
+# Neat Runtime Overview
+
+## What Neat Is
+
+SiMa.ai Neat is an application-development framework for building and running AI
+applications on the SiMa.ai platform. It provides developers a set of Python and
+C++ APIs to execute and test compiled model artifacts, compose AI applications
+that leverage the SoC's hardware blocks, and manage runtime execution.
+
+In the broader SiMa.ai software ecosystem, Neat sits at the application layer.
+It builds on the SiMa.ai runtime stack and uses GStreamer-based execution
+underneath so developers can stay focused on application logic instead of
+manually stitching together lower-level runtime pieces.
+
+## How It Works
+
+Neat gives developers a direct mental model for the application path. A compiled
+model archive becomes a Model component, application logic is assembled as a
+Graph, and that graph is built and executed as a Run object on the SoC. The same
+workflow is designed to work well with agentic development so teams can explore,
+build, and iterate faster.
+
+## Runtime APIs
+
+Neat is SiMa.ai's application runtime for deploying AI pipelines on SiMa
+hardware. It provides Python and C++ APIs for loading model artifacts, composing
+runtime graphs, and running inference on SiMa devices.
+
+## Model Hosting
+
+Neat can host GenAI models through a PyNeat OpenAI-compatible server. The server
+exposes familiar endpoints such as `/v1/models`, `/v1/chat/completions`, and
+audio transcription routes. Applications can use those endpoints without knowing
+the lower-level graph execution details.
+
+## Multimodal Assistant
+
+The Multimodal Assistant demo uses Neat to connect multiple AI features in one
+application. The model server hosts the configured LLM or VLM for chat, plus an
+ASR model for speech transcription. The Flask web app sends text, image, and
+audio requests to the server and streams responses back to the browser.
+
+## RAG Behavior
+
+Retrieval augmented generation adds document context to a user question before
+the chat model receives it. A Markdown file is split into sections, embedded
+with the local GTE embedding model, and stored in a Milvus vector database. At
+query time, the app searches the vector database and appends the retrieved text
+to the prompt.
+
+## Customer Configuration
+
+Customers configure model names and model paths in `common/config.yaml`. The
+first configured chat model is used as the default. Additional hosted chat
+models can be selected from the UI. The ASR model is configured separately
+because speech transcription does not depend on the selected chat model.
+
+## Test Facts
+
+- The canonical RAG validation phrase is: neat modalix retrieval anchor.
+- The Multimodal Assistant uses Flask for the web UI.
+- The GenAI model server is started separately from the web app.
+- The RAG database file is named `milvus.db`.
+- Markdown RAG upload creates the vector database locally without RAGFPS.
+- Piper provides text-to-speech playback when voice assets are installed.

--- a/examples/genai/multimodal-assistant/python/.gitignore
+++ b/examples/genai/multimodal-assistant/python/.gitignore
@@ -8,6 +8,7 @@ uploads/
 *.wav
 .milvus*
 milvus.db*
+milvus.meta.json
 .cache/*
 .venv-*/*
 *.tar.gz

--- a/examples/genai/multimodal-assistant/python/app.py
+++ b/examples/genai/multimodal-assistant/python/app.py
@@ -44,34 +44,28 @@ ttfs = 0
 vectodb_proc = None
 rag_db_client = None
 RAG_DB_PATH = None
-upload_and_process_file = None
-is_rag_fps_available = None
 start_service = None
+create_markdown_vectordb = None
 
 def ensure_rag_modules_loaded():
     global rag_db_client
     global RAG_DB_PATH
-    global upload_and_process_file
-    global is_rag_fps_available
     global start_service
+    global create_markdown_vectordb
 
     if rag_db_client is not None:
         return rag_db_client
 
-    from vectordb.gradioclient import (
-        upload_and_process_file as _upload_and_process_file,
-        is_rag_fps_available as _is_rag_fps_available,
-    )
     from vectordb.vectordb import (
         RAG_DB_PATH as _RAG_DB_PATH,
         start_service as _start_service,
         RagDbClient,
     )
+    from vectordb.create_db import create_markdown_vectordb as _create_markdown_vectordb
 
-    upload_and_process_file = _upload_and_process_file
-    is_rag_fps_available = _is_rag_fps_available
     RAG_DB_PATH = _RAG_DB_PATH
     start_service = _start_service
+    create_markdown_vectordb = _create_markdown_vectordb
     rag_db_client = RagDbClient()
     return rag_db_client
 
@@ -456,6 +450,7 @@ class AppContext:
         self.asr_model_name = "whisper-small"
         self.max_tokens = None
         self.rag_enabled = True
+        self.rag_embedding_model_dir = ""
         self.vision_image_size = None
 
         # Conversation history for OpenAI-style chat
@@ -645,6 +640,9 @@ class AppContext:
         self.asr_model_name = app_cfg.asr_model.name
         self.max_tokens = app_cfg.request.max_tokens
         self.rag_enabled = app_cfg.rag.enabled
+        self.rag_embedding_model_dir = app_cfg.rag.embedding_model_dir
+        if self.rag_embedding_model_dir:
+            os.environ["VDB_EMBED_MODEL_DIR"] = self.rag_embedding_model_dir
         self.update_settings(
             camidx=None,
             model_server_ip=model_server,
@@ -669,6 +667,8 @@ class AppContext:
         self.app.config['ASR_MODEL_NAME'] = self.asr_model_name
         self.app.config['MAX_TOKENS'] = self.max_tokens
         self.app.config['RAG_ENABLED'] = self.rag_enabled
+        self.app.config['RAG_FILE_PROCESSING_URL'] = self.ragserver or ""
+        self.app.config['RAG_EMBEDDING_MODEL_DIR'] = self.rag_embedding_model_dir
         self.app.config['VISION_IMAGE_SIZE'] = self.vision_image_size
 
     def get_config(self):
@@ -931,10 +931,15 @@ class AppContext:
                 query_str = AppConstants.DEFAULT_MODEL_QUERY_STR
 
             full_query_str = query_str
+            rag_used = False
+            rag_hits = 0
 
             # if we have the query and search_rag flag is on, search the rag database
             if search_rag and self.rag_enabled and len(full_query_str) > 0:
+                ensure_rag_modules_loaded()
                 rag = rag_db_client.search(query_str)
+                rag_used = True
+                rag_hits = len(rag)
                 full_query_str = f"{query_str}\n\nThe context is:\n\n{[entry['content'] for entry in rag]}"
 
             # Add user message to conversation history (detect if image is present)
@@ -972,14 +977,18 @@ class AppContext:
             )
             thread.start()
 
-            return {'question': query_str, 'ttt': elapsed_time}
+            return {
+                'question': query_str,
+                'ttt': elapsed_time,
+                'rag_used': rag_used,
+                'rag_hits': rag_hits,
+            }
 
         @self.app.route('/raghealth', methods=['GET'])
         def check_rag_server():
             if not self.rag_enabled:
                 return {
                     "rag_db": "disabled",
-                    "rag_fps": "disabled",
                     "message": "RAG is disabled"
                 }, 200
 
@@ -990,22 +999,14 @@ class AppContext:
                 logging.error(f"Exception checking RAG DB server: {e}")
                 rag_db_status = False
 
-            try:
-                rag_fps_status = is_rag_fps_available(self.ragserver)
-            except Exception as e:
-                logging.warning(f"Optional RAG File Processing Server check failed: {e}")
-                rag_fps_status = False
-
             if rag_db_status:
                 return {
                     "rag_db": "ok",
-                    "rag_fps": "ok" if rag_fps_status else "unavailable",
                     "message": "RAG DB is available"
                 }, 200
             else:
                 return {
                     "rag_db": "unavailable",
-                    "rag_fps": "ok" if rag_fps_status else "unavailable",
                     "message": "RAG DB is not available"
                 }, 503
 
@@ -1120,30 +1121,31 @@ class AppContext:
                 return "No file provided", 400
 
             filename = secure_filename(uploaded_file.filename)
-            if not filename.lower().endswith((".pdf", ".txt", ".md", ".xml")):
-                return "Unsupported file type. Only PDF and TXT are allowed.", 400
+            if not filename.lower().endswith(".md"):
+                return "Only Markdown RAG upload is supported locally.", 400
 
             with tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(filename)[1]) as tmp:
                 uploaded_file.save(tmp)
                 tmp_path = tmp.name
 
             def stream_response():
+                global vectodb_proc
                 yield "⏳ Starting...\n"
                 try:
                     ensure_rag_modules_loaded()
-                    for line in upload_and_process_file(tmp_path, self.ragserver):
-                        yield line + "\n"
+                    yield "🛑 Stopping existing vectordb service...\n"
+                    stop_service()
 
-                        if 'Database synchronized' in line:
-                            time.sleep(2)
-                            yield "🛑 Stopping existing vectordb service...\n"
-                            stop_service()
-                            time.sleep(5)
+                    yield "📚 Creating VectorDB from Markdown...\n"
+                    create_markdown_vectordb(
+                        input_path=tmp_path,
+                        output_db=RAG_DB_PATH,
+                        embedding_model=self.rag_embedding_model_dir,
+                    )
 
-                            yield "🚀 Starting vectordb service with new database...\n"
-                            global vectodb_proc
-                            vectodb_proc = start_service()
-                            time.sleep(20)
+                    yield "🚀 Starting vectordb service with new database...\n"
+                    vectodb_proc = start_service()
+                    yield "✅ Markdown RAG database is ready.\n"
 
                 except Exception as e:
                     yield f"❌ {str(e)}\n"

--- a/examples/genai/multimodal-assistant/python/app_config.py
+++ b/examples/genai/multimodal-assistant/python/app_config.py
@@ -48,6 +48,7 @@ class WebConfig:
 @dataclass(frozen=True)
 class RagConfig:
     enabled: bool
+    embedding_model_dir: str
 
 
 @dataclass(frozen=True)
@@ -94,11 +95,11 @@ def load_server_config(path: Path = DEFAULT_SERVER_CONFIG, apps_root: Path = APP
             port=int(web.get("port", 5000)),
             https=_load_bool(web.get("https", True)),
         ),
-        rag=RagConfig(enabled=_load_bool(rag.get("enabled", False))),
+        rag=_load_rag_config(rag, apps_root),
     )
 
 
-def load_web_config(path: Path = DEFAULT_WEB_CONFIG) -> AppConfig:
+def load_web_config(path: Path = DEFAULT_WEB_CONFIG, apps_root: Path = APPS_ROOT) -> AppConfig:
     config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     raw = config.get("app", config)
     server = config.get("server", {})
@@ -128,7 +129,7 @@ def load_web_config(path: Path = DEFAULT_WEB_CONFIG) -> AppConfig:
             port=int(web.get("port", 5000)),
             https=_load_bool(web.get("https", True)),
         ),
-        rag=RagConfig(enabled=_load_bool(rag.get("enabled", False))),
+        rag=_load_rag_config(rag, apps_root),
     )
 
 
@@ -192,6 +193,25 @@ def _load_model_name(models: dict, key: str) -> ServedModel:
     if not name:
         raise ValueError(f"models.{key} is required")
     return ServedModel(name=name, path=None)
+
+
+def _load_rag_config(raw: object, apps_root: Path) -> RagConfig:
+    rag = raw if isinstance(raw, dict) else {}
+    return RagConfig(
+        enabled=_load_bool(rag.get("enabled", False)),
+        embedding_model_dir=_load_optional_path(rag.get("embedding_model_dir", ""), apps_root),
+    )
+
+
+def _load_optional_path(value: object, apps_root: Path) -> str:
+    path_text = str(value or "").strip()
+    if not path_text:
+        return ""
+
+    path = Path(path_text).expanduser()
+    if not path.is_absolute():
+        path = apps_root / path
+    return str(path)
 
 
 def _load_bool(value: object) -> bool:

--- a/examples/genai/multimodal-assistant/python/static/newui.js
+++ b/examples/genai/multimodal-assistant/python/static/newui.js
@@ -1164,6 +1164,12 @@ async function startProcessingInternal(resultMessage, textchat = null, waitForTr
       });
       const data = await response.json();
       displayResult(data.question || resultMessage, 'static/sample_audio.wav', data.ttt);
+      const ragStatus = document.getElementById("ragStatus");
+      if (isRagEnabled() && ragStatus) {
+        ragStatus.textContent = data.rag_used
+          ? `RAG used: yes, hits: ${data.rag_hits || 0}`
+          : "RAG used: no";
+      }
     } catch (error) {
       activeGeneration = false;
       console.error('Error uploading files:', error);
@@ -1593,8 +1599,15 @@ function initializeVoiceSync() {
   }
 }
 
+function setRagControls(dbReady) {
+  const importButton = document.getElementById("importRagDatabaseButton");
+  const uploadButton = document.getElementById("uploadToRagButton");
+  if (importButton) importButton.disabled = !dbReady;
+  if (uploadButton) uploadButton.disabled = false;
+}
+
 // Initialize RAG health check
-function initializeRagHealth() {
+function initializeRagHealth(attempt = 1) {
   if (!isRagEnabled()) {
     return;
   }
@@ -1603,13 +1616,10 @@ function initializeRagHealth() {
     .then(res => res.json().then(data => ({ status: res.status, data })))
     .then(({ status, data }) => {
       const dbStatus = data.rag_db === "ok";
-      const fpsStatus = data.rag_fps === "ok";
 
       // Update status message
-      if (dbStatus && fpsStatus) {
-        ragServerStatusText = "✅ RAG Database and RAG File Processing Server are online.";
-      } else if (dbStatus && !fpsStatus) {
-        ragServerStatusText = "✅ RAG Database is online. ⚠️ RAG File Processing Server is unavailable.";
+      if (dbStatus) {
+        ragServerStatusText = "✅ RAG Database is online.";
       } else {
         ragServerStatusText = "❌ RAG Database is not ready yet, please wait...";
       }
@@ -1618,11 +1628,10 @@ function initializeRagHealth() {
       const ragStatus = document.getElementById("ragStatus");
       if (ragStatus) ragStatus.textContent = ragServerStatusText;
 
-      // Enable/disable buttons accordingly
-      const importButton = document.getElementById("importRagDatabaseButton");
-      const uploadButton = document.getElementById("uploadToRagButton");
-      if (importButton) importButton.disabled = !dbStatus;
-      if (uploadButton) uploadButton.disabled = !fpsStatus;
+      setRagControls(dbStatus);
+      if (!dbStatus && attempt < 15) {
+        setTimeout(() => initializeRagHealth(attempt + 1), 2000);
+      }
     })
     .catch(err => {
       ragServerStatusText = "❌ Error checking RAG server health.";
@@ -1630,11 +1639,10 @@ function initializeRagHealth() {
       const ragStatus = document.getElementById("ragStatus");
       if (ragStatus) ragStatus.textContent = ragServerStatusText;
 
-      // Disable both buttons on error
-      const importButton = document.getElementById("importRagDatabaseButton");
-      const uploadButton = document.getElementById("uploadToRagButton");
-      if (importButton) importButton.disabled = true;
-      if (uploadButton) uploadButton.disabled = true;
+      setRagControls(false);
+      if (attempt < 15) {
+        setTimeout(() => initializeRagHealth(attempt + 1), 2000);
+      }
     });
 }
 
@@ -1784,7 +1792,7 @@ document.getElementById("uploadToRagButton").addEventListener("click", async () 
 
   const fileInput = document.createElement("input");
   fileInput.type = "file";
-  fileInput.accept = ".pdf,.txt.,.md";
+  fileInput.accept = ".md";
   fileInput.click();
 
   fileInput.onchange = async () => {
@@ -1792,7 +1800,7 @@ document.getElementById("uploadToRagButton").addEventListener("click", async () 
     if (!file) return;
 
     const messageBox = document.getElementById("settingsMessage");
-    messageBox.textContent = "⏳ Uploading file to RAG server...";
+    messageBox.textContent = "⏳ Creating RAG database from Markdown...";
 
     try {
       const formData = new FormData();

--- a/examples/genai/multimodal-assistant/python/vectordb/create_db.py
+++ b/examples/genai/multimodal-assistant/python/vectordb/create_db.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_milvus import Milvus
+from langchain_text_splitters import MarkdownHeaderTextSplitter
+
+
+DEFAULT_COLLECTION = "demo_collection"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s | %(message)s")
+
+
+def create_markdown_vectordb(
+    input_path: str,
+    output_db: str,
+    embedding_model: str,
+    collection: str = DEFAULT_COLLECTION,
+) -> None:
+    source = Path(input_path).expanduser().resolve()
+    db_path = Path(output_db).expanduser().resolve()
+    model_path = Path(embedding_model).expanduser().resolve()
+
+    if not source.is_file():
+        raise FileNotFoundError(f"Markdown file does not exist: {source}")
+    if not model_path.is_dir():
+        raise FileNotFoundError(f"Embedding model directory does not exist: {model_path}")
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_text = source.read_text(encoding="utf-8", errors="ignore")
+    splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=[
+            ("#", "Header_1"),
+            ("##", "Header_2"),
+            ("###", "Header_3"),
+            ("####", "Header_4"),
+        ]
+    )
+    documents = splitter.split_text(markdown_text)
+    if not documents:
+        raise ValueError(f"No Markdown chunks were created from: {source}")
+
+    embedding = HuggingFaceEmbeddings(
+        model_name=str(model_path),
+        model_kwargs={"device": "cpu"},
+    )
+    Milvus.from_documents(
+        documents=documents,
+        embedding=embedding,
+        collection_name=collection,
+        connection_args={"uri": str(db_path)},
+        index_params={"index_type": "FLAT", "metric_type": "IP"},
+        drop_old=True,
+    )
+
+    metadata_path = db_path.with_suffix(".meta.json")
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "input": str(source),
+                "collection": collection,
+                "embedding_model": str(model_path),
+                "chunks": len(documents),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    logging.info("Created %s with %d Markdown chunks", db_path, len(documents))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a Milvus VectorDB from a Markdown file.")
+    parser.add_argument("--input", required=True, help="Markdown input file")
+    parser.add_argument("--output", required=True, help="Output milvus.db path")
+    parser.add_argument("--embedding-model", required=True, help="Local embedding model directory")
+    parser.add_argument("--collection", default=DEFAULT_COLLECTION, help="Milvus collection name")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    create_markdown_vectordb(
+        input_path=args.input,
+        output_db=args.output,
+        embedding_model=args.embedding_model,
+        collection=args.collection,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/genai/multimodal-assistant/python/vectordb/vectordb.py
+++ b/examples/genai/multimodal-assistant/python/vectordb/vectordb.py
@@ -184,6 +184,15 @@ class RagDbClient:
 app = Flask(__name__)
 ragdb: VectorDB = None
 
+@app.route("/", methods=["GET"])
+def index_endpoint():
+    return jsonify({
+        "service": "rag-vectordb",
+        "message": "This is the RAG VectorDB API, not the Multimodal Assistant UI.",
+        "search": "/search?query=<text>&k=3&min_score=-1",
+    })
+
+
 def initialize_db():
     global ragdb
     db_path = os.environ.get("VECTOR_DB_PATH", RAG_DB_PATH)
@@ -210,9 +219,11 @@ def search_endpoint():
         abort(500, description=str(e))
 
 def main():
-    app.run(host=os.environ.get("HOST", DEFAULT_VDB_HOST),
-            port=int(os.environ.get("PORT", DEFAULT_VDB_PORT)),
-            debug=False)
+    host = os.environ.get("HOST", DEFAULT_VDB_HOST)
+    port = int(os.environ.get("PORT", DEFAULT_VDB_PORT))
+    log.info("RAG VectorDB API: http://127.0.0.1:%s/search", port)
+    log.info("Multimodal Assistant UI runs on the Flask app port, not this service.")
+    app.run(host=host, port=port, debug=False)
 
 
 def start_service():

--- a/examples/genai/multimodal-assistant/run.sh
+++ b/examples/genai/multimodal-assistant/run.sh
@@ -14,6 +14,7 @@ if [[ -z "${PYNEAT_PYTHON:-}" ]]; then
 fi
 
 APP_PYTHON="${APP_PYTHON:-python3}"
+SHUTDOWN_GRACE_SECONDS="${SHUTDOWN_GRACE_SECONDS:-10}"
 
 if [[ ! -f "${CONFIG_PATH}" ]]; then
   echo "config does not exist: ${CONFIG_PATH}" >&2
@@ -22,11 +23,33 @@ fi
 
 pids=()
 
+any_child_running() {
+  local running_pids
+  running_pids="$(jobs -r -p || true)"
+  for pid in "${pids[@]}"; do
+    if grep -qx "${pid}" <<<"${running_pids}"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 cleanup() {
   trap - EXIT INT TERM
   for pid in "${pids[@]}"; do
     if kill -0 "${pid}" 2>/dev/null; then
-      kill "${pid}" 2>/dev/null || true
+      kill -INT "${pid}" 2>/dev/null || true
+    fi
+  done
+
+  local deadline=$((SECONDS + SHUTDOWN_GRACE_SECONDS))
+  while any_child_running && [[ "${SECONDS}" -lt "${deadline}" ]]; do
+    sleep 1
+  done
+
+  for pid in "${pids[@]}"; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill -TERM "${pid}" 2>/dev/null || true
     fi
   done
   for pid in "${pids[@]}"; do

--- a/examples/genai/multimodal-assistant/run.sh
+++ b/examples/genai/multimodal-assistant/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_PATH="${CONFIG_PATH:-${EXAMPLE_DIR}/common/config.yaml}"
+PYTHON_DIR="${EXAMPLE_DIR}/python"
+
+if [[ -z "${PYNEAT_PYTHON:-}" ]]; then
+  if [[ -x "${HOME}/pyneat/bin/python" ]]; then
+    PYNEAT_PYTHON="${HOME}/pyneat/bin/python"
+  else
+    PYNEAT_PYTHON="python3"
+  fi
+fi
+
+APP_PYTHON="${APP_PYTHON:-python3}"
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  echo "config does not exist: ${CONFIG_PATH}" >&2
+  exit 2
+fi
+
+pids=()
+
+cleanup() {
+  trap - EXIT INT TERM
+  for pid in "${pids[@]}"; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill "${pid}" 2>/dev/null || true
+    fi
+  done
+  for pid in "${pids[@]}"; do
+    wait "${pid}" 2>/dev/null || true
+  done
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+echo "Starting Neat OpenAI-compatible model server..."
+"${PYNEAT_PYTHON}" "${PYTHON_DIR}/serve_models.py" --config "${CONFIG_PATH}" &
+pids+=("$!")
+
+sleep "${MODEL_SERVER_START_DELAY:-2}"
+
+echo "Starting Multimodal Assistant Flask UI..."
+"${APP_PYTHON}" "${PYTHON_DIR}/serve_web.py" --config "${CONFIG_PATH}" &
+pids+=("$!")
+
+echo "Multimodal Assistant is starting. Press Ctrl+C to stop both processes."
+
+while [[ "$(jobs -r -p | wc -l | tr -d ' ')" -eq "${#pids[@]}" ]]; do
+  sleep 1
+done
+
+status=0
+running_pids="$(jobs -r -p)"
+for pid in "${pids[@]}"; do
+  if ! grep -qx "${pid}" <<<"${running_pids}"; then
+    set +e
+    wait "${pid}"
+    status=$?
+    set -e
+    break
+  fi
+done
+
+exit "${status}"


### PR DESCRIPTION
## Summary

Adds Phase 3 RAG support for the Multimodal Assistant example.

- adds a local Markdown-to-Milvus helper for creating `milvus.db`
- adds an example-owned RAG smoke-test document under `common/rag/`
- wires Markdown upload to rebuild the local VectorDB without RAGFPS
- reports whether RAG was used and how many hits were retrieved
- retries RAG health checks while VectorDB starts
- adds a root `run.sh` wrapper for launching model server and Flask UI together
- updates the README with separate general-demo and optional-RAG setup steps

## Validation

- `python3 -m py_compile examples/genai/multimodal-assistant/python/app.py examples/genai/multimodal-assistant/python/app_config.py examples/genai/multimodal-assistant/python/serve_models.py examples/genai/multimodal-assistant/python/serve_web.py examples/genai/multimodal-assistant/python/vectordb/create_db.py examples/genai/multimodal-assistant/python/vectordb/vectordb.py`
- `node --check examples/genai/multimodal-assistant/python/static/newui.js`
- `bash -n examples/genai/multimodal-assistant/run.sh`
- `python3 scripts/validate_readmes.py examples/genai/multimodal-assistant/README.md`
- `python3 scripts/generate_catalog.py`

## Notes

Generated VectorDB files are intentionally not committed:

- `examples/genai/multimodal-assistant/python/milvus.db`
- `examples/genai/multimodal-assistant/python/milvus.meta.json`
