### PR TITLE
Enable folder E2E for DETR and RetinaFace

### DIFF
--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -12,7 +12,7 @@
 | Model | retinaface_mobilenet25 [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz] |
 
 ## Concept
-This example demonstrates single-image face detection with **RetinaFace**, a one-stage dense detector designed for robust face localization across pose, scale, and occlusion conditions.
+This example demonstrates folder-based face detection with **RetinaFace**, a one-stage dense detector designed for robust face localization across pose, scale, and occlusion conditions.
 
 RetinaFace predicts:
 - Face bounding boxes
@@ -21,7 +21,7 @@ RetinaFace predicts:
 
 Compared with generic object detectors, RetinaFace is specialized for facial geometry and alignment-sensitive tasks. Landmark outputs make it useful not only for drawing detection overlays, but also for downstream steps such as face alignment, tracking initialization, quality filtering, and recognition pre-processing.
 
-In this app, the compiled `retinaface_mobilenet25` package is run on an input image, raw outputs are decoded into candidate detections, low-confidence candidates are filtered, overlapping boxes are merged with Non-Maximum Suppression (NMS), and the final boxes/landmarks are rendered to an output image.
+In this app, the compiled `retinaface_mobilenet25` package is run on images from an input folder, raw outputs are decoded into candidate detections, low-confidence candidates are filtered, overlapping boxes are merged with Non-Maximum Suppression (NMS), and the final boxes/landmarks are rendered to output images.
 
 ## Preview
 Snippet from a pipeline run:
@@ -150,13 +150,12 @@ Notes:
 - Use an absolute path for `SIMANEAT_APPS_TEST_MODELS_DIR` in Python e2e. The test runs `main.py` with `cwd` set to the example directory.
 - `SIMANEAT_APPS_TEST_INPUT_DIR` is supported by both C++ and Python e2e tests.
 - If `SIMANEAT_APPS_TEST_INPUT_DIR` is not set, both e2e tests fall back to `assets/test_images`.
-- RetinaFace e2e prefers an image filename containing `face` when present, then falls back to the first available image in the input directory.
 
 ## Debugging Notes
 - If the model fails to load, verify `assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz` exists and is readable.
 - If no detections appear, lower `decode.confidence_threshold` and confirm the input actually contains faces.
 - If too many duplicate boxes appear, reduce `decode.nms_iou` and/or lower `decode.top_k`.
-- If output writing fails, ensure the parent directory of `<output_image_path>` exists and is writable.
+- If output writing fails, ensure `io.output_dir` exists or can be created.
 
 ## Source Files
 - C++ source: `cpp/main.cpp`

--- a/examples/face-detection/face-detector/common/config.yaml
+++ b/examples/face-detection/face-detector/common/config.yaml
@@ -2,8 +2,8 @@ model:
   path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
 
 io:
-  image: assets/test_images/image.png
-  output: sandbox/face-detector/output.png
+  input_dir: assets/test_images
+  output_dir: sandbox/face-detector
 
 decode:
   confidence_threshold: 0.40

--- a/examples/face-detection/face-detector/cpp/main.cpp
+++ b/examples/face-detection/face-detector/cpp/main.cpp
@@ -1,6 +1,6 @@
 /**
  * @example face-detector.cpp
- * Minimal RetinaFace pipeline (tensor input): run inference on one image and decode
+ * Minimal RetinaFace pipeline (tensor input): run inference on a folder and decode
  * boxes/landmarks.
  *
  * Usage: face-detector [--config <path>]
@@ -16,6 +16,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
@@ -475,9 +476,9 @@ static void draw_detections(cv::Mat& bgr, const std::vector<Detection>& dets, in
 }
 
 struct Config {
-  fs::path image;
+  fs::path input_dir;
   std::string model = "assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz";
-  fs::path output;
+  fs::path output_dir;
   float conf = 0.4f;
   float nms = 0.9f;
   int top_k = 5000;
@@ -489,12 +490,30 @@ struct Config {
   int timeout_ms = 20000;
 };
 
+static bool is_image_file(const fs::path& path) {
+  std::string ext = path.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp";
+}
+
+static std::vector<fs::path> image_paths_in_dir(const fs::path& input_dir) {
+  std::vector<fs::path> images;
+  for (const auto& entry : fs::directory_iterator(input_dir)) {
+    if (entry.is_regular_file() && is_image_file(entry.path())) {
+      images.push_back(entry.path());
+    }
+  }
+  std::sort(images.begin(), images.end());
+  return images;
+}
+
 static Config load_config(const fs::path& path) {
   const auto raw = sima_examples::ScalarConfig::load(path);
   Config cfg;
   cfg.model = raw.string_or("model.path", "assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz");
-  cfg.image = raw.string_or("io.image", "assets/test_images/input.jpg");
-  cfg.output = raw.string_or("io.output", "sandbox/face-detector/output.png");
+  cfg.input_dir = raw.string_or("io.input_dir", "assets/test_images");
+  cfg.output_dir = raw.string_or("io.output_dir", "sandbox/face-detector");
   cfg.conf = static_cast<float>(raw.double_or("decode.confidence_threshold", 0.4));
   cfg.nms = static_cast<float>(raw.double_or("decode.nms_iou", 0.9));
   cfg.top_k = raw.int_or("decode.top_k", 5000);
@@ -549,25 +568,17 @@ int main(int argc, char** argv) {
 
   try {
     const Config args = parse_config(argc, argv);
-    if (!fs::exists(args.image)) {
-      throw std::runtime_error("image does not exist: " + args.image.string());
+    if (!fs::is_directory(args.input_dir)) {
+      throw std::runtime_error("input_dir does not exist: " + args.input_dir.string());
     }
     if (!fs::exists(args.model)) {
       throw std::runtime_error("model does not exist: " + args.model);
     }
 
-    cv::Mat bgr_u8 = cv::imread(args.image.string(), cv::IMREAD_COLOR);
-    if (bgr_u8.empty()) {
-      throw std::runtime_error("failed to read image: " + args.image.string());
+    const std::vector<fs::path> image_paths = image_paths_in_dir(args.input_dir);
+    if (image_paths.empty()) {
+      throw std::runtime_error("no images found in: " + args.input_dir.string());
     }
-
-    cv::Mat bgr_f32;
-    bgr_u8.convertTo(bgr_f32, CV_32FC3);
-    bgr_mean_subtract_inplace(bgr_f32);
-    auto [padded, meta] = pad_to_aspect(bgr_f32, kInferW, kInferH);
-
-    cv::Mat resized;
-    cv::resize(padded, resized, cv::Size(kInferW, kInferH), 0, 0, cv::INTER_LINEAR);
 
     simaai::neat::Model::Options model_opt;
     model_opt.preprocess.kind = simaai::neat::InputKind::Tensor;
@@ -588,10 +599,22 @@ int main(int argc, char** argv) {
     simaai::neat::Tensor dummy_t = tensor_from_hwc_f32(dummy);
     auto run = graph.build(simaai::neat::TensorList{dummy_t}, simaai::neat::RunMode::Async);
 
-    simaai::neat::Tensor input_t = tensor_from_hwc_f32(resized);
     std::vector<Detection> dets;
 
     if (args.profile) {
+      const fs::path& image_path = image_paths.front();
+      cv::Mat bgr_u8 = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+      if (bgr_u8.empty()) {
+        throw std::runtime_error("failed to read image: " + image_path.string());
+      }
+      cv::Mat bgr_f32;
+      bgr_u8.convertTo(bgr_f32, CV_32FC3);
+      bgr_mean_subtract_inplace(bgr_f32);
+      auto [padded, meta] = pad_to_aspect(bgr_f32, kInferW, kInferH);
+      cv::Mat resized;
+      cv::resize(padded, resized, cv::Size(kInferW, kInferH), 0, 0, cv::INTER_LINEAR);
+      simaai::neat::Tensor input_t = tensor_from_hwc_f32(resized);
+
       const int runs = std::max(1, args.num_runs);
       std::vector<double> graph_times;
       std::vector<double> post_times;
@@ -651,7 +674,7 @@ int main(int argc, char** argv) {
       const double fps_overall = runs_d / total_sum;
 
       std::cout << "Profiling over " << graph_times.size() << " runs (image='"
-                << args.image.string() << "'):\n";
+                << image_path.string() << "'):\n";
       std::cout << "  Graph run (push+pull): mean=" << graph_stats.mean
                 << "s, min=" << graph_stats.min << "s, max=" << graph_stats.max
                 << "s, FPS=" << fps_graph << "\n";
@@ -668,45 +691,64 @@ int main(int argc, char** argv) {
                   << d.x2 << "," << d.y2 << "]\n";
       }
     } else {
-      if (!run.push(simaai::neat::TensorList{input_t})) {
-        throw std::runtime_error("run.push failed");
-      }
-
-      auto out_sample = run.pull(args.timeout_ms);
-      if (!out_sample.has_value()) {
-        throw std::runtime_error("run.pull returned no sample");
-      }
-
-      const std::vector<simaai::neat::Tensor> out_tensors = collect_tensors(*out_sample);
-      std::cout << "Model produced " << out_tensors.size() << " tensor(s)\n";
-      for (size_t i = 0; i < out_tensors.size(); ++i) {
-        const auto& t = out_tensors[i];
-        std::cout << "  [" << i << "] dtype=" << static_cast<int>(t.dtype) << " shape=[";
-        for (size_t d = 0; d < t.shape.size(); ++d) {
-          std::cout << t.shape[d] << (d + 1 < t.shape.size() ? "," : "");
+      fs::create_directories(args.output_dir);
+      int processed = 0;
+      for (const fs::path& image_path : image_paths) {
+        cv::Mat bgr_u8 = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+        if (bgr_u8.empty()) {
+          throw std::runtime_error("failed to read image: " + image_path.string());
         }
-        std::cout << "]\n";
-      }
+        cv::Mat bgr_f32;
+        bgr_u8.convertTo(bgr_f32, CV_32FC3);
+        bgr_mean_subtract_inplace(bgr_f32);
+        auto [padded, meta] = pad_to_aspect(bgr_f32, kInferW, kInferH);
+        cv::Mat resized;
+        cv::resize(padded, resized, cv::Size(kInferW, kInferH), 0, 0, cv::INTER_LINEAR);
+        simaai::neat::Tensor input_t = tensor_from_hwc_f32(resized);
 
-      decode_outputs(out_tensors, dets, meta, args.conf, args.nms, args.top_k, args.keep_top_k,
-                     args.landmarks);
+        if (!run.push(simaai::neat::TensorList{input_t})) {
+          throw std::runtime_error("run.push failed");
+        }
 
-      std::cout << "Detections: " << dets.size() << "\n";
-      for (size_t i = 0; i < std::min<size_t>(dets.size(), 20); ++i) {
-        const auto& d = dets[i];
-        std::cout << "  [" << i << "] score=" << d.score << " box=[" << d.x1 << "," << d.y1 << ","
-                  << d.x2 << "," << d.y2 << "]\n";
-      }
+        auto out_sample = run.pull(args.timeout_ms);
+        if (!out_sample.has_value()) {
+          throw std::runtime_error("run.pull returned no sample");
+        }
 
-      if (!args.output.empty()) {
+        const std::vector<simaai::neat::Tensor> out_tensors = collect_tensors(*out_sample);
+        std::cout << "Model produced " << out_tensors.size() << " tensor(s)\n";
+        for (size_t i = 0; i < out_tensors.size(); ++i) {
+          const auto& t = out_tensors[i];
+          std::cout << "  [" << i << "] dtype=" << static_cast<int>(t.dtype) << " shape=[";
+          for (size_t d = 0; d < t.shape.size(); ++d) {
+            std::cout << t.shape[d] << (d + 1 < t.shape.size() ? "," : "");
+          }
+          std::cout << "]\n";
+        }
+
+        decode_outputs(out_tensors, dets, meta, args.conf, args.nms, args.top_k, args.keep_top_k,
+                       args.landmarks);
+
+        std::cout << "Detections: " << dets.size() << "\n";
+        for (size_t i = 0; i < std::min<size_t>(dets.size(), 20); ++i) {
+          const auto& d = dets[i];
+          std::cout << "  [" << i << "] score=" << d.score << " box=[" << d.x1 << "," << d.y1 << ","
+                    << d.x2 << "," << d.y2 << "]\n";
+        }
+
         cv::Mat overlay = bgr_u8.clone();
         draw_detections(overlay, dets, args.max_draw);
-        fs::create_directories(args.output.parent_path());
-        if (!cv::imwrite(args.output.string(), overlay)) {
-          throw std::runtime_error("failed to write: " + args.output.string());
+        const fs::path output_path =
+            args.output_dir / (image_path.stem().string() + "_retinaface.png");
+        if (!cv::imwrite(output_path.string(), overlay)) {
+          throw std::runtime_error("failed to write: " + output_path.string());
         }
-        std::cout << "Wrote annotated image: " << args.output << "\n";
+        ++processed;
+        std::cout << "[" << processed << "/" << image_paths.size() << "] "
+                  << image_path.filename().string() << ": " << dets.size() << " detections -> "
+                  << output_path.filename().string() << "\n";
       }
+      std::cout << "Done: " << processed << " images processed\n";
     }
 
     run.close();

--- a/examples/face-detection/face-detector/cpp/tests/test_e2e.cpp
+++ b/examples/face-detection/face-detector/cpp/tests/test_e2e.cpp
@@ -1,16 +1,13 @@
 // E2E test for face-detector.
-// Runs the binary with a real RetinaFace model and a local face image, and verifies it exits
-// successfully and produces an annotated output image.
+// Runs the binary with a real RetinaFace model and a local image folder, and verifies it exits
+// successfully and produces annotated output images.
 #include "support/testing/test_process.h"
 #include "support/testing/test_config.h"
 
-#include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
 
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
@@ -36,44 +33,16 @@ int main(int argc, char** argv) {
   const char* input_dir_raw = env_or_null("SIMANEAT_APPS_TEST_INPUT_DIR");
   const std::string input_dir = input_dir_raw ? input_dir_raw : "assets/test_images";
 
-  std::string image_path;
-  if (fs::exists(input_dir)) {
-    std::vector<fs::path> image_candidates;
-    for (auto& entry : fs::directory_iterator(input_dir)) {
-      const auto ext = entry.path().extension().string();
-      if (ext == ".png" || ext == ".jpg" || ext == ".jpeg") {
-        image_candidates.push_back(entry.path());
-      }
-    }
-
-    std::sort(image_candidates.begin(), image_candidates.end());
-
-    for (const auto& candidate : image_candidates) {
-      std::string name = candidate.filename().string();
-      std::transform(name.begin(), name.end(), name.begin(),
-                     [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-      if (name.find("face") != std::string::npos) {
-        image_path = candidate.string();
-        break;
-      }
-    }
-
-    if (image_path.empty() && !image_candidates.empty()) {
-      image_path = image_candidates.front().string();
-    }
-  }
-
-  if (image_path.empty()) {
+  if (!fs::exists(input_dir) || fs::is_empty(input_dir)) {
     env_or_skip("SIMANEAT_APPS_TEST_INPUT_DIR",
                 "directory containing test images (defaults to assets/test_images)");
-    return kSkipCode; // not reached if env_or_skip exits, but keeps compiler happy
+    return kSkipCode;
   }
 
   const std::string out_dir = create_test_output_dir("face-detector", "test_full_pipeline");
   if (out_dir.empty()) {
     return 1;
   }
-  fs::path out_image = fs::path(out_dir) / "retinaface_output.png";
   const double confidence_threshold = e2e_double("face-detector", "decode", "confidence_threshold");
   const double nms_iou = e2e_double("face-detector", "decode", "nms_iou");
   const int top_k = e2e_int("face-detector", "decode", "top_k");
@@ -84,8 +53,8 @@ int main(int argc, char** argv) {
     config_file << "model:\n"
                 << "  path: " << model_path << "\n"
                 << "io:\n"
-                << "  image: " << image_path << "\n"
-                << "  output: " << out_image.string() << "\n"
+                << "  input_dir: " << input_dir << "\n"
+                << "  output_dir: " << out_dir << "\n"
                 << "decode:\n"
                 << "  confidence_threshold: " << confidence_threshold << "\n"
                 << "  nms_iou: " << nms_iou << "\n"
@@ -110,18 +79,19 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  if (!fs::exists(out_image)) {
-    std::cerr << "[FAIL] expected annotated output image not found at " << out_image << "\n";
+  const int output_files = count_output_files(out_dir);
+  if (output_files == 0) {
+    std::cerr << "[FAIL] expected annotated output images but output directory is empty\n";
     remove_dir(out_dir);
     return 1;
   }
-  if (fs::is_empty(out_image)) {
-    std::cerr << "[FAIL] annotated output image is empty at " << out_image << "\n";
+  if (!all_output_files_nonempty(out_dir)) {
+    std::cerr << "[FAIL] some annotated output images are empty\n";
     remove_dir(out_dir);
     return 1;
   }
 
   remove_dir(out_dir);
-  std::cout << "[OK] face-detector pipeline completed successfully: " << out_image << "\n";
+  std::cout << "[OK] face-detector pipeline produced " << output_files << " output files\n";
   return 0;
 }

--- a/examples/face-detection/face-detector/python/main.py
+++ b/examples/face-detection/face-detector/python/main.py
@@ -1,6 +1,6 @@
 """RetinaFace face detection example using a compiled NEAT model.
 
-This script performs an end-to-end single-image RetinaFace pipeline:
+This script performs an end-to-end folder-based RetinaFace pipeline:
   - Preprocesses the input image for the model (mean subtraction + pad + resize)
   - Runs inference through a NEAT Graph
   - Decodes RetinaFace outputs into face boxes, confidence scores, and landmarks
@@ -42,6 +42,10 @@ CFG_MNET = {
     "variance": [0.1, 0.2],
     "clip": False,
 }
+
+
+def is_image(path: Path) -> bool:
+    return path.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
 
 
 class PreprocMeta(NamedTuple):
@@ -384,33 +388,7 @@ def draw_detections(image_bgr: np.ndarray, detections: list[dict[str, Any]]) -> 
     return out
 
 
-def prepare_graph_and_frame(
-    model_path: Path,
-    image_path: Path,
-) -> tuple[Any, pyneat.Tensor, np.ndarray, PreprocMeta]:
-    """Prepare a reusable Graph run object and preprocessed frame for repeated inference."""
-    _log(f"Preparing graph and frame. model_path={model_path}, image_path={image_path}")
-    if not image_path.is_file():
-        raise FileNotFoundError(f"Input image does not exist: {image_path}")
-
-    _log("Reading input image with OpenCV")
-    bgr = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
-    if bgr is None:
-        raise RuntimeError(f"Failed to read image: {image_path}")
-
-    orig_h, orig_w = bgr.shape[:2]
-
-    _log("Applying BGR mean subtraction")
-    img = bgr.astype(np.float32) - np.array([104.0, 117.0, 123.0], dtype=np.float32)
-
-    _log("Padding image to target aspect ratio before resize")
-    padded, meta = pad_image_bgr(img, orig_h, orig_w, INFER_WIDTH, INFER_HEIGHT)
-
-    _log("Resizing padded image to model input size (640x640)")
-    img = cv2.resize(padded, (INFER_WIDTH, INFER_HEIGHT), interpolation=cv2.INTER_LINEAR)
-
-    resized = np.ascontiguousarray(img, dtype=np.float32)
-
+def build_retinaface_runner(model_path: Path) -> Any:
     _log("Configuring pyneat.ModelOptions for tensor input (FP32)")
     opt = pyneat.ModelOptions()
     opt.preprocess.kind = pyneat.InputKind.Tensor
@@ -432,18 +410,41 @@ def prepare_graph_and_frame(
 
     _log("Building Graph run with dummy frame")
     dummy = tensor_from_hwc_f32(np.zeros((INFER_HEIGHT, INFER_WIDTH, 3), dtype=np.float32))
-    run = graph.build([dummy], pyneat.RunMode.Async)
+    return graph.build([dummy], pyneat.RunMode.Async)
 
-    return run, tensor_from_hwc_f32(resized), bgr, meta
+
+def prepare_retinaface_frame(image_path: Path) -> tuple[pyneat.Tensor, np.ndarray, PreprocMeta]:
+    _log(f"Preparing frame. image_path={image_path}")
+    if not image_path.is_file():
+        raise FileNotFoundError(f"Input image does not exist: {image_path}")
+
+    _log("Reading input image with OpenCV")
+    bgr = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+    if bgr is None:
+        raise RuntimeError(f"Failed to read image: {image_path}")
+
+    orig_h, orig_w = bgr.shape[:2]
+
+    _log("Applying BGR mean subtraction")
+    img = bgr.astype(np.float32) - np.array([104.0, 117.0, 123.0], dtype=np.float32)
+
+    _log("Padding image to target aspect ratio before resize")
+    padded, meta = pad_image_bgr(img, orig_h, orig_w, INFER_WIDTH, INFER_HEIGHT)
+
+    _log("Resizing padded image to model input size (640x640)")
+    img = cv2.resize(padded, (INFER_WIDTH, INFER_HEIGHT), interpolation=cv2.INTER_LINEAR)
+    resized = np.ascontiguousarray(img, dtype=np.float32)
+
+    return tensor_from_hwc_f32(resized), bgr, meta
 
 
 def run_retinaface_inference(
-    model_path: Path,
+    run: Any,
     image_path: Path,
     timeout_ms: int,
 ) -> tuple[list[pyneat.Tensor], np.ndarray, PreprocMeta]:
-    _log(f"Starting inference. model_path={model_path}, image_path={image_path}")
-    run, input_tensor, bgr, meta = prepare_graph_and_frame(model_path, image_path)
+    _log(f"Starting inference. image_path={image_path}")
+    input_tensor, bgr, meta = prepare_retinaface_frame(image_path)
 
     _log("Pushing preprocessed frame into Graph")
     if not run.push([input_tensor]):
@@ -456,17 +457,11 @@ def run_retinaface_inference(
 
     _log(f"Inference complete. Original image size: {meta.orig_w}x{meta.orig_h}")
 
-    try:
-        run.close()
-    except Exception as exc:
-        # Best-effort cleanup: log and continue, do not mask inference result.
-        logger.debug("Failed to close RetinaFace graph run cleanly", exc_info=exc)
-
     return collect_tensors(sample), bgr, meta
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="RetinaFace face detection example")
+    parser = argparse.ArgumentParser(description="RetinaFace face detection folder example")
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
     args = parser.parse_args()
 
@@ -483,8 +478,8 @@ def main() -> int:
     runtime_cfg = raw.get("runtime", {})
 
     model_path = Path(model_cfg.get("path", DEFAULT_MODEL_PATH))
-    image_path = Path(io_cfg.get("image", "assets/test_images/input.jpg"))
-    output_path = Path(io_cfg.get("output", "sandbox/face-detector/output.png"))
+    input_dir = Path(io_cfg.get("input_dir", "assets/test_images"))
+    output_dir = Path(io_cfg.get("output_dir", "sandbox/face-detector"))
     confidence_threshold = float(decode_cfg.get("confidence_threshold", 0.4))
     nms_threshold = float(decode_cfg.get("nms_iou", 0.9))
     top_k = int(decode_cfg.get("top_k", 5000))
@@ -503,13 +498,21 @@ def main() -> int:
     if not model_path.is_file():
         print(f"Model file does not exist: {model_path}", file=sys.stderr)
         return 2
+    if not input_dir.is_dir():
+        print(f"Input directory does not exist: {input_dir}", file=sys.stderr)
+        return 2
+
+    image_paths = sorted(path for path in input_dir.iterdir() if path.is_file() and is_image(path))
+    if not image_paths:
+        print(f"No images found in {input_dir}", file=sys.stderr)
+        return 3
 
     # Profiling mode: reuse a single graph run and frame, and profile graph vs postprocessing.
     if profile:
+        image_path = image_paths[0]
         try:
-            run, input_tensor, orig_bgr, meta = prepare_graph_and_frame(
-                model_path, image_path
-            )
+            run = build_retinaface_runner(model_path)
+            input_tensor, orig_bgr, meta = prepare_retinaface_frame(image_path)
         except Exception as e:
             print(f"Error during graph preparation: {e}", file=sys.stderr)
             return 3
@@ -603,47 +606,55 @@ def main() -> int:
         # Intentionally do NOT write an output image in profiling mode.
         return 0
 
+    output_dir.mkdir(parents=True, exist_ok=True)
+    processed = 0
     try:
-        _log("Invoking run_retinaface_inference()")
-        tensors, orig_bgr, meta = run_retinaface_inference(model_path, image_path, timeout_ms)
+        run = build_retinaface_runner(model_path)
     except Exception as e:
-        print(f"Error during inference: {e}", file=sys.stderr)
+        print(f"Error during graph preparation: {e}", file=sys.stderr)
         return 3
 
-    _log("Collecting tensors from output samples")
-    if not tensors:
-        print("No tensors found in model output", file=sys.stderr)
-        return 4
+    try:
+        for image_path in image_paths:
+            _log("Invoking run_retinaface_inference()")
+            try:
+                tensors, orig_bgr, meta = run_retinaface_inference(run, image_path, timeout_ms)
+            except Exception as e:
+                print(f"Error during inference for {image_path}: {e}", file=sys.stderr)
+                return 3
 
-    np_outs = tensor_numpy_outputs(tensors)
-    print(f"Model produced {len(np_outs)} tensor(s):")
-    for i, arr in enumerate(np_outs):
-        print(f"  [{i}] shape={arr.shape}, dtype={arr.dtype}")
+            _log("Collecting tensors from output samples")
+            if not tensors:
+                print(f"No tensors found in model output for {image_path}", file=sys.stderr)
+                return 4
 
-    _log("Running RetinaFace postprocessing")
-    bboxes, scores, landmarks = parse_retinaface_outputs(np_outs)
-    detections = postprocess_retinaface(
-        bboxes,
-        scores,
-        landmarks,
-        meta,
-        confidence_threshold=confidence_threshold,
-        nms_threshold=nms_threshold,
-        top_k=top_k,
-        keep_top_k=keep_top_k,
-        with_landmarks=landmarks is not None,
-    )
+            np_outs = tensor_numpy_outputs(tensors)
+            _log("Running RetinaFace postprocessing")
+            bboxes, scores, landmarks = parse_retinaface_outputs(np_outs)
+            detections = postprocess_retinaface(
+                bboxes,
+                scores,
+                landmarks,
+                meta,
+                confidence_threshold=confidence_threshold,
+                nms_threshold=nms_threshold,
+                top_k=top_k,
+                keep_top_k=keep_top_k,
+                with_landmarks=landmarks is not None,
+            )
 
-    print(f"Detections: {len(detections)}")
-    for i, det in enumerate(detections[:20]):
-        box = det["box"]
-        print(f"  [{i}] score={det['score']:.4f} box=[{box[0]:.1f},{box[1]:.1f},{box[2]:.1f},{box[3]:.1f}]")
+            out_img = draw_detections(orig_bgr, detections)
+            output_path = output_dir / f"{image_path.stem}_retinaface.png"
+            cv2.imwrite(str(output_path), out_img)
+            processed += 1
+            print(f"[{processed}/{len(image_paths)}] {image_path.name}: {len(detections)} detections -> {output_path.name}")
+    finally:
+        try:
+            run.close()
+        except Exception as exc:
+            logger.debug("Failed to close RetinaFace graph run cleanly", exc_info=exc)
 
-    if str(output_path):
-        out_img = draw_detections(orig_bgr, detections)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        cv2.imwrite(str(output_path), out_img)
-        print(f"Wrote annotated image: {output_path}")
+    print(f"Done: {processed} images processed")
     return 0
 
 

--- a/examples/face-detection/face-detector/python/tests/test_e2e.py
+++ b/examples/face-detection/face-detector/python/tests/test_e2e.py
@@ -1,6 +1,5 @@
 """E2E tests for face-detector (Python)."""
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,25 +8,6 @@ import pytest
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "python" / "main.py"
-
-
-def _find_image(input_dir: Path, pattern: str) -> Path | None:
-    if not input_dir.exists():
-        return None
-    images = sorted(f for f in input_dir.iterdir() if f.suffix.lower() in {".png", ".jpg", ".jpeg"})
-    for f in images:
-        if pattern in f.name.lower():
-            return f
-    if images:
-        return images[0]
-    return None
-
-
-def _resolve_input_dir(default_dir: Path) -> Path:
-    raw = os.environ.get("SIMANEAT_APPS_TEST_INPUT_DIR", "").strip()
-    if raw:
-        return Path(raw)
-    return default_dir
 
 
 @pytest.mark.e2e
@@ -41,17 +21,14 @@ class TestE2E:
         skip_unless_e2e_ready,
         e2e_config_writer,
     ):
-        input_dir = _resolve_input_dir(test_images_dir)
-        image = _find_image(input_dir, "face")
         skip_unless_e2e_ready(
-            image is not None,
-            f"no suitable test image found in input_dir={input_dir}",
+            test_images_dir.exists() and any(test_images_dir.iterdir()),
+            f"test_images_dir is missing or empty: {test_images_dir}",
         )
 
-        out_path = tmp_output_dir / "retinaface_output.png"
         config_path = e2e_config_writer(
             {
-                "io": {"image": str(image), "output": str(out_path)},
+                "io": {"input_dir": str(test_images_dir), "output_dir": str(tmp_output_dir)},
                 "runtime": {"num_runs": 1},
             }
         )
@@ -74,4 +51,6 @@ class TestE2E:
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
 
-        assert out_path.exists(), "Expected an annotated output image to be written"
+        output_files = [path for path in tmp_output_dir.iterdir() if path.is_file()]
+        assert output_files, "Expected annotated output images to be written"
+        assert all(path.stat().st_size > 0 for path in output_files), "Output image is empty"

--- a/examples/face-detection/face-detector/test-scope.yaml
+++ b/examples/face-detection/face-detector/test-scope.yaml
@@ -8,10 +8,10 @@ unit:
   cpp: true
 e2e:
   python:
-    enabled: false
-    reason: RetinaFace e2e is blocked by the current detess/dequant issue.
-    models: []
+    enabled: true
+    models:
+      - retinaface_mobilenet25
   cpp:
-    enabled: false
-    reason: RetinaFace e2e is blocked by the current detess/dequant issue.
-    models: []
+    enabled: true
+    models:
+      - retinaface_mobilenet25

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -5,16 +5,16 @@
 | --- | --- |
 | Category | object-detection |
 | Difficulty | Intermediate |
-| Tags | detr, object-detection, single-image, coco |
+| Tags | detr, object-detection, folder-input, coco |
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | detr-object-detector |
 | Model | detr_resnet50_modified_class_embed_bbox_embed [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz] |
 
 ## Concept
-This example demonstrates single-image object detection with a compiled **DETR** model. The input image is resized with aspect-ratio preservation into the model frame, normalized with ImageNet mean and standard deviation, run through the NEAT pipeline, and then decoded into object boxes and class scores.
+This example demonstrates folder-based object detection with a compiled **DETR** model. Each input image is resized with aspect-ratio preservation into the model frame, normalized with ImageNet mean and standard deviation, run through the NEAT pipeline, and then decoded into object boxes and class scores.
 
-The model emits two raw tensors: classification logits and normalized bounding boxes for a fixed set of object queries. The example applies `softmax` over the class logits, `sigmoid` over the box outputs, filters by confidence, optionally keeps only the COCO `person` class, maps detections back onto the original image, and writes an annotated output image.
+The model emits two raw tensors: classification logits and normalized bounding boxes for a fixed set of object queries. The example applies `softmax` over the class logits, `sigmoid` over the box outputs, filters by confidence, optionally keeps only the COCO `person` class, maps detections back onto the original image, and writes annotated output images.
 
 ## Preview
 Snippet from a pipeline run:
@@ -37,7 +37,7 @@ Download into `assets/models/`:
   `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz`
 
 ## Important Behavior
-- The example expects one input image.
+- The example expects an input folder with image files.
 - Input preprocessing preserves aspect ratio and center-pads into an `1333x800` model frame.
 - Output boxes are mapped back to the original image resolution before drawing.
 - By default all DETR foreground classes are considered; `--person-only` keeps only the DETR `person` class.
@@ -147,9 +147,9 @@ pytest -c tests/pytest.ini --rootdir="$PWD" -m e2e \
 ## Debugging Notes
 - If the model fails to load, verify `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` exists and is readable.
 - First-run model initialization can exceed 60 seconds on some setups. Increase `SIMANEAT_APPS_TEST_TIMEOUT_MS` (for example `180000`) for e2e runs.
-- If no detections appear, lower `decode.confidence_threshold` and confirm the input image contains supported COCO objects.
+- If no detections appear, lower `decode.confidence_threshold` and confirm the input images contain supported COCO objects.
 - If detections are visibly offset, verify the model frame assumptions (`1333x800`) still match the compiled package.
-- If output writing fails, ensure the parent directory of `<output_image_path>` exists and is writable.
+- If output writing fails, ensure `io.output_dir` exists or can be created.
 
 ## Source Files
 - C++ source: `cpp/main.cpp`

--- a/examples/object-detection/detr-object-detector/common/config.yaml
+++ b/examples/object-detection/detr-object-detector/common/config.yaml
@@ -2,11 +2,11 @@ model:
   path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
 
 io:
-  image: assets/test_images/image.png
-  output: sandbox/detr-object-detector/output.png
+  input_dir: assets/test_images
+  output_dir: sandbox/detr-object-detector
 
 decode:
-  confidence_threshold: 0.01
+  confidence_threshold: 0.70
   max_draw: 50
   person_only: false
 

--- a/examples/object-detection/detr-object-detector/cpp/main.cpp
+++ b/examples/object-detection/detr-object-detector/cpp/main.cpp
@@ -1,6 +1,6 @@
 /**
  * @example detr-object-detector.cpp
- * Minimal DETR single-image detection pipeline using tensor input and raw tensor decode.
+ * Minimal DETR folder detection pipeline using tensor input and raw tensor decode.
  *
  * Usage: detr-object-detector [--config <path>]
  */
@@ -15,6 +15,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
@@ -91,9 +92,9 @@ struct Detection {
 };
 
 struct Config {
-  fs::path image;
+  fs::path input_dir;
   std::string model = "assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz";
-  fs::path output;
+  fs::path output_dir;
   float conf = 0.5f;
   int max_draw = 50;
   bool person_only = false;
@@ -131,13 +132,31 @@ Stats compute_stats(const std::vector<double>& values) {
   return s;
 }
 
+bool is_image_file(const fs::path& path) {
+  std::string ext = path.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp";
+}
+
+std::vector<fs::path> image_paths_in_dir(const fs::path& input_dir) {
+  std::vector<fs::path> images;
+  for (const auto& entry : fs::directory_iterator(input_dir)) {
+    if (entry.is_regular_file() && is_image_file(entry.path())) {
+      images.push_back(entry.path());
+    }
+  }
+  std::sort(images.begin(), images.end());
+  return images;
+}
+
 Config load_config(const fs::path& path) {
   const auto raw = sima_examples::ScalarConfig::load(path);
   Config cfg;
   cfg.model = raw.string_or(
       "model.path", "assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz");
-  cfg.image = raw.string_or("io.image", "assets/test_images/input.jpg");
-  cfg.output = raw.string_or("io.output", "sandbox/detr-object-detector/output.png");
+  cfg.input_dir = raw.string_or("io.input_dir", "assets/test_images");
+  cfg.output_dir = raw.string_or("io.output_dir", "sandbox/detr-object-detector");
   cfg.conf = static_cast<float>(raw.double_or("decode.confidence_threshold", 0.5));
   cfg.max_draw = raw.int_or("decode.max_draw", 50);
   cfg.person_only = raw.bool_or("decode.person_only", false);
@@ -466,19 +485,17 @@ int main(int argc, char** argv) {
 
   try {
     const Config args = parse_config(argc, argv);
-    if (!fs::exists(args.image)) {
-      throw std::runtime_error("image does not exist: " + args.image.string());
+    if (!fs::is_directory(args.input_dir)) {
+      throw std::runtime_error("input_dir does not exist: " + args.input_dir.string());
     }
     if (!fs::exists(args.model)) {
       throw std::runtime_error("model does not exist: " + args.model);
     }
 
-    cv::Mat bgr_u8 = cv::imread(args.image.string(), cv::IMREAD_COLOR);
-    if (bgr_u8.empty()) {
-      throw std::runtime_error("failed to read image: " + args.image.string());
+    const std::vector<fs::path> image_paths = image_paths_in_dir(args.input_dir);
+    if (image_paths.empty()) {
+      throw std::runtime_error("no images found in: " + args.input_dir.string());
     }
-
-    auto [input_f32, meta] = preprocess_to_tensor_input(bgr_u8);
 
     simaai::neat::Model::Options model_opt;
     model_opt.preprocess.kind = simaai::neat::InputKind::Tensor;
@@ -498,9 +515,16 @@ int main(int argc, char** argv) {
     cv::Mat dummy(kModelH, kModelW, CV_32FC3, cv::Scalar(0.0f, 0.0f, 0.0f));
     auto run = graph.build(simaai::neat::TensorList{tensor_from_hwc_f32(dummy)},
                            simaai::neat::RunMode::Async);
-    simaai::neat::Tensor input_t = tensor_from_hwc_f32(input_f32);
 
     if (args.profile) {
+      const fs::path& image_path = image_paths.front();
+      cv::Mat bgr_u8 = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+      if (bgr_u8.empty()) {
+        throw std::runtime_error("failed to read image: " + image_path.string());
+      }
+      auto [input_f32, meta] = preprocess_to_tensor_input(bgr_u8);
+      simaai::neat::Tensor input_t = tensor_from_hwc_f32(input_f32);
+
       const int runs = std::max(1, args.num_runs);
       std::vector<double> graph_times;
       std::vector<double> post_times;
@@ -535,7 +559,7 @@ int main(int argc, char** argv) {
       const double total_sum = graph_stats.sum + post.sum;
 
       std::cout << "Profiling over " << graph_times.size() << " runs (image='"
-                << args.image.string() << "'):\n";
+                << image_path.string() << "'):\n";
       std::cout << "  Graph run (push+pull): mean=" << graph_stats.mean
                 << "s, min=" << graph_stats.min << "s, max=" << graph_stats.max
                 << "s, FPS=" << (runs_d / graph_stats.sum) << "\n";
@@ -556,61 +580,42 @@ int main(int argc, char** argv) {
       return 0;
     }
 
-    const auto t0_total = std::chrono::steady_clock::now();
-    const auto t0_infer = std::chrono::steady_clock::now();
-    if (!run.push(simaai::neat::TensorList{input_t})) {
-      throw std::runtime_error("run.push failed");
-    }
-
-    auto out_sample = run.pull(args.timeout_ms);
-    const auto t1_infer = std::chrono::steady_clock::now();
-    if (!out_sample.has_value()) {
-      throw std::runtime_error("run.pull returned no sample");
-    }
-
-    const std::vector<simaai::neat::Tensor> tensors = collect_tensors(*out_sample);
-    std::cout << "Model produced " << tensors.size() << " tensor(s)\n";
-    for (size_t i = 0; i < tensors.size(); ++i) {
-      std::cout << "  [" << i << "] shape=[";
-      for (size_t d = 0; d < tensors[i].shape.size(); ++d) {
-        std::cout << tensors[i].shape[d] << (d + 1 < tensors[i].shape.size() ? "," : "");
+    fs::create_directories(args.output_dir);
+    int processed = 0;
+    for (const fs::path& image_path : image_paths) {
+      cv::Mat bgr_u8 = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+      if (bgr_u8.empty()) {
+        throw std::runtime_error("failed to read image: " + image_path.string());
       }
-      std::cout << "] dtype=" << static_cast<int>(tensors[i].dtype) << "\n";
-    }
+      auto [input_f32, meta] = preprocess_to_tensor_input(bgr_u8);
+      simaai::neat::Tensor input_t = tensor_from_hwc_f32(input_f32);
 
-    const auto [logits, boxes] = extract_logits_and_boxes(tensors);
-    const std::vector<Detection> dets =
-        decode_detr_outputs(logits, boxes, meta, args.conf, args.person_only);
-
-    std::cout << "Detections: " << dets.size() << "\n";
-    for (size_t i = 0; i < std::min<size_t>(dets.size(), 20); ++i) {
-      const auto& d = dets[i];
-      std::cout << "  [" << i << "] class=" << class_name(d.class_id) << "(" << d.class_id
-                << ") score=" << d.score << " box=[" << d.x1 << "," << d.y1 << "," << d.x2 << ","
-                << d.y2 << "]\n";
-    }
-
-    if (!args.output.empty()) {
-      fs::path parent = args.output.parent_path();
-      if (!parent.empty()) {
-        fs::create_directories(parent);
+      if (!run.push(simaai::neat::TensorList{input_t})) {
+        throw std::runtime_error("run.push failed");
       }
+
+      auto out_sample = run.pull(args.timeout_ms);
+      if (!out_sample.has_value()) {
+        throw std::runtime_error("run.pull returned no sample");
+      }
+
+      const std::vector<simaai::neat::Tensor> tensors = collect_tensors(*out_sample);
+      const auto [logits, boxes] = extract_logits_and_boxes(tensors);
+      const std::vector<Detection> dets =
+          decode_detr_outputs(logits, boxes, meta, args.conf, args.person_only);
+
       cv::Mat overlay = bgr_u8.clone();
       draw_detections(overlay, dets, args.max_draw);
-      if (!cv::imwrite(args.output.string(), overlay)) {
-        throw std::runtime_error("failed to write: " + args.output.string());
+      const fs::path output_path = args.output_dir / (image_path.stem().string() + "_detr.png");
+      if (!cv::imwrite(output_path.string(), overlay)) {
+        throw std::runtime_error("failed to write: " + output_path.string());
       }
-      std::cout << "Wrote annotated image: " << args.output << "\n";
+      ++processed;
+      std::cout << "[" << processed << "/" << image_paths.size() << "] "
+                << image_path.filename().string() << ": " << dets.size() << " detections -> "
+                << output_path.filename().string() << "\n";
     }
-
-    const auto t1_total = std::chrono::steady_clock::now();
-    if (args.profile) {
-      const std::chrono::duration<double, std::milli> total_ms = t1_total - t0_total;
-      const std::chrono::duration<double, std::milli> infer_ms = t1_infer - t0_infer;
-      std::cout << "Timing:\n";
-      std::cout << "  End-to-end: " << total_ms.count() << " ms\n";
-      std::cout << "  Model inference: " << infer_ms.count() << " ms\n";
-    }
+    std::cout << "Done: " << processed << " images processed\n";
 
     run.close();
     return 0;

--- a/examples/object-detection/detr-object-detector/cpp/tests/test_e2e.cpp
+++ b/examples/object-detection/detr-object-detector/cpp/tests/test_e2e.cpp
@@ -1,15 +1,13 @@
 // E2E test for detr-object-detector.
-// Runs the binary with a real DETR model and a local image, and verifies it exits successfully
-// and produces an annotated output image.
+// Runs the binary with a real DETR model and a local image folder, and verifies it exits
+// successfully and produces annotated output images.
 #include "support/testing/test_process.h"
 #include "support/testing/test_config.h"
 
-#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
 
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
@@ -33,17 +31,7 @@ int main(int argc, char** argv) {
   const char* input_dir_raw = env_or_null("SIMANEAT_APPS_TEST_INPUT_DIR");
   const std::string input_dir = input_dir_raw ? input_dir_raw : "assets/test_images";
 
-  std::vector<fs::path> image_candidates;
-  if (fs::exists(input_dir)) {
-    for (const auto& entry : fs::directory_iterator(input_dir)) {
-      const auto ext = entry.path().extension().string();
-      if (ext == ".png" || ext == ".jpg" || ext == ".jpeg") {
-        image_candidates.push_back(entry.path());
-      }
-    }
-  }
-  std::sort(image_candidates.begin(), image_candidates.end());
-  if (image_candidates.empty()) {
+  if (!fs::exists(input_dir) || fs::is_empty(input_dir)) {
     env_or_skip("SIMANEAT_APPS_TEST_INPUT_DIR",
                 "directory containing test images (defaults to assets/test_images)");
     return kSkipCode;
@@ -54,7 +42,6 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  fs::path out_image = fs::path(out_dir) / "detr_output.png";
   const double confidence_threshold =
       e2e_double("detr-object-detector", "decode", "confidence_threshold");
   const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
@@ -63,8 +50,8 @@ int main(int argc, char** argv) {
     config_file << "model:\n"
                 << "  path: " << model_path << "\n"
                 << "io:\n"
-                << "  image: " << image_candidates.front().string() << "\n"
-                << "  output: " << out_image.string() << "\n"
+                << "  input_dir: " << input_dir << "\n"
+                << "  output_dir: " << out_dir << "\n"
                 << "decode:\n"
                 << "  confidence_threshold: " << confidence_threshold << "\n"
                 << "  max_draw: 50\n"
@@ -85,18 +72,19 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  if (!fs::exists(out_image)) {
-    std::cerr << "[FAIL] expected annotated output image not found at " << out_image << "\n";
+  const int output_files = count_output_files(out_dir);
+  if (output_files == 0) {
+    std::cerr << "[FAIL] expected annotated output images but output directory is empty\n";
     remove_dir(out_dir);
     return 1;
   }
-  if (fs::is_empty(out_image)) {
-    std::cerr << "[FAIL] annotated output image is empty at " << out_image << "\n";
+  if (!all_output_files_nonempty(out_dir)) {
+    std::cerr << "[FAIL] some annotated output images are empty\n";
     remove_dir(out_dir);
     return 1;
   }
 
   remove_dir(out_dir);
-  std::cout << "[OK] detr-object-detector pipeline completed successfully: " << out_image << "\n";
+  std::cout << "[OK] detr-object-detector pipeline produced " << output_files << " output files\n";
   return 0;
 }

--- a/examples/object-detection/detr-object-detector/python/main.py
+++ b/examples/object-detection/detr-object-detector/python/main.py
@@ -1,4 +1,4 @@
-"""DETR single-image object detection example using manual tensor preprocessing."""
+"""DETR folder object detection example using manual tensor preprocessing."""
 
 from __future__ import annotations
 
@@ -124,6 +124,10 @@ BOX_COLORS = [
     (128, 255, 0),
     (255, 128, 0),
 ]
+
+
+def is_image(path: Path) -> bool:
+    return path.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
 
 
 def _log(msg: str) -> None:
@@ -383,18 +387,14 @@ def build_graph_runner(model: pyneat.Model) -> pyneat.Run:
     return graph.build([dummy], pyneat.RunMode.Async)
 
 
-def run_model_inference(model: pyneat.Model, preprocessed: np.ndarray) -> list[np.ndarray]:
-    runner = build_graph_runner(model)
+def run_model_inference(runner: pyneat.Run, preprocessed: np.ndarray, timeout_ms: int) -> list[np.ndarray]:
     tensor = tensor_from_hwc_f32(preprocessed)
-    try:
-        if not runner.push([tensor]):
-            raise RuntimeError("Run.push() failed")
-        sample = runner.pull(timeout_ms=20000)
-        if sample is None:
-            raise RuntimeError("Run.pull() returned no sample")
-        return tensor_numpy_outputs(collect_tensors(sample))
-    finally:
-        runner.close()
+    if not runner.push([tensor]):
+        raise RuntimeError("Run.push() failed")
+    sample = runner.pull(timeout_ms=timeout_ms)
+    if sample is None:
+        raise RuntimeError("Run.pull() returned no sample")
+    return tensor_numpy_outputs(collect_tensors(sample))
 
 
 def build_model_runner(model: pyneat.Model, preprocessed: np.ndarray) -> tuple[pyneat.Run, pyneat.Tensor]:
@@ -417,7 +417,7 @@ def format_profile_stats(name: str, values: list[float]) -> str:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="DETR single-image object detection example")
+    parser = argparse.ArgumentParser(description="DETR folder object detection example")
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
     args = parser.parse_args()
 
@@ -433,9 +433,9 @@ def main() -> int:
     decode_cfg = raw.get("decode", {})
     runtime_cfg = raw.get("runtime", {})
 
-    image_path = Path(io_cfg.get("image", "assets/test_images/input.jpg"))
+    input_dir = Path(io_cfg.get("input_dir", "assets/test_images"))
     model_path = Path(model_cfg.get("path", DEFAULT_MODEL_PATH))
-    output_path = Path(io_cfg.get("output", "sandbox/detr-object-detector/output.png"))
+    output_dir = Path(io_cfg.get("output_dir", "sandbox/detr-object-detector"))
     confidence_threshold = float(decode_cfg.get("confidence_threshold", 0.5))
     max_draw = int(decode_cfg.get("max_draw", 50))
     person_only = bool(decode_cfg.get("person_only", False))
@@ -449,20 +449,26 @@ def main() -> int:
     if not model_path.is_file():
         print(f"Model file does not exist: {model_path}", file=sys.stderr)
         return 2
+    if not input_dir.is_dir():
+        print(f"Input directory does not exist: {input_dir}", file=sys.stderr)
+        return 2
+
+    image_paths = sorted(path for path in input_dir.iterdir() if path.is_file() and is_image(path))
+    if not image_paths:
+        print(f"No images found in {input_dir}", file=sys.stderr)
+        return 3
 
     try:
-        orig_bgr, preprocessed, meta = prepare_input(image_path)
         model = load_tensor_model(model_path)
-    except FileNotFoundError as exc:
-        print(str(exc), file=sys.stderr)
-        return 2
     except Exception as exc:
-        logger.debug("Inference failure", exc_info=exc)
-        print(f"Error during inference: {exc}", file=sys.stderr)
+        logger.debug("Model loading failure", exc_info=exc)
+        print(f"Error loading model: {exc}", file=sys.stderr)
         return 3
 
     if profile:
+        image_path = image_paths[0]
         try:
+            orig_bgr, preprocessed, meta = prepare_input(image_path)
             runner, tensor = build_model_runner(model, preprocessed)
             graph_times: list[float] = []
             post_times: list[float] = []
@@ -519,49 +525,55 @@ def main() -> int:
             print(f"Error during profiling: {exc}", file=sys.stderr)
             return 4
 
+    output_dir.mkdir(parents=True, exist_ok=True)
+    processed = 0
     try:
-        arrays = run_model_inference(model, preprocessed)
+        runner = build_graph_runner(model)
     except Exception as exc:
-        logger.debug("Inference failure", exc_info=exc)
-        print(f"Error during inference: {exc}", file=sys.stderr)
+        logger.debug("Graph build failure", exc_info=exc)
+        print(f"Error building graph runner: {exc}", file=sys.stderr)
         return 3
 
-    if not arrays:
-        print("No tensors found in model output", file=sys.stderr)
-        return 4
-
-    print(f"Model produced {len(arrays)} tensor(s):")
-    for i, arr in enumerate(arrays):
-        print(f"  [{i}] shape={arr.shape}, dtype={arr.dtype}")
-
     try:
-        logits, boxes = extract_logits_and_boxes(arrays)
-        detections = process_detr_output(
-            boxes,
-            logits,
-            meta,
-            confidence_threshold=confidence_threshold,
-            detect_only_person=person_only,
-        )
-    except Exception as exc:
-        logger.debug("Decode failure", exc_info=exc)
-        print(f"Error during decode: {exc}", file=sys.stderr)
-        return 4
+        for image_path in image_paths:
+            try:
+                orig_bgr, preprocessed, meta = prepare_input(image_path)
+                arrays = run_model_inference(runner, preprocessed, timeout_ms)
+            except FileNotFoundError as exc:
+                print(str(exc), file=sys.stderr)
+                return 2
+            except Exception as exc:
+                logger.debug("Inference failure", exc_info=exc)
+                print(f"Error during inference for {image_path}: {exc}", file=sys.stderr)
+                return 3
 
-    print(f"Detections: {len(detections)}")
-    for i, det in enumerate(detections[:20]):
-        box = det["box"]
-        print(
-            f"  [{i}] class={class_name(det['class_id'])}({det['class_id']}) score={det['score']:.4f} "
-            f"box=[{box[0]:.1f},{box[1]:.1f},{box[2]:.1f},{box[3]:.1f}]"
-        )
+            if not arrays:
+                print(f"No tensors found in model output for {image_path}", file=sys.stderr)
+                return 4
 
-    if str(output_path):
-        out_img = visualize_detections(orig_bgr, detections, max_draw=max_draw)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        cv2.imwrite(str(output_path), out_img)
-        print(f"Wrote annotated image: {output_path}")
+            try:
+                logits, boxes = extract_logits_and_boxes(arrays)
+                detections = process_detr_output(
+                    boxes,
+                    logits,
+                    meta,
+                    confidence_threshold=confidence_threshold,
+                    detect_only_person=person_only,
+                )
+            except Exception as exc:
+                logger.debug("Decode failure", exc_info=exc)
+                print(f"Error during decode for {image_path}: {exc}", file=sys.stderr)
+                return 4
 
+            output_path = output_dir / f"{image_path.stem}_detr.png"
+            out_img = visualize_detections(orig_bgr, detections, max_draw=max_draw)
+            cv2.imwrite(str(output_path), out_img)
+            processed += 1
+            print(f"[{processed}/{len(image_paths)}] {image_path.name}: {len(detections)} detections -> {output_path.name}")
+    finally:
+        runner.close()
+
+    print(f"Done: {processed} images processed")
     return 0
 
 

--- a/examples/object-detection/detr-object-detector/python/tests/test_e2e.py
+++ b/examples/object-detection/detr-object-detector/python/tests/test_e2e.py
@@ -1,6 +1,5 @@
 """E2E tests for detr-object-detector (Python)."""
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,22 +8,6 @@ import pytest
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "python" / "main.py"
-
-
-def _find_image(input_dir: Path) -> Path | None:
-    if not input_dir.exists():
-        return None
-    images = sorted(f for f in input_dir.iterdir() if f.suffix.lower() in {".png", ".jpg", ".jpeg"})
-    if images:
-        return images[0]
-    return None
-
-
-def _resolve_input_dir(default_dir: Path) -> Path:
-    raw = os.environ.get("SIMANEAT_APPS_TEST_INPUT_DIR", "").strip()
-    if raw:
-        return Path(raw)
-    return default_dir
 
 
 @pytest.mark.e2e
@@ -38,17 +21,14 @@ class TestE2E:
         skip_unless_e2e_ready,
         e2e_config_writer,
     ):
-        input_dir = _resolve_input_dir(test_images_dir)
-        image = _find_image(input_dir)
         skip_unless_e2e_ready(
-            image is not None,
-            f"no suitable test image found in input_dir={input_dir}",
+            test_images_dir.exists() and any(test_images_dir.iterdir()),
+            f"test_images_dir is missing or empty: {test_images_dir}",
         )
 
-        out_path = tmp_output_dir / "detr_output.png"
         config_path = e2e_config_writer(
             {
-                "io": {"image": str(image), "output": str(out_path)},
+                "io": {"input_dir": str(test_images_dir), "output_dir": str(tmp_output_dir)},
                 "runtime": {"num_runs": 1},
             }
         )
@@ -69,4 +49,6 @@ class TestE2E:
             f"main.py exited with code {result.returncode}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
-        assert out_path.exists(), "Expected an annotated output image to be written"
+        output_files = [path for path in tmp_output_dir.iterdir() if path.is_file()]
+        assert output_files, "Expected annotated output images to be written"
+        assert all(path.stat().st_size > 0 for path in output_files), "Output image is empty"

--- a/tests/utils/pytest_fixtures.py
+++ b/tests/utils/pytest_fixtures.py
@@ -261,7 +261,8 @@ def run_until_output_files(request):
 @pytest.fixture
 def test_images_dir() -> Path:
     """Return the path to bundled test images."""
-    return APPS_ROOT / "assets" / "test_images"
+    raw = os.environ.get("SIMANEAT_APPS_TEST_INPUT_DIR", "").strip()
+    return Path(raw) if raw else APPS_ROOT / "assets" / "test_images"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Enable RetinaFace Python and C++ E2E coverage.
- Adapt RetinaFace and DETR examples to process an image folder instead of a single image.
- Save annotated outputs under each example's `sandbox/*` output directory.
- Update E2E tests to use `SIMANEAT_APPS_TEST_INPUT_DIR` through the shared fixture.

## Details

Both examples now use this IO shape:

```yaml
io:
  input_dir: assets/test_images
  output_dir: sandbox/<example-name>
```

The Python paths build one NEAT graph runner per folder run and reuse it for each image. The C++ paths also build the graph once and loop over the sorted image files.

## Manual Output Check

Use temporary configs so the checked-in generic configs do not need local edits:

```bash
cd /workspace/sima-neat/apps
source ~/pyneat/bin/activate

mkdir -p sandbox/run-configs
rm -rf sandbox/detr-object-detector sandbox/face-detector

cat > sandbox/run-configs/detr.yaml <<'YAML'
model:
  path: assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
io:
  input_dir: assets/coco-images
  output_dir: sandbox/detr-object-detector
decode:
  confidence_threshold: 0.70
  max_draw: 50
  person_only: false
runtime:
  timeout_ms: 20000
  profile: false
YAML

cat > sandbox/run-configs/face.yaml <<'YAML'
model:
  path: assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz
io:
  input_dir: assets/coco-images
  output_dir: sandbox/face-detector
decode:
  confidence_threshold: 0.40
  nms_iou: 0.90
  top_k: 5000
  keep_top_k: 750
  max_draw: 50
  landmarks: true
runtime:
  timeout_ms: 20000
  profile: false
YAML

python examples/object-detection/detr-object-detector/python/main.py --config sandbox/run-configs/detr.yaml
python examples/face-detection/face-detector/python/main.py --config sandbox/run-configs/face.yaml

find sandbox/detr-object-detector -type f -name '*_detr.png' -size +0 | wc -l
find sandbox/face-detector -type f -name '*_retinaface.png' -size +0 | wc -l
```

## Validation

Ran locally from `apps`:

```bash
python3 -m py_compile \
  examples/face-detection/face-detector/python/main.py \
  examples/face-detection/face-detector/python/tests/test_e2e.py \
  examples/object-detection/detr-object-detector/python/main.py \
  examples/object-detection/detr-object-detector/python/tests/test_e2e.py \
  tests/utils/pytest_fixtures.py

python3 tests/utils/test_scope.py --scope-file examples validate --quiet
python3 scripts/validate_readmes.py --root .
git diff --check
```

Targeted SDK build passed for:

```bash
cmake --build build --target \
  app__workspace_sima_neat_apps_examples_face_detection_face_detector_cpp_face_detector \
  face-detector_e2e_test \
  app__workspace_sima_neat_apps_examples_object_detection_detr_object_detector_cpp_detr_object_detector \
  detr-object-detector_e2e_test
```

Board E2E was attempted, but unrelated examples hit runtime preflight timeouts across multiple models. The failure pattern points to board/runtime state, not this folder-input change.

## Links

- Tracks #196
