### PR TITLE
Add YOLO26 pose estimator repro

### DIFF
--- a/assets/portal/pose-estimation/yolo26-pose-estimator/image.svg
+++ b/assets/portal/pose-estimation/yolo26-pose-estimator/image.svg
@@ -1,0 +1,50 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#101820"/>
+  <rect x="120" y="92" width="1040" height="536" rx="28" fill="#17212B" stroke="#2F3E4C" stroke-width="4"/>
+  <path d="M160 540C300 470 423 494 570 440C727 382 844 271 1120 298" stroke="#263846" stroke-width="18" stroke-linecap="round"/>
+  <path d="M184 550C316 495 435 514 586 462C744 408 844 313 1094 320" stroke="#3B5364" stroke-width="8" stroke-linecap="round"/>
+  <rect x="312" y="176" width="226" height="376" rx="10" stroke="#42F56F" stroke-width="7"/>
+  <rect x="708" y="151" width="214" height="394" rx="10" stroke="#42F56F" stroke-width="7"/>
+  <g stroke="#F04C9B" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M424 238L386 310L372 406"/>
+    <path d="M424 238L469 314L485 404"/>
+    <path d="M386 310L465 312"/>
+    <path d="M386 310L356 430L332 520"/>
+    <path d="M465 312L482 430L516 520"/>
+    <path d="M424 238L421 188"/>
+    <path d="M421 188L393 204"/>
+    <path d="M421 188L451 203"/>
+  </g>
+  <g stroke="#18B8FF" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M814 221L760 314L735 407"/>
+    <path d="M814 221L872 313L894 405"/>
+    <path d="M760 314L871 314"/>
+    <path d="M760 314L738 443L704 526"/>
+    <path d="M871 314L888 445L932 526"/>
+    <path d="M814 221L812 171"/>
+    <path d="M812 171L782 188"/>
+    <path d="M812 171L842 188"/>
+  </g>
+  <g fill="#FFDE59">
+    <circle cx="421" cy="188" r="15"/>
+    <circle cx="386" cy="310" r="12"/>
+    <circle cx="465" cy="312" r="12"/>
+    <circle cx="356" cy="430" r="12"/>
+    <circle cx="482" cy="430" r="12"/>
+    <circle cx="332" cy="520" r="12"/>
+    <circle cx="516" cy="520" r="12"/>
+    <circle cx="812" cy="171" r="15"/>
+    <circle cx="760" cy="314" r="12"/>
+    <circle cx="871" cy="314" r="12"/>
+    <circle cx="738" cy="443" r="12"/>
+    <circle cx="888" cy="445" r="12"/>
+    <circle cx="704" cy="526" r="12"/>
+    <circle cx="932" cy="526" r="12"/>
+  </g>
+  <rect x="312" y="130" width="194" height="44" rx="6" fill="#42F56F"/>
+  <rect x="708" y="105" width="194" height="44" rx="6" fill="#42F56F"/>
+  <text x="330" y="160" fill="#101820" font-family="Arial, Helvetica, sans-serif" font-size="26" font-weight="700">person 0.96</text>
+  <text x="726" y="135" fill="#101820" font-family="Arial, Helvetica, sans-serif" font-size="26" font-weight="700">person 0.98</text>
+  <text x="112" y="667" fill="#D7E2EA" font-family="Arial, Helvetica, sans-serif" font-size="36" font-weight="700">YOLO26 Pose Estimator</text>
+  <text x="112" y="704" fill="#8DA3B5" font-family="Arial, Helvetica, sans-serif" font-size="24">model-managed preprocessing and pose decode</text>
+</svg>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,6 +50,7 @@ endfunction()
 
 add_subdirectory(classification)
 add_subdirectory(object-detection)
+add_subdirectory(pose-estimation)
 add_subdirectory(tracking)
 add_subdirectory(segmentation)
 add_subdirectory(depth-estimation)

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -3,7 +3,7 @@
 ## Metadata
 | Field | Value |
 | --- | --- |
-| Category | <classification / object-detection / face-detection / segmentation / depth-estimation / genai / throughput> |
+| Category | <classification / object-detection / pose-estimation / face-detection / segmentation / depth-estimation / genai / throughput> |
 | Difficulty | <Beginner / Intermediate / Advanced> |
 | Tags | <comma-separated tags> |
 | Languages | C++, Python |

--- a/examples/pose-estimation/CMakeLists.txt
+++ b/examples/pose-estimation/CMakeLists.txt
@@ -1,0 +1,7 @@
+foreach(example IN ITEMS
+    yolo26-pose-estimator
+)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${example}/src/cpp/CMakeLists.txt")
+    add_subdirectory(${example}/src/cpp ${example})
+  endif()
+endforeach()

--- a/examples/pose-estimation/yolo26-pose-estimator/README.md
+++ b/examples/pose-estimation/yolo26-pose-estimator/README.md
@@ -1,0 +1,148 @@
+# YOLO26 Pose Estimator
+
+## Metadata
+| Field | Value |
+| --- | --- |
+| Category | pose-estimation |
+| Difficulty | Intermediate |
+| Tags | pose-estimation, yolo26, image-folder |
+| Languages | C++, Python |
+| Status | experimental |
+| Binary Name | yolo26-pose-estimator |
+| Model | yolo26m-pose-bf16-b1 [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-pose/yolo26m-pose-bf16-b1.tar.gz] |
+
+## Concept
+`yolo26-pose-estimator` runs a YOLO26 pose model on every image in a folder and
+writes annotated output images with person boxes, skeleton lines, and keypoints.
+The example uses Neat model-managed preprocessing with `COCO_YOLO`
+normalization and `YoloV26Pose` decode.
+
+## Preview
+Snippet from a pipeline run:
+
+![YOLO26 pose estimator preview](../../../assets/portal/pose-estimation/yolo26-pose-estimator/image.svg)
+
+## Supported Models
+Supported YOLO26 pose models:
+
+- `yolo26n-pose-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-pose-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-pose-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-pose-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-pose-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-pose-bf16-b1.tar.gz`
+- `yolo26m-pose-int8-b1.tar.gz`
+- `yolo26m-pose-int8-b4.tar.gz`
+
+Download the supported variants:
+
+```bash
+SDK_VERSION=${NEAT_APPS_MODEL_SDK_VERSION:-2.0.0}
+mkdir -p assets/models/YOLO26-POSE
+cd assets/models/YOLO26-POSE
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26n-pose-bf16-mla_tess-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26s-pose-bf16-mla_tess-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26m-pose-bf16-mla_tess-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26l-pose-bf16-mla_tess-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26x-pose-bf16-mla_tess-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26m-pose-bf16-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26m-pose-int8-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-pose/yolo26m-pose-int8-b4.tar.gz"
+
+cd ../../..
+```
+
+## Prerequisites
+- Installed Neat framework on the DevKit.
+- A YOLO26 pose model package downloaded locally.
+- `model.path` set in `src/common/config.yaml`.
+- Input images available under `io.input_dir`.
+
+## Important Behavior
+- C++ and Python read runtime values from `src/common/config.yaml`.
+- `model.path` must point to a valid YOLO26 pose model package.
+- `io.input_dir` may contain `.jpg`, `.jpeg`, `.png`, or `.bmp` images.
+- `io.output_dir` receives annotated `.png` output files.
+- Use `output.overlay: false` to skip drawing and writing output images.
+- The model path uses model-managed preprocessing with `COCO_YOLO` normalization and `YoloV26Pose` decode.
+
+## Command-Line Options
+- `--config <path>`
+  Optional. YAML config path. Defaults to `src/common/config.yaml`.
+
+## Build
+### Build From The Apps Repo
+```bash
+cd <apps-repo-root>
+./build.sh
+```
+
+Binary output:
+```bash
+./build/examples/pose-estimation/yolo26-pose-estimator/yolo26-pose-estimator
+```
+
+### Build This Example Directly With CMake
+```bash
+cd <apps-repo-root>/examples/pose-estimation/yolo26-pose-estimator
+cmake -S src/cpp -B build
+cmake --build build -j
+```
+
+Binary output:
+```bash
+./build/yolo26-pose-estimator
+```
+
+## Run
+### C++
+```bash
+./build/examples/pose-estimation/yolo26-pose-estimator/yolo26-pose-estimator \
+  --config examples/pose-estimation/yolo26-pose-estimator/src/common/config.yaml
+```
+
+### Python
+```bash
+source ~/pyneat/bin/activate
+pip install -r examples/pose-estimation/yolo26-pose-estimator/src/python/requirements.txt
+python3 examples/pose-estimation/yolo26-pose-estimator/src/python/main.py \
+  --config examples/pose-estimation/yolo26-pose-estimator/src/common/config.yaml
+```
+
+Example config:
+
+```yaml
+model:
+  path: assets/models/YOLO26-POSE/yolo26m-pose-bf16-b1.tar.gz
+
+io:
+  input_dir: assets/test_images
+  output_dir: sandbox/yolo26-pose-estimator
+
+decode:
+  score_threshold: 0.55
+  nms_iou: 0.60
+  max_detections: 50
+
+runtime:
+  timeout_ms: 20000
+  num_runs: 1
+  profile: false
+
+output:
+  overlay: true
+```
+
+## Debugging Notes
+- If startup fails, verify `model.path`.
+- If no images are processed, verify `io.input_dir`.
+- If output images are missing, verify `output.overlay` is `true` and `io.output_dir` is writable.
+- If poses look wrong, first verify the model path and that `decode_type` is `YoloV26Pose`.
+
+## Source Files
+- C++ source: `src/cpp/main.cpp`
+- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+- Python source: `src/python/main.py`
+- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
+- Shared config: `src/common/config.yaml`

--- a/examples/pose-estimation/yolo26-pose-estimator/src/common/config.yaml
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/common/config.yaml
@@ -1,0 +1,19 @@
+model:
+  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+
+io:
+  input_dir: assets/test_images
+  output_dir: sandbox/yolo26-pose-estimator
+
+decode:
+  score_threshold: 0.55
+  nms_iou: 0.60
+  max_detections: 50
+
+runtime:
+  timeout_ms: 20000
+  num_runs: 1
+  profile: false
+
+output:
+  overlay: true

--- a/examples/pose-estimation/yolo26-pose-estimator/src/common/config.yaml
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/common/config.yaml
@@ -17,3 +17,6 @@ runtime:
 
 output:
   overlay: true
+
+debug:
+  pose: false

--- a/examples/pose-estimation/yolo26-pose-estimator/src/cpp/CMakeLists.txt
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/cpp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(yolo26-pose-estimator LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  include(CTest)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/ExampleModule.cmake")
+sima_neat_apps_module("yolo26-pose-estimator" UNIT_TEST E2E_TEST)

--- a/examples/pose-estimation/yolo26-pose-estimator/src/cpp/main.cpp
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/cpp/main.cpp
@@ -1,0 +1,449 @@
+/**
+ * @example yolo26-pose-estimator.cpp
+ * Minimal YOLO26 pose-estimation pipeline for every image in a folder.
+ *
+ * Usage: yolo26-pose-estimator [--config <path>]
+ */
+#include "neat.h"
+#include "support/runtime/config_utils.h"
+
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr float kDefaultMinScore = 0.55f;
+constexpr float kDefaultNmsIou = 0.60f;
+constexpr float kKeypointScore = 0.50f;
+constexpr int kMaxDet = 50;
+constexpr int kTimeoutMs = 20000;
+constexpr int kPoseKeypoints = 17;
+constexpr int kPoseColumns = 3;
+
+constexpr std::array<std::pair<int, int>, 16> kSkeleton = {{
+    {5, 7},
+    {7, 9},
+    {6, 8},
+    {8, 10},
+    {5, 6},
+    {5, 11},
+    {6, 12},
+    {11, 12},
+    {11, 13},
+    {13, 15},
+    {12, 14},
+    {14, 16},
+    {0, 1},
+    {0, 2},
+    {1, 3},
+    {2, 4},
+}};
+
+const std::array<cv::Scalar, 17> kKeypointColors = {{
+    cv::Scalar(255, 128, 0),
+    cv::Scalar(255, 153, 51),
+    cv::Scalar(255, 178, 102),
+    cv::Scalar(230, 230, 0),
+    cv::Scalar(255, 153, 255),
+    cv::Scalar(153, 204, 255),
+    cv::Scalar(255, 102, 255),
+    cv::Scalar(255, 51, 255),
+    cv::Scalar(102, 178, 255),
+    cv::Scalar(51, 153, 255),
+    cv::Scalar(255, 153, 153),
+    cv::Scalar(255, 102, 102),
+    cv::Scalar(255, 51, 51),
+    cv::Scalar(153, 255, 153),
+    cv::Scalar(102, 255, 102),
+    cv::Scalar(51, 255, 51),
+    cv::Scalar(0, 255, 0),
+}};
+
+struct Config {
+  std::string model_path;
+  std::string input_dir;
+  std::string output_dir;
+  float min_score = kDefaultMinScore;
+  float nms_iou = kDefaultNmsIou;
+  int max_detections = kMaxDet;
+  int timeout_ms = kTimeoutMs;
+  bool profile = false;
+  bool overlay = true;
+  int num_runs = 1;
+};
+
+struct Keypoint {
+  float x = 0.0f;
+  float y = 0.0f;
+  float score = 0.0f;
+};
+
+struct PoseDetection {
+  float x1 = 0.0f;
+  float y1 = 0.0f;
+  float x2 = 0.0f;
+  float y2 = 0.0f;
+  float score = 0.0f;
+  int class_id = 0;
+  std::array<Keypoint, kPoseKeypoints> keypoints;
+};
+
+Config load_config(const fs::path& path) {
+  const auto raw = sima_examples::ScalarConfig::load(path);
+  Config cfg;
+  cfg.model_path = raw.string_or("model.path", "assets/models/yolo26m-pose-bf16-b1.tar.gz");
+  cfg.input_dir = raw.string_or("io.input_dir", "assets/test_images");
+  cfg.output_dir = raw.string_or("io.output_dir", "sandbox/yolo26-pose-estimator");
+  cfg.min_score = static_cast<float>(raw.double_or("decode.score_threshold", kDefaultMinScore));
+  cfg.nms_iou = static_cast<float>(raw.double_or("decode.nms_iou", kDefaultNmsIou));
+  cfg.max_detections = raw.int_or("decode.max_detections", kMaxDet);
+  cfg.timeout_ms = raw.int_or("runtime.timeout_ms", kTimeoutMs);
+  cfg.num_runs = raw.int_or("runtime.num_runs", 1);
+  cfg.profile = raw.bool_or("runtime.profile", false);
+  cfg.overlay = raw.bool_or("output.overlay", true);
+  if (cfg.min_score < 0.0f || cfg.min_score > 1.0f) {
+    throw std::runtime_error("decode.score_threshold must be in [0.0, 1.0]");
+  }
+  if (cfg.nms_iou < 0.0f || cfg.nms_iou > 1.0f) {
+    throw std::runtime_error("decode.nms_iou must be in [0.0, 1.0]");
+  }
+  if (cfg.max_detections < 1) {
+    throw std::runtime_error("decode.max_detections must be >= 1");
+  }
+  if (cfg.timeout_ms <= 0) {
+    throw std::runtime_error("runtime.timeout_ms must be > 0");
+  }
+  if (cfg.num_runs < 1) {
+    throw std::runtime_error("runtime.num_runs must be >= 1");
+  }
+  return cfg;
+}
+
+Config parse_config(int argc, char** argv) {
+  fs::path config_path = sima_examples::default_config_path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR);
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--config") {
+      if (i + 1 >= argc) {
+        throw std::runtime_error("--config requires a path");
+      }
+      config_path = argv[++i];
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: " << argv[0] << " [--config <path>]\n";
+      std::exit(0);
+    } else {
+      throw std::runtime_error("unknown argument: " + arg);
+    }
+  }
+  return load_config(config_path);
+}
+
+bool is_image(const fs::path& p) {
+  std::string ext = p.extension().string();
+  for (char& c : ext) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp");
+}
+
+int clear_output_images(const fs::path& output_dir, const fs::path& input_dir) {
+  if (fs::weakly_canonical(output_dir) == fs::weakly_canonical(input_dir)) {
+    std::cerr << "Skipping output cleanup because output_dir matches input_dir: " << output_dir
+              << "\n";
+    return 0;
+  }
+
+  int removed = 0;
+  for (const auto& entry : fs::directory_iterator(output_dir)) {
+    if (entry.is_regular_file() && is_image(entry.path())) {
+      fs::remove(entry.path());
+      ++removed;
+    }
+  }
+  return removed;
+}
+
+std::vector<float> tensor_to_floats(const simaai::neat::Tensor& tensor) {
+  if (tensor.dtype != simaai::neat::TensorDType::Float32) {
+    throw std::runtime_error("expected Float32 tensor");
+  }
+  std::size_t elements = 1;
+  for (const int64_t dim : tensor.shape) {
+    if (dim == 0) {
+      return {};
+    }
+    elements *= static_cast<std::size_t>(dim);
+  }
+  const std::vector<std::uint8_t> bytes = tensor.copy_dense_bytes_tight();
+  if (bytes.size() % sizeof(float) != 0) {
+    throw std::runtime_error("float tensor byte size is not aligned");
+  }
+  if (bytes.size() != elements * sizeof(float)) {
+    throw std::runtime_error("float tensor byte size does not match tensor shape");
+  }
+  std::vector<float> values(elements);
+  if (!values.empty()) {
+    std::memcpy(values.data(), bytes.data(), bytes.size());
+  }
+  return values;
+}
+
+std::vector<PoseDetection> decode_poses(const simaai::neat::TensorList& outputs, int image_width,
+                                        int image_height, int max_detections) {
+  if (outputs.empty()) {
+    throw std::runtime_error("model returned no pose tensors");
+  }
+
+  const auto decoded =
+      simaai::neat::decode_pose(outputs, image_width, image_height, max_detections, false);
+  std::vector<PoseDetection> poses;
+  for (const auto& item : decoded) {
+    const auto boxes = tensor_to_floats(item.boxes);
+    const auto keypoints = tensor_to_floats(item.keypoints);
+    const size_t box_count = boxes.size() / 6U;
+    const size_t keypoint_count = keypoints.size() / (kPoseKeypoints * kPoseColumns);
+    const size_t count = std::min(box_count, keypoint_count);
+    for (size_t i = 0; i < count; ++i) {
+      const float* box = boxes.data() + i * 6U;
+      if (box[2] <= box[0] || box[3] <= box[1]) {
+        continue;
+      }
+
+      PoseDetection pose;
+      pose.x1 = box[0];
+      pose.y1 = box[1];
+      pose.x2 = box[2];
+      pose.y2 = box[3];
+      pose.score = box[4];
+      pose.class_id = static_cast<int>(box[5]);
+
+      const float* point_base = keypoints.data() + i * kPoseKeypoints * kPoseColumns;
+      for (int k = 0; k < kPoseKeypoints; ++k) {
+        const float* point = point_base + k * kPoseColumns;
+        pose.keypoints[static_cast<size_t>(k)] = Keypoint{point[0], point[1], point[2]};
+      }
+      poses.push_back(pose);
+      if (static_cast<int>(poses.size()) >= max_detections) {
+        return poses;
+      }
+    }
+  }
+  return poses;
+}
+
+bool valid_keypoint(const Keypoint& point, const PoseDetection& pose, int width, int height) {
+  const float box_w = pose.x2 - pose.x1;
+  const float box_h = pose.y2 - pose.y1;
+  const float margin = std::max(8.0f, 0.10f * std::max(box_w, box_h));
+  return point.score >= kKeypointScore && point.x >= 0.0f && point.y >= 0.0f &&
+         point.x < static_cast<float>(width) && point.y < static_cast<float>(height) &&
+         point.x >= pose.x1 - margin && point.x <= pose.x2 + margin &&
+         point.y >= pose.y1 - margin && point.y <= pose.y2 + margin;
+}
+
+void draw_pose(cv::Mat& frame, const PoseDetection& pose) {
+  const int x1 = std::max(0, std::min(frame.cols - 1, static_cast<int>(std::round(pose.x1))));
+  const int y1 = std::max(0, std::min(frame.rows - 1, static_cast<int>(std::round(pose.y1))));
+  const int x2 = std::max(0, std::min(frame.cols - 1, static_cast<int>(std::round(pose.x2))));
+  const int y2 = std::max(0, std::min(frame.rows - 1, static_cast<int>(std::round(pose.y2))));
+  if (x2 > x1 && y2 > y1) {
+    cv::rectangle(frame, cv::Point(x1, y1), cv::Point(x2, y2), cv::Scalar(0, 255, 0), 2);
+    const std::string text = "person " + cv::format("%.2f", pose.score);
+    cv::putText(frame, text, cv::Point(x1, std::max(0, y1 - 4)), cv::FONT_HERSHEY_SIMPLEX, 0.5,
+                cv::Scalar(0, 255, 0), 1, cv::LINE_AA);
+  }
+
+  for (const auto& [start, end] : kSkeleton) {
+    const Keypoint& p0 = pose.keypoints[static_cast<size_t>(start)];
+    const Keypoint& p1 = pose.keypoints[static_cast<size_t>(end)];
+    if (!valid_keypoint(p0, pose, frame.cols, frame.rows) ||
+        !valid_keypoint(p1, pose, frame.cols, frame.rows)) {
+      continue;
+    }
+    cv::line(frame,
+             cv::Point(static_cast<int>(std::round(p0.x)), static_cast<int>(std::round(p0.y))),
+             cv::Point(static_cast<int>(std::round(p1.x)), static_cast<int>(std::round(p1.y))),
+             cv::Scalar(255, 0, 255), 2, cv::LINE_AA);
+  }
+
+  for (size_t i = 0; i < pose.keypoints.size(); ++i) {
+    const Keypoint& point = pose.keypoints[i];
+    if (!valid_keypoint(point, pose, frame.cols, frame.rows)) {
+      continue;
+    }
+    cv::circle(
+        frame,
+        cv::Point(static_cast<int>(std::round(point.x)), static_cast<int>(std::round(point.y))), 3,
+        kKeypointColors[i % kKeypointColors.size()], cv::FILLED, cv::LINE_AA);
+  }
+}
+
+void draw_poses(cv::Mat& frame, const std::vector<PoseDetection>& poses) {
+  for (const auto& pose : poses) {
+    draw_pose(frame, pose);
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  std::cout.setf(std::ios::unitbuf);
+  std::cerr.setf(std::ios::unitbuf);
+
+  Config cfg;
+  try {
+    cfg = parse_config(argc, argv);
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
+
+  const fs::path input_dir = cfg.input_dir;
+  const fs::path output_dir = cfg.output_dir;
+
+  if (!fs::is_directory(input_dir)) {
+    std::cerr << "Input directory does not exist: " << input_dir << "\n";
+    return 2;
+  }
+  fs::create_directories(output_dir);
+  const int removed_outputs = clear_output_images(output_dir, input_dir);
+  if (removed_outputs > 0) {
+    std::cout << "Cleared " << removed_outputs << " stale output images\n";
+  }
+
+  std::vector<fs::path> images;
+  for (const auto& entry : fs::directory_iterator(input_dir)) {
+    if (entry.is_regular_file() && is_image(entry.path())) {
+      images.push_back(entry.path());
+    }
+  }
+  std::sort(images.begin(), images.end());
+
+  if (images.empty()) {
+    std::cerr << "No images found in " << input_dir << "\n";
+    return 3;
+  }
+  std::cout << "Found " << images.size() << " images\n";
+
+  try {
+    simaai::neat::Model::Options model_opt;
+    model_opt.preprocess.kind = simaai::neat::InputKind::Image;
+    model_opt.preprocess.enable = simaai::neat::AutoFlag::On;
+    model_opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::BGR;
+    model_opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
+    model_opt.decode_type = simaai::neat::BoxDecodeType::YoloV26Pose;
+    model_opt.score_threshold = cfg.min_score;
+    model_opt.nms_iou_threshold = cfg.nms_iou;
+    model_opt.top_k = cfg.max_detections;
+
+    simaai::neat::Model model(cfg.model_path, model_opt);
+
+    cv::Mat seed_bgr = cv::imread(images.front().string(), cv::IMREAD_COLOR);
+    if (seed_bgr.empty()) {
+      throw std::runtime_error("failed to read build seed image: " + images.front().string());
+    }
+    std::cout << "[BUILD] Building pipeline...\n";
+    auto runner = model.build(std::vector<cv::Mat>{seed_bgr}, simaai::neat::Model::RouteOptions{});
+    std::cout << "[BUILD] Pipeline built\n";
+
+    runner.run(std::vector<cv::Mat>{seed_bgr}, cfg.timeout_ms);
+    std::cout << "[WARMUP] done\n";
+
+    const int total_images = static_cast<int>(images.size()) * cfg.num_runs;
+    if (cfg.num_runs > 1) {
+      std::cout << "Looping " << cfg.num_runs << "x over " << images.size() << " images ("
+                << total_images << " total)\n";
+    }
+
+    const auto pipeline_start = std::chrono::steady_clock::now();
+    int processed = 0;
+
+    for (int run_idx = 0; run_idx < cfg.num_runs; ++run_idx) {
+      for (const auto& image_path : images) {
+        const auto img_start = std::chrono::steady_clock::now();
+
+        cv::Mat bgr = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+        if (bgr.empty()) {
+          std::cerr << "Skipping unreadable: " << image_path.filename() << "\n";
+          continue;
+        }
+
+        const auto infer_start = std::chrono::steady_clock::now();
+        simaai::neat::TensorList out = runner.run(std::vector<cv::Mat>{bgr}, cfg.timeout_ms);
+        const auto infer_end = std::chrono::steady_clock::now();
+
+        const std::vector<PoseDetection> poses =
+            decode_poses(out, bgr.cols, bgr.rows, cfg.max_detections);
+        const auto decode_end = std::chrono::steady_clock::now();
+
+        if (cfg.overlay) {
+          draw_poses(bgr, poses);
+          const fs::path out_path = output_dir / (image_path.stem().string() + ".png");
+          if (!cv::imwrite(out_path.string(), bgr)) {
+            std::cerr << "Failed to write: " << out_path << "\n";
+            continue;
+          }
+        }
+        const auto img_end = std::chrono::steady_clock::now();
+
+        ++processed;
+        if (cfg.overlay) {
+          std::cout << "[" << processed << "/" << total_images << "] " << image_path.filename()
+                    << " -> " << image_path.stem().string() << ".png"
+                    << " (" << poses.size() << " poses)\n";
+        } else {
+          std::cout << "[" << processed << "/" << total_images << "] " << image_path.filename()
+                    << " (" << poses.size() << " poses)\n";
+        }
+
+        if (cfg.profile) {
+          using ms = std::chrono::duration<double, std::milli>;
+          const auto pre_ms = ms(infer_start - img_start).count();
+          const auto inf_ms = ms(infer_end - infer_start).count();
+          const auto dec_ms = ms(decode_end - infer_end).count();
+          const auto post_ms = ms(img_end - decode_end).count();
+          const auto tot_ms = ms(img_end - img_start).count();
+          std::cout << "[PROFILE] " << image_path.filename().string()
+                    << ": preprocess=" << cv::format("%.1f", pre_ms)
+                    << "ms inference=" << cv::format("%.1f", inf_ms)
+                    << "ms decode=" << cv::format("%.1f", dec_ms)
+                    << "ms overlay+save=" << cv::format("%.1f", post_ms)
+                    << "ms total=" << cv::format("%.1f", tot_ms) << "ms\n";
+        }
+      }
+    }
+
+    runner.close();
+
+    if (cfg.profile && processed > 0) {
+      const auto pipeline_end = std::chrono::steady_clock::now();
+      const auto total_s = std::chrono::duration<double>(pipeline_end - pipeline_start).count();
+      const auto avg_ms = (total_s * 1000.0) / static_cast<double>(processed);
+      const auto fps = static_cast<double>(processed) / total_s;
+      std::cout << "[PROFILE] Total: " << processed << " images in " << cv::format("%.1f", total_s)
+                << "s (avg " << cv::format("%.1f", avg_ms) << "ms/image, "
+                << cv::format("%.1f", fps) << " FPS)\n";
+    }
+
+    std::cout << "Done: " << processed << " images processed\n";
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 4;
+  }
+}

--- a/examples/pose-estimation/yolo26-pose-estimator/src/cpp/main.cpp
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/cpp/main.cpp
@@ -84,6 +84,7 @@ struct Config {
   int timeout_ms = kTimeoutMs;
   bool profile = false;
   bool overlay = true;
+  bool debug_pose = false;
   int num_runs = 1;
 };
 
@@ -116,6 +117,7 @@ Config load_config(const fs::path& path) {
   cfg.num_runs = raw.int_or("runtime.num_runs", 1);
   cfg.profile = raw.bool_or("runtime.profile", false);
   cfg.overlay = raw.bool_or("output.overlay", true);
+  cfg.debug_pose = raw.bool_or("debug.pose", false);
   if (cfg.min_score < 0.0f || cfg.min_score > 1.0f) {
     throw std::runtime_error("decode.score_threshold must be in [0.0, 1.0]");
   }
@@ -299,6 +301,20 @@ void draw_poses(cv::Mat& frame, const std::vector<PoseDetection>& poses) {
   }
 }
 
+void log_pose_debug(const fs::path& image_path, int width, int height, const PoseDetection& pose) {
+  std::cout << "[POSE_DEBUG] image=" << image_path.filename().string() << " frame=" << width << "x"
+            << height << " bbox=(" << cv::format("%.1f", pose.x1) << ","
+            << cv::format("%.1f", pose.y1) << "," << cv::format("%.1f", pose.x2) << ","
+            << cv::format("%.1f", pose.y2) << ") score=" << cv::format("%.3f", pose.score)
+            << " class_id=" << pose.class_id << "\n";
+  for (size_t i = 0; i < pose.keypoints.size(); ++i) {
+    const Keypoint& point = pose.keypoints[i];
+    std::cout << "[POSE_DEBUG] kp[" << i << "]=(" << cv::format("%.1f", point.x) << ","
+              << cv::format("%.1f", point.y) << ") score=" << cv::format("%.3f", point.score)
+              << "\n";
+  }
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -372,6 +388,7 @@ int main(int argc, char** argv) {
 
     const auto pipeline_start = std::chrono::steady_clock::now();
     int processed = 0;
+    bool printed_pose_debug = false;
 
     for (int run_idx = 0; run_idx < cfg.num_runs; ++run_idx) {
       for (const auto& image_path : images) {
@@ -390,6 +407,11 @@ int main(int argc, char** argv) {
         const std::vector<PoseDetection> poses =
             decode_poses(out, bgr.cols, bgr.rows, cfg.max_detections);
         const auto decode_end = std::chrono::steady_clock::now();
+
+        if (cfg.debug_pose && !printed_pose_debug && !poses.empty()) {
+          log_pose_debug(image_path, bgr.cols, bgr.rows, poses.front());
+          printed_pose_debug = true;
+        }
 
         if (cfg.overlay) {
           draw_poses(bgr, poses);

--- a/examples/pose-estimation/yolo26-pose-estimator/src/python/main.py
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/python/main.py
@@ -140,6 +140,16 @@ def draw_poses(frame: np.ndarray, poses: list[dict]) -> np.ndarray:
     return frame
 
 
+def log_pose_debug(image_path: Path, width: int, height: int, pose: dict) -> None:
+    print(
+        f"[POSE_DEBUG] image={image_path.name} frame={width}x{height} "
+        f"bbox=({pose['x1']:.1f},{pose['y1']:.1f},{pose['x2']:.1f},{pose['y2']:.1f}) "
+        f"score={pose['score']:.3f} class_id={pose['class_id']}"
+    )
+    for idx, point in enumerate(pose["keypoints"]):
+        print(f"[POSE_DEBUG] kp[{idx}]=({point[0]:.1f},{point[1]:.1f}) score={point[2]:.3f}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="YOLO26 folder pose-estimation pipeline")
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
@@ -167,6 +177,7 @@ def main() -> int:
     num_runs = int(runtime_cfg.get("num_runs", 1))
     profile = bool(runtime_cfg.get("profile", False))
     overlay = bool(output_cfg.get("overlay", True))
+    debug_pose = bool(raw.get("debug", {}).get("pose", False))
 
     if not 0.0 <= min_score <= 1.0:
         print(f"Error: decode.score_threshold must be in [0.0, 1.0], got {min_score}", file=sys.stderr)
@@ -238,6 +249,7 @@ def main() -> int:
 
         pipeline_start = time.perf_counter()
         processed = 0
+        printed_pose_debug = False
 
         for img_path in all_images:
             img_start = time.perf_counter()
@@ -260,6 +272,10 @@ def main() -> int:
 
             poses = pose_results_from_output(out, width, height, max_detections)
             decode_end = time.perf_counter()
+
+            if debug_pose and not printed_pose_debug and poses:
+                log_pose_debug(img_path, width, height, poses[0])
+                printed_pose_debug = True
 
             if overlay:
                 draw_poses(bgr, poses)

--- a/examples/pose-estimation/yolo26-pose-estimator/src/python/main.py
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/python/main.py
@@ -1,0 +1,308 @@
+"""YOLO26 pose-estimation pipeline using pyneat."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+
+MIN_SCORE = 0.55
+NMS_IOU = 0.60
+MAX_DET = 50
+KEYPOINT_SCORE = 0.50
+DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
+SKELETON = [
+    (5, 7), (7, 9), (6, 8), (8, 10), (5, 6), (5, 11), (6, 12),
+    (11, 12), (11, 13), (13, 15), (12, 14), (14, 16),
+    (0, 1), (0, 2), (1, 3), (2, 4),
+]
+KEYPOINT_COLORS = [
+    (255, 128, 0), (255, 153, 51), (255, 178, 102), (230, 230, 0),
+    (255, 153, 255), (153, 204, 255), (255, 102, 255), (255, 51, 255),
+    (102, 178, 255), (51, 153, 255), (255, 153, 153), (255, 102, 102),
+    (255, 51, 51), (153, 255, 153), (102, 255, 102), (51, 255, 51),
+    (0, 255, 0),
+]
+
+
+def is_image(path: Path) -> bool:
+    return path.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
+
+
+def load_config(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def clear_output_images(output_dir: Path, input_dir: Path) -> int:
+    if output_dir.resolve() == input_dir.resolve():
+        print(
+            f"Skipping output cleanup because output_dir matches input_dir: {output_dir}",
+            file=sys.stderr,
+        )
+        return 0
+
+    removed = 0
+    for path in output_dir.iterdir():
+        if path.is_file() and is_image(path):
+            path.unlink()
+            removed += 1
+    return removed
+
+
+def tensor_to_numpy(tensor) -> np.ndarray:
+    return np.asarray(tensor.to_numpy(copy=True))
+
+
+def pose_results_from_output(result, width: int, height: int, max_detections: int) -> list[dict]:
+    decoded = pyneat.decode_pose(
+        list(result),
+        clamp_to=(width, height),
+        top_k=max_detections,
+        strict=False,
+    )
+    poses = []
+    for item in decoded:
+        boxes = tensor_to_numpy(item.boxes).astype(np.float32).reshape((-1, 6))
+        keypoints = tensor_to_numpy(item.keypoints).astype(np.float32).reshape((-1, 17, 3))
+        for box, points in zip(boxes, keypoints):
+            x1, y1, x2, y2, score, class_id = box.tolist()
+            if x2 <= x1 or y2 <= y1:
+                continue
+            poses.append(
+                {
+                    "x1": float(x1),
+                    "y1": float(y1),
+                    "x2": float(x2),
+                    "y2": float(y2),
+                    "score": float(score),
+                    "class_id": int(class_id),
+                    "keypoints": points,
+                }
+            )
+    return poses[:max_detections]
+
+
+def valid_keypoint(point: np.ndarray, pose: dict, width: int, height: int) -> bool:
+    x, y, score = point.tolist()
+    box_w = pose["x2"] - pose["x1"]
+    box_h = pose["y2"] - pose["y1"]
+    margin = max(8.0, 0.10 * max(box_w, box_h))
+    return (
+        score >= KEYPOINT_SCORE
+        and 0 <= x < width
+        and 0 <= y < height
+        and pose["x1"] - margin <= x <= pose["x2"] + margin
+        and pose["y1"] - margin <= y <= pose["y2"] + margin
+    )
+
+
+def draw_pose(frame: np.ndarray, pose: dict) -> None:
+    x1 = max(0, int(round(pose["x1"])))
+    y1 = max(0, int(round(pose["y1"])))
+    x2 = min(frame.shape[1] - 1, int(round(pose["x2"])))
+    y2 = min(frame.shape[0] - 1, int(round(pose["y2"])))
+    if x2 > x1 and y2 > y1:
+        cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        cv2.putText(
+            frame,
+            f"person {pose['score']:.2f}",
+            (x1, max(0, y1 - 4)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            (0, 255, 0),
+            1,
+            cv2.LINE_AA,
+        )
+
+    keypoints = pose["keypoints"]
+    for start, end in SKELETON:
+        if valid_keypoint(keypoints[start], pose, frame.shape[1], frame.shape[0]) and valid_keypoint(
+            keypoints[end], pose, frame.shape[1], frame.shape[0]
+        ):
+            p0 = tuple(int(round(v)) for v in keypoints[start, :2])
+            p1 = tuple(int(round(v)) for v in keypoints[end, :2])
+            cv2.line(frame, p0, p1, (255, 0, 255), 2, cv2.LINE_AA)
+
+    for idx, point in enumerate(keypoints):
+        if valid_keypoint(point, pose, frame.shape[1], frame.shape[0]):
+            center = tuple(int(round(v)) for v in point[:2])
+            cv2.circle(frame, center, 3, KEYPOINT_COLORS[idx % len(KEYPOINT_COLORS)], -1, cv2.LINE_AA)
+
+
+def draw_poses(frame: np.ndarray, poses: list[dict]) -> np.ndarray:
+    for pose in poses:
+        draw_pose(frame, pose)
+    return frame
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="YOLO26 folder pose-estimation pipeline")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
+    args = parser.parse_args()
+
+    global cv2, np, pyneat
+    import cv2
+    import numpy as np
+    import pyneat
+
+    raw = load_config(args.config)
+    model_cfg = raw.get("model", {})
+    io_cfg = raw.get("io", {})
+    decode_cfg = raw.get("decode", {})
+    runtime_cfg = raw.get("runtime", {})
+    output_cfg = raw.get("output", {})
+
+    model_path = model_cfg.get("path", "assets/models/yolo26m-pose-bf16-b1.tar.gz")
+    input_dir = Path(io_cfg.get("input_dir", "assets/test_images"))
+    output_dir = Path(io_cfg.get("output_dir", "sandbox/yolo26-pose-estimator"))
+    min_score = float(decode_cfg.get("score_threshold", MIN_SCORE))
+    nms_iou = float(decode_cfg.get("nms_iou", NMS_IOU))
+    max_detections = int(decode_cfg.get("max_detections", MAX_DET))
+    timeout_ms = int(runtime_cfg.get("timeout_ms", 20000))
+    num_runs = int(runtime_cfg.get("num_runs", 1))
+    profile = bool(runtime_cfg.get("profile", False))
+    overlay = bool(output_cfg.get("overlay", True))
+
+    if not 0.0 <= min_score <= 1.0:
+        print(f"Error: decode.score_threshold must be in [0.0, 1.0], got {min_score}", file=sys.stderr)
+        return 2
+    if not 0.0 <= nms_iou <= 1.0:
+        print(f"Error: decode.nms_iou must be in [0.0, 1.0], got {nms_iou}", file=sys.stderr)
+        return 2
+    if max_detections < 1:
+        print(f"Error: decode.max_detections must be >= 1, got {max_detections}", file=sys.stderr)
+        return 2
+    if timeout_ms <= 0:
+        print(f"Error: runtime.timeout_ms must be > 0, got {timeout_ms}", file=sys.stderr)
+        return 2
+    if num_runs < 1:
+        print(f"Error: runtime.num_runs must be >= 1, got {num_runs}", file=sys.stderr)
+        return 2
+    if not input_dir.is_dir():
+        print(f"Input directory does not exist: {input_dir}", file=sys.stderr)
+        return 2
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    removed_outputs = clear_output_images(output_dir, input_dir)
+    if removed_outputs:
+        print(f"Cleared {removed_outputs} stale output images")
+
+    images = sorted(p for p in input_dir.iterdir() if p.is_file() and is_image(p))
+    if not images:
+        print(f"No images found in {input_dir}", file=sys.stderr)
+        return 3
+    print(f"Found {len(images)} images")
+
+    try:
+        opt = pyneat.ModelOptions()
+        opt.preprocess.kind = pyneat.InputKind.Image
+        opt.preprocess.enable = pyneat.AutoFlag.On
+        opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.BGR
+        opt.preprocess.preset = pyneat.NormalizePreset.COCO_YOLO
+        opt.decode_type = pyneat.BoxDecodeType.YoloV26Pose
+        opt.score_threshold = min_score
+        opt.nms_iou_threshold = nms_iou
+        opt.top_k = max_detections
+        model = pyneat.Model(model_path, opt)
+
+        seed = cv2.imread(str(images[0]), cv2.IMREAD_COLOR)
+        if seed is None:
+            print(f"Error: failed to read build seed image: {images[0].name}", file=sys.stderr)
+            return 4
+        t_dummy = pyneat.Tensor.from_numpy(
+            np.ascontiguousarray(seed, dtype=np.uint8),
+            copy=True,
+            image_format=pyneat.PixelFormat.BGR,
+            memory=pyneat.TensorMemory.EV74,
+        )
+        run_opt = pyneat.RunOptions()
+        run_opt.queue_depth = 8
+        run_opt.overflow_policy = pyneat.OverflowPolicy.Block
+        run_opt.preset = pyneat.RunPreset.Balanced
+        runner = model.build(
+            [t_dummy],
+            route_options=pyneat.ModelRouteOptions(),
+            run_options=run_opt,
+        )
+        runner.run([t_dummy], timeout_ms=timeout_ms)
+        print("[WARMUP] done")
+
+        all_images = images * num_runs
+        if num_runs > 1:
+            print(f"Looping {num_runs}x over {len(images)} images ({len(all_images)} total)")
+
+        pipeline_start = time.perf_counter()
+        processed = 0
+
+        for img_path in all_images:
+            img_start = time.perf_counter()
+            bgr = cv2.imread(str(img_path), cv2.IMREAD_COLOR)
+            if bgr is None:
+                print(f"Skipping unreadable: {img_path.name}", file=sys.stderr)
+                continue
+
+            height, width = bgr.shape[:2]
+            t_in = pyneat.Tensor.from_numpy(
+                np.ascontiguousarray(bgr, dtype=np.uint8),
+                copy=True,
+                image_format=pyneat.PixelFormat.BGR,
+                memory=pyneat.TensorMemory.EV74,
+            )
+
+            infer_start = time.perf_counter()
+            out = runner.run([t_in], timeout_ms=timeout_ms)
+            infer_end = time.perf_counter()
+
+            poses = pose_results_from_output(out, width, height, max_detections)
+            decode_end = time.perf_counter()
+
+            if overlay:
+                draw_poses(bgr, poses)
+                out_path = output_dir / f"{img_path.stem}.png"
+                cv2.imwrite(str(out_path), bgr)
+            img_end = time.perf_counter()
+
+            processed += 1
+            pose_str = f"({len(poses)} poses)"
+            if overlay:
+                print(f"[{processed}/{len(all_images)}] {img_path.name} -> {img_path.stem}.png {pose_str}")
+            else:
+                print(f"[{processed}/{len(all_images)}] {img_path.name} {pose_str}")
+
+            if profile:
+                pre_ms = (infer_start - img_start) * 1000
+                inf_ms = (infer_end - infer_start) * 1000
+                dec_ms = (decode_end - infer_end) * 1000
+                post_ms = (img_end - decode_end) * 1000
+                tot_ms = (img_end - img_start) * 1000
+                print(
+                    f"[PROFILE] {img_path.name}: preprocess={pre_ms:.1f}ms "
+                    f"inference={inf_ms:.1f}ms decode={dec_ms:.1f}ms "
+                    f"overlay+save={post_ms:.1f}ms total={tot_ms:.1f}ms"
+                )
+
+        if profile and processed > 0:
+            pipeline_end = time.perf_counter()
+            total_s = pipeline_end - pipeline_start
+            avg_ms = (total_s * 1000) / processed
+            fps = processed / total_s
+            print(
+                f"[PROFILE] Total: {processed} images in {total_s:.1f}s "
+                f"(avg {avg_ms:.1f}ms/image, {fps:.1f} FPS)"
+            )
+
+        runner.close()
+        print(f"Done: {processed} images processed")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/pose-estimation/yolo26-pose-estimator/src/python/requirements.txt
+++ b/examples/pose-estimation/yolo26-pose-estimator/src/python/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+opencv-python

--- a/examples/pose-estimation/yolo26-pose-estimator/tests/cpp/test_e2e.cpp
+++ b/examples/pose-estimation/yolo26-pose-estimator/tests/cpp/test_e2e.cpp
@@ -1,0 +1,103 @@
+// E2E test for yolo26-pose-estimator.
+// Runs the binary with a real model and test images, then verifies pose overlays.
+#include "support/testing/test_config.h"
+#include "support/testing/test_process.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <regex>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace sima_examples::testing;
+
+bool has_nonzero_pose_count(const std::string& text) {
+  const std::regex pattern(R"(\(([0-9]+) poses\))");
+  auto begin = std::sregex_iterator(text.begin(), text.end(), pattern);
+  auto end = std::sregex_iterator();
+  for (auto it = begin; it != end; ++it) {
+    if (std::stoi((*it)[1].str()) > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+  const std::string binary = argv[1];
+
+  const char* models_dir_raw = env_or_null("SIMANEAT_APPS_TEST_MODELS_DIR");
+  const std::string models_dir = models_dir_raw ? models_dir_raw : "assets/models";
+
+  const std::string model_path = configured_model_path("yolo26-pose-estimator", models_dir);
+  if (model_path.empty() || !fs::exists(model_path)) {
+    return skip_or_fail(
+        "configured YOLO26 pose model not found under SIMANEAT_APPS_TEST_MODELS_DIR");
+  }
+
+  const char* images_raw = env_or_null("SIMANEAT_APPS_TEST_INPUT_DIR");
+  const std::string input_dir = images_raw ? images_raw : "assets/test_images";
+  if (!fs::exists(input_dir) || fs::is_empty(input_dir)) {
+    env_or_skip("SIMANEAT_APPS_TEST_INPUT_DIR",
+                "directory with test images (assets/test_images is empty or missing)");
+  }
+
+  auto out_dir = create_test_output_dir("yolo26-pose-estimator", "test_full_pipeline");
+  if (out_dir.empty())
+    return 1;
+
+  const double score_threshold = e2e_double("yolo26-pose-estimator", "decode", "score_threshold");
+  const double nms_iou = e2e_double("yolo26-pose-estimator", "decode", "nms_iou");
+  const int max_detections = e2e_int("yolo26-pose-estimator", "decode", "max_detections");
+  const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
+  {
+    std::ofstream config_file(config_path);
+    config_file << "model:\n"
+                << "  path: " << model_path << "\n"
+                << "io:\n"
+                << "  input_dir: " << input_dir << "\n"
+                << "  output_dir: " << out_dir << "\n"
+                << "decode:\n"
+                << "  score_threshold: " << score_threshold << "\n"
+                << "  nms_iou: " << nms_iou << "\n"
+                << "  max_detections: " << max_detections << "\n"
+                << "runtime:\n"
+                << "  timeout_ms: 20000\n"
+                << "  num_runs: 1\n"
+                << "  profile: false\n"
+                << "output:\n"
+                << "  overlay: true\n";
+  }
+
+  const int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
+
+  auto r = spawn_and_wait(binary, {"--config", config_path.string()}, timeout);
+
+  const int output_files = count_output_files(out_dir);
+
+  int rc = 0;
+  if (r.exit_code != 0) {
+    std::cerr << "[FAIL] exit code " << r.exit_code << "\n";
+    std::cerr << "stderr:\n" << r.stderr_text << "\n";
+    rc = 1;
+  } else if (!has_nonzero_pose_count(r.stdout_text)) {
+    std::cerr << "[FAIL] expected at least one decoded pose\n";
+    rc = 1;
+  } else if (output_files == 0) {
+    std::cerr << "[FAIL] expected output files but output directory is empty\n";
+    rc = 1;
+  } else if (!all_output_files_nonempty(out_dir)) {
+    std::cerr << "[FAIL] some output files are empty\n";
+    rc = 1;
+  } else {
+    std::cout << "[OK] YOLO26 pose overlay produced " << output_files << " output files\n";
+  }
+
+  remove_dir(out_dir);
+  return rc;
+}

--- a/examples/pose-estimation/yolo26-pose-estimator/tests/cpp/test_unit.cpp
+++ b/examples/pose-estimation/yolo26-pose-estimator/tests/cpp/test_unit.cpp
@@ -1,0 +1,70 @@
+// Unit test for yolo26-pose-estimator: validates CLI arg handling.
+#include "support/testing/test_process.h"
+
+#include <iostream>
+#include <string>
+
+using sima_examples::testing::spawn_and_wait;
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+  const std::string binary = argv[1];
+  int failures = 0;
+
+  {
+    auto r = spawn_and_wait(binary, {"--help"}, 20000);
+    if (r.exit_code != 0) {
+      std::cerr << "[FAIL] help: expected exit 0, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stdout_text.find("Usage") == std::string::npos) {
+      std::cerr << "[FAIL] help: stdout does not contain Usage\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] help prints usage\n";
+    }
+  }
+
+  {
+    auto r = spawn_and_wait(binary, {"--bogus"}, 20000);
+    if (r.exit_code != 1) {
+      std::cerr << "[FAIL] unknown flag: expected exit 1, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stderr_text.find("unknown argument") == std::string::npos) {
+      std::cerr << "[FAIL] unknown flag: stderr does not explain failure\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] unknown flag correctly rejected\n";
+    }
+  }
+
+  {
+    auto r = spawn_and_wait(binary, {"--config"}, 20000);
+    if (r.exit_code != 1) {
+      std::cerr << "[FAIL] missing config path: expected exit 1, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stderr_text.find("--config requires a path") == std::string::npos) {
+      std::cerr << "[FAIL] missing config path: stderr does not explain failure\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] missing config path correctly rejected\n";
+    }
+  }
+
+  {
+    auto r = spawn_and_wait(binary, {"--config", "/nonexistent/yolo26-pose-config.yaml"}, 20000);
+    if (r.exit_code != 1) {
+      std::cerr << "[FAIL] bad config: expected exit 1, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stderr_text.find("failed to open config") == std::string::npos) {
+      std::cerr << "[FAIL] bad config: stderr does not explain failure\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] bad config path correctly rejected\n";
+    }
+  }
+
+  return failures > 0 ? 1 : 0;
+}

--- a/examples/pose-estimation/yolo26-pose-estimator/tests/python/test_e2e.py
+++ b/examples/pose-estimation/yolo26-pose-estimator/tests/python/test_e2e.py
@@ -1,0 +1,62 @@
+"""E2E tests for yolo26-pose-estimator (Python)."""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+
+
+@pytest.mark.e2e
+class TestE2E:
+    def test_full_pipeline(
+        self,
+        e2e_model_path,
+        tmp_output_dir,
+        test_images_dir,
+        test_timeout_ms,
+        skip_unless_e2e_ready,
+        e2e_config_writer,
+    ):
+        skip_unless_e2e_ready(
+            test_images_dir.exists() and any(test_images_dir.iterdir()),
+            "test_images_dir is missing or empty",
+        )
+
+        config_path = e2e_config_writer(
+            {
+                "io": {"input_dir": str(test_images_dir), "output_dir": str(tmp_output_dir)},
+            }
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(MAIN_PY),
+                "--config",
+                str(config_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=test_timeout_ms / 1000,
+            cwd=str(EXAMPLE_DIR),
+        )
+
+        assert result.returncode == 0, (
+            f"main.py exited with code {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        pose_counts = [int(count) for count in re.findall(r"\((\d+) poses\)", result.stdout)]
+        assert any(count > 0 for count in pose_counts), result.stdout
+
+        output_files = [
+            path
+            for path in tmp_output_dir.iterdir()
+            if path.is_file() and path.name != "config.yaml"
+        ]
+        assert output_files, "Expected output files but output directory is empty"
+        assert all(path.stat().st_size > 0 for path in output_files)

--- a/examples/pose-estimation/yolo26-pose-estimator/tests/python/test_unit.py
+++ b/examples/pose-estimation/yolo26-pose-estimator/tests/python/test_unit.py
@@ -1,0 +1,44 @@
+"""Unit tests for yolo26-pose-estimator (Python)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+
+
+@pytest.mark.unit
+class TestArgParsing:
+    """Validate CLI argument parsing for the YOLO26 pose pipeline."""
+
+    def test_help(self):
+        r = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert r.returncode == 0
+        assert "--config" in r.stdout
+
+    def test_bad_config_path(self):
+        r = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--config", "/nonexistent/yolo26-pose-config.yaml"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert r.returncode != 0
+
+    def test_unknown_flag(self):
+        r = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--bogus"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert r.returncode == 2
+        assert "unrecognized" in r.stderr.lower() or "error" in r.stderr.lower()

--- a/examples/pose-estimation/yolo26-pose-estimator/tests/test-scope.yaml
+++ b/examples/pose-estimation/yolo26-pose-estimator/tests/test-scope.yaml
@@ -1,0 +1,45 @@
+models:
+  yolo26n-pose-bf16-mla_tess-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26n-pose-bf16-mla_tess-b1.tar.gz
+    file: yolo26n-pose-bf16-mla_tess-b1.tar.gz
+  yolo26s-pose-bf16-mla_tess-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26s-pose-bf16-mla_tess-b1.tar.gz
+    file: yolo26s-pose-bf16-mla_tess-b1.tar.gz
+  yolo26m-pose-bf16-mla_tess-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26m-pose-bf16-mla_tess-b1.tar.gz
+    file: yolo26m-pose-bf16-mla_tess-b1.tar.gz
+  yolo26l-pose-bf16-mla_tess-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26l-pose-bf16-mla_tess-b1.tar.gz
+    file: yolo26l-pose-bf16-mla_tess-b1.tar.gz
+  yolo26x-pose-bf16-mla_tess-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26x-pose-bf16-mla_tess-b1.tar.gz
+    file: yolo26x-pose-bf16-mla_tess-b1.tar.gz
+  yolo26m-pose-bf16-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26m-pose-bf16-b1.tar.gz
+    file: yolo26m-pose-bf16-b1.tar.gz
+  yolo26m-pose-int8-b1:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26m-pose-int8-b1.tar.gz
+    file: yolo26m-pose-int8-b1.tar.gz
+  yolo26m-pose-int8-b4:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-pose/yolo26m-pose-int8-b4.tar.gz
+    file: yolo26m-pose-int8-b4.tar.gz
+unit:
+  python: true
+  cpp: true
+e2e:
+  python:
+    enabled: true
+    models:
+    - yolo26m-pose-bf16-b1
+  cpp:
+    enabled: true
+    models:
+    - yolo26m-pose-bf16-b1

--- a/portal/public/category-assets/pose-estimation.svg
+++ b/portal/public/category-assets/pose-estimation.svg
@@ -1,0 +1,43 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <!-- Head -->
+  <circle cx="310" cy="62" r="18" stroke="#F0FFF4" stroke-width="2"/>
+  <!-- Neck to torso -->
+  <path d="M310 80V170" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round"/>
+  <!-- Shoulders -->
+  <path d="M250 120H370" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round"/>
+  <!-- Left arm raised -->
+  <path d="M250 120L210 80L180 40" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Right arm extended back -->
+  <path d="M370 120L420 160L470 180" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Torso to hips -->
+  <path d="M310 170V230" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round"/>
+  <!-- Hips -->
+  <path d="M270 230H350" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round"/>
+  <!-- Left leg striding forward -->
+  <path d="M270 230L240 290L220 340" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Right leg bent back -->
+  <path d="M350 230L390 280L410 340" stroke="#F0FFF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Keypoint dots -->
+  <circle cx="310" cy="62" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="310" cy="120" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="250" cy="120" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="370" cy="120" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="210" cy="80" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="180" cy="40" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="420" cy="160" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="470" cy="180" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="310" cy="170" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="270" cy="230" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="350" cy="230" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="240" cy="290" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="220" cy="340" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="390" cy="280" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <circle cx="410" cy="340" r="4" fill="#F0FFF4" fill-opacity="0.9"/>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1A5E3A"/>
+      <stop offset="1" stop-color="#6DD49E"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -16,10 +16,12 @@ IMAGE_CANDIDATES = (
     "assets/card.jpg",
     "assets/card.jpeg",
     "assets/card.webp",
+    "assets/card.svg",
     "assets/hero.png",
     "assets/hero.jpg",
     "assets/hero.jpeg",
     "assets/hero.webp",
+    "assets/hero.svg",
 )
 MODEL_REFERENCE_RE = re.compile(r"^(?P<label>[^\[]+?)(?:\s*\[(?P<url>https?://[^\]]+)\])?$")
 PORTAL_IMAGE_CANDIDATES = (
@@ -27,6 +29,7 @@ PORTAL_IMAGE_CANDIDATES = (
     "image.jpg",
     "image.jpeg",
     "image.webp",
+    "image.svg",
 )
 
 

--- a/scripts/validate_readmes.py
+++ b/scripts/validate_readmes.py
@@ -16,6 +16,7 @@ from pathlib import Path
 VALID_CATEGORIES = {
     "classification",
     "object-detection",
+    "pose-estimation",
     "tracking",
     "segmentation",
     "depth-estimation",


### PR DESCRIPTION
## Summary
- add a YOLO26 pose-estimation example
- add pose portal/category assets and test scope metadata
- add opt-in `debug.pose` logging to print one decoded bbox and all 17 keypoints before drawing

## Why Draft
This branch is mainly a repro for the current YOLO26 pose coordinate issue. The debug output shows BoxDecode emits keypoints in original-frame-like coordinates, but some y values exceed the source frame height. That points to native pose decode math/head semantics rather than app-side drawing or scaling.

## Testing
Manual repro on Modalix with `yolo26m-pose-bf16-b1`:

```bash
cd /workspace/sima-neat/apps
./build/examples/pose-estimation/yolo26-pose-estimator/yolo26-pose-estimator \
  --config sandbox/configs/pose-estimation/yolo26-pose-estimator/yolo26m-pose-bf16-b1/config.yaml
```

Observed debug sample:
- frame: `1000x563`
- bbox: `(1.0,41.0,191.0,556.0)`
- keypoints include y values above frame height, e.g. `675`, `785`

Python syntax and diff checks passed before split.