### PR TITLE
Update GenAI examples for GenAIServer API

### DIFF
--- a/examples/genai/detection-to-vlm-assistant/python/deploy_openai_server.py
+++ b/examples/genai/detection-to-vlm-assistant/python/deploy_openai_server.py
@@ -36,11 +36,11 @@ def main() -> None:
 
     import pyneat
 
-    options = pyneat.OpenAIServerOptions()
+    options = pyneat.GenAIServerOptions()
     options.host = args.host
     options.port = args.port
 
-    server = pyneat.OpenAIServer(options)
+    server = pyneat.GenAIServer(options)
     model_specs = args.model or DEFAULT_MODELS
     for model_dir, served_name in model_specs:
         path = Path(model_dir)

--- a/examples/genai/multimodal-assistant/python/server/main.py
+++ b/examples/genai/multimodal-assistant/python/server/main.py
@@ -39,13 +39,13 @@ def start_openai_server(cfg: AppConfig):
             "provided by the installed Neat runtime."
         ) from exc
 
-    options = pyneat.OpenAIServerOptions()
+    options = pyneat.GenAIServerOptions()
     options.host = cfg.openai.host
     options.port = cfg.openai.port
 
     server = None
     try:
-        server = pyneat.OpenAIServer(options)
+        server = pyneat.GenAIServer(options)
         for model in cfg.chat_models:
             chat_name = server.add_model(model.path, model.name)
             print(f"added chat model: {chat_name} -> {model.path}", flush=True)


### PR DESCRIPTION
## Summary

- Update GenAI examples from the old `pyneat.OpenAIServer` API to the renamed `pyneat.GenAIServer` API.
- Update both server option construction and server construction in the affected examples.
- Keep OpenAI-compatible endpoint wording unchanged because the served HTTP API is still `/v1/...` compatible.

## Why

Core renamed the public GenAI server bindings from `OpenAIServer` to `GenAIServer`. The old names are no longer present in latest core artifacts, so the GenAI examples would fail at startup with the new PyNeat wheel.

## Affected Examples

- `examples/genai/multimodal-assistant/python/server/main.py`
- `examples/genai/detection-to-vlm-assistant/python/deploy_openai_server.py`

## Validation

- `python3 -m py_compile examples/genai/multimodal-assistant/python/server/main.py examples/genai/detection-to-vlm-assistant/python/deploy_openai_server.py`
- `rg "OpenAIServer|OpenAIServerOptions" examples/genai --glob '!**/__pycache__/**'` returns no matches.

Closes #194
