### PR TITLE
Share C++ e2e config writer

### DIFF
--- a/examples/classification/image-classifier/tests/cpp/test_e2e.cpp
+++ b/examples/classification/image-classifier/tests/cpp/test_e2e.cpp
@@ -4,7 +4,6 @@
 #include "support/testing/test_config.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -46,26 +45,12 @@ int main(int argc, char** argv) {
   if (out_dir.empty())
     return 1;
 
-  const int expected_class_id = e2e_int("image-classifier", "validation", "expected_class_id");
-  const double min_probability = e2e_double("image-classifier", "validation", "min_probability");
-  const std::string config_path = (fs::path(out_dir).parent_path() / "config.yaml").string();
-  {
-    std::ofstream config(config_path);
-    config << "model:\n"
-           << "  path: " << model_path << "\n"
-           << "io:\n"
-           << "  image: " << image_path << "\n"
-           << "  fallback_image_url: null\n"
-           << "runtime:\n"
-           << "  input_width: 224\n"
-           << "  input_height: 224\n"
-           << "  timeout_ms: 20000\n"
-           << "validation:\n"
-           << "  expected_class_id: " << expected_class_id << "\n"
-           << "  min_probability: " << min_probability << "\n";
-  }
+  const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
+  write_e2e_config(
+      "image-classifier", config_path,
+      {{"model.path", model_path}, {"io.image", image_path}, {"io.fallback_image_url", "null"}});
 
-  auto r = spawn_and_wait(binary, {"--config", config_path}, timeout);
+  auto r = spawn_and_wait(binary, {"--config", config_path.string()}, timeout);
 
   if (r.exit_code != 0) {
     std::cerr << "[FAIL] exit code " << r.exit_code << "\n";

--- a/examples/depth-estimation/depth-estimator/tests/cpp/test_e2e.cpp
+++ b/examples/depth-estimation/depth-estimator/tests/cpp/test_e2e.cpp
@@ -4,7 +4,6 @@
 #include "support/testing/test_process.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -39,18 +38,9 @@ int main(int argc, char** argv) {
     return 1;
 
   const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
-  {
-    std::ofstream config_file(config_path);
-    config_file << "model:\n"
-                << "  path: " << model_path << "\n"
-                << "io:\n"
-                << "  input_dir: " << input_dir << "\n"
-                << "  output_dir: " << out_dir << "\n"
-                << "runtime:\n"
-                << "  infer_size: 518\n"
-                << "  timeout_ms: 20000\n"
-                << "  queue_depth: 4\n";
-  }
+  write_e2e_config(
+      "depth-estimator", config_path,
+      {{"model.path", model_path}, {"io.input_dir", input_dir}, {"io.output_dir", out_dir}});
 
   int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
 

--- a/examples/face-detection/face-detector/tests/cpp/test_e2e.cpp
+++ b/examples/face-detection/face-detector/tests/cpp/test_e2e.cpp
@@ -5,7 +5,6 @@
 #include "support/testing/test_config.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -43,30 +42,12 @@ int main(int argc, char** argv) {
   if (out_dir.empty()) {
     return 1;
   }
-  const double confidence_threshold = e2e_double("face-detector", "decode", "confidence_threshold");
-  const double nms_iou = e2e_double("face-detector", "decode", "nms_iou");
-  const int top_k = e2e_int("face-detector", "decode", "top_k");
-  const int keep_top_k = e2e_int("face-detector", "decode", "keep_top_k");
   const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
-  {
-    std::ofstream config_file(config_path);
-    config_file << "model:\n"
-                << "  path: " << model_path << "\n"
-                << "io:\n"
-                << "  input_dir: " << input_dir << "\n"
-                << "  output_dir: " << out_dir << "\n"
-                << "decode:\n"
-                << "  confidence_threshold: " << confidence_threshold << "\n"
-                << "  nms_iou: " << nms_iou << "\n"
-                << "  top_k: " << top_k << "\n"
-                << "  keep_top_k: " << keep_top_k << "\n"
-                << "  max_draw: 50\n"
-                << "  landmarks: true\n"
-                << "runtime:\n"
-                << "  timeout_ms: 20000\n"
-                << "  profile: false\n"
-                << "  num_runs: 1\n";
-  }
+  write_e2e_config("face-detector", config_path,
+                   {{"model.path", model_path},
+                    {"io.input_dir", input_dir},
+                    {"io.output_dir", out_dir},
+                    {"runtime.num_runs", "1"}});
 
   int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 30000);
 

--- a/examples/object-detection/detr-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/detr-object-detector/tests/cpp/test_e2e.cpp
@@ -5,7 +5,6 @@
 #include "support/testing/test_config.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -42,25 +41,12 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const double confidence_threshold =
-      e2e_double("detr-object-detector", "decode", "confidence_threshold");
   const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
-  {
-    std::ofstream config_file(config_path);
-    config_file << "model:\n"
-                << "  path: " << model_path << "\n"
-                << "io:\n"
-                << "  input_dir: " << input_dir << "\n"
-                << "  output_dir: " << out_dir << "\n"
-                << "decode:\n"
-                << "  confidence_threshold: " << confidence_threshold << "\n"
-                << "  max_draw: 50\n"
-                << "  person_only: false\n"
-                << "runtime:\n"
-                << "  timeout_ms: 20000\n"
-                << "  profile: false\n"
-                << "  num_runs: 1\n";
-  }
+  write_e2e_config("detr-object-detector", config_path,
+                   {{"model.path", model_path},
+                    {"io.input_dir", input_dir},
+                    {"io.output_dir", out_dir},
+                    {"runtime.num_runs", "1"}});
   int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 30000);
 
   auto r = spawn_and_wait(binary, {"--config", config_path.string()}, timeout);

--- a/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
@@ -4,7 +4,6 @@
 #include "support/testing/test_process.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -39,90 +38,21 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const sima_examples::ScalarConfig& common = example_common_config("multi-stream-object-detector");
   const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        : "127.0.0.1";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
-  const bool input_tcp = common.bool_or("input.tcp", true);
-  const int input_latency_ms = common.int_or("input.latency_ms", 100);
-  const int worker_count = common.int_or("runtime.worker_count", 4);
-  const int mailbox_depth = common.int_or("runtime.mailbox_depth", 1);
-  const bool profile = common.bool_or("runtime.profile", false);
-  const int frames = common.int_or("inference.frames", 0);
-  const int fps = common.int_or("inference.fps", 0);
-  const bool video_enabled = common.bool_or("output.video_enabled", true);
-  const std::string video_mode = common.string_or("output.video_mode", "annotated");
-  const int save_every =
-      e2e_int("multi-stream-object-detector", "testing.e2e.output", "save_every");
   const int total_saved_frames =
       e2e_int("multi-stream-object-detector", "testing.e2e.output", "total_saved_frames");
-  const double min_score = e2e_double("multi-stream-object-detector", "inference", "min_score");
-  const double nms_iou = e2e_double("multi-stream-object-detector", "inference", "nms_iou");
-  const int max_detections = e2e_int("multi-stream-object-detector", "inference", "max_detections");
-  {
-    std::ofstream out(config_path);
-    out << "model:\n"
-        << "  path: " << model_path
-        << "\n"
-           "\n"
-           "input:\n"
-           "  tcp: "
-        << (input_tcp ? "true" : "false") << "\n"
-        << "  latency_ms: " << input_latency_ms << "\n"
-        << "\n"
-           "runtime:\n"
-           "  worker_count: "
-        << worker_count
-        << "\n"
-           "  mailbox_depth: "
-        << mailbox_depth
-        << "\n"
-           "  profile: "
-        << (profile ? "true" : "false")
-        << "\n"
-           "\n"
-           "inference:\n"
-           "  frames: "
-        << frames
-        << "\n"
-           "  fps: "
-        << fps << "\n"
-        << "  min_score: " << min_score << "\n"
-        << "  nms_iou: " << nms_iou << "\n"
-        << "  max_detections: " << max_detections << "\n"
-        << "\n"
-           "output:\n"
-           "  insight:\n"
-           "    host: "
-        << insight_host
-        << "\n"
-           "    video_port_base: "
-        << video_port_base
-        << "\n"
-           "    metadata_port_base: "
-        << metadata_port_base
-        << "\n"
-           "  video_enabled: "
-        << (video_enabled ? "true" : "false")
-        << "\n"
-           "  video_mode: "
-        << video_mode
-        << "\n"
-           "  debug_dir: "
-        << output_dir
-        << "\n"
-           "  save_every: "
-        << save_every
-        << "\n"
-           "\n"
-           "streams:\n";
-    for (std::size_t index = 0; index < 2; ++index) {
-      out << "  - " << rtsp_urls[index] << "\n";
-    }
-  }
+  write_e2e_config("multi-stream-object-detector", config_path,
+                   {{"model.path", model_path},
+                    {"output.debug_dir", output_dir},
+                    {"output.insight.host", insight_host},
+                    {"output.insight.video_port_base", std::to_string(video_port_base)},
+                    {"output.insight.metadata_port_base", std::to_string(metadata_port_base)}},
+                   {{"streams", {rtsp_urls[0], rtsp_urls[1]}}});
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},

--- a/examples/object-detection/single-stream-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/single-stream-object-detector/tests/cpp/test_e2e.cpp
@@ -2,10 +2,8 @@
 #include "support/testing/test_process.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
 
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
@@ -36,43 +34,20 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const sima_examples::ScalarConfig& common =
-      example_common_config("single-stream-object-detector");
   const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        : "127.0.0.1";
   const int video_port = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
-  const int save_every =
-      e2e_int("single-stream-object-detector", "testing.e2e.output", "save_every");
   const int total_saved_frames =
       e2e_int("single-stream-object-detector", "testing.e2e.output", "total_saved_frames");
-
-  {
-    std::ofstream config_file(config_path);
-    config_file << "source:\n"
-                << "  rtsp_url: " << rtsp_url << "\n"
-                << "  latency_ms: " << common.int_or("source.latency_ms", 100) << "\n"
-                << "  tcp: " << (common.bool_or("source.tcp", true) ? "true" : "false") << "\n"
-                << "model:\n"
-                << "  path: " << model_path << "\n"
-                << "inference:\n"
-                << "  frames: " << common.int_or("inference.frames", 0) << "\n"
-                << "  min_score: " << common.double_or("inference.min_score", 0.40) << "\n"
-                << "  nms_iou: " << common.double_or("inference.nms_iou", 0.60) << "\n"
-                << "  max_detections: " << common.int_or("inference.max_detections", 24) << "\n"
-                << "runtime:\n"
-                << "  profile: " << (common.bool_or("runtime.profile", false) ? "true" : "false")
-                << "\n"
-                << "  profile_interval: " << common.int_or("runtime.profile_interval", 100) << "\n"
-                << "output:\n"
-                << "  save_dir: " << output_dir << "\n"
-                << "  save_every: " << save_every << "\n"
-                << "  insight:\n"
-                << "    host: " << insight_host << "\n"
-                << "    video_port: " << video_port << "\n"
-                << "    metadata_port: " << metadata_port << "\n";
-  }
+  write_e2e_config("single-stream-object-detector", config_path,
+                   {{"source.rtsp_url", rtsp_url},
+                    {"model.path", model_path},
+                    {"output.save_dir", output_dir},
+                    {"output.insight.host", insight_host},
+                    {"output.insight.video_port", std::to_string(video_port)},
+                    {"output.insight.metadata_port", std::to_string(metadata_port)}});
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   const ProcessResult result = spawn_until_output_files(argv[1], {"--config", config_path.string()},

--- a/examples/object-detection/yolo26-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/yolo26-object-detector/tests/cpp/test_e2e.cpp
@@ -4,7 +4,6 @@
 #include "support/testing/test_config.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -62,29 +61,13 @@ int main(int argc, char** argv) {
   if (out_dir.empty())
     return 1;
 
-  const double score_threshold = e2e_double("yolo26-object-detector", "decode", "score_threshold");
-  const double nms_iou = e2e_double("yolo26-object-detector", "decode", "nms_iou");
-  const int max_detections = e2e_int("yolo26-object-detector", "decode", "max_detections");
   const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
-  {
-    std::ofstream config_file(config_path);
-    config_file << "model:\n"
-                << "  path: " << model_path << "\n"
-                << "  labels: " << labels_file << "\n"
-                << "io:\n"
-                << "  input_dir: " << input_dir << "\n"
-                << "  output_dir: " << out_dir << "\n"
-                << "decode:\n"
-                << "  score_threshold: " << score_threshold << "\n"
-                << "  nms_iou: " << nms_iou << "\n"
-                << "  max_detections: " << max_detections << "\n"
-                << "runtime:\n"
-                << "  timeout_ms: 20000\n"
-                << "  num_runs: 1\n"
-                << "  profile: false\n"
-                << "output:\n"
-                << "  overlay: true\n";
-  }
+  write_e2e_config("yolo26-object-detector", config_path,
+                   {{"model.path", model_path},
+                    {"model.labels", labels_file},
+                    {"io.input_dir", input_dir},
+                    {"io.output_dir", out_dir},
+                    {"runtime.num_runs", "1"}});
 
   int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
 

--- a/examples/segmentation/single-stream-instance-segmenter/tests/cpp/test_e2e.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/tests/cpp/test_e2e.cpp
@@ -3,7 +3,6 @@
 #include "support/testing/test_process.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -38,52 +37,20 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const sima_examples::ScalarConfig& common =
-      example_common_config("single-stream-instance-segmenter");
   const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        : "127.0.0.1";
   const int video_port = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
-  const int save_every =
-      e2e_int("single-stream-instance-segmenter", "testing.e2e.output", "save_every");
   const int total_saved_frames =
       e2e_int("single-stream-instance-segmenter", "testing.e2e.output", "total_saved_frames");
-
-  {
-    std::ofstream config_file(config_path);
-    config_file
-        << "source:\n"
-        << "  rtsp_url: " << rtsp_url << "\n"
-        << "  latency_ms: " << common.int_or("source.latency_ms", 100) << "\n"
-        << "  tcp: " << (common.bool_or("source.tcp", true) ? "true" : "false") << "\n"
-        << "model:\n"
-        << "  path: " << model_path << "\n"
-        << "  labels: "
-        << common.string_or(
-               "model.labels",
-               "examples/segmentation/single-stream-instance-segmenter/src/common/coco_label.txt")
-        << "\n"
-        << "inference:\n"
-        << "  frames: " << common.int_or("inference.frames", 0) << "\n"
-        << "  min_score: " << common.double_or("inference.min_score", 0.55) << "\n"
-        << "  nms_iou: " << common.double_or("inference.nms_iou", 0.60) << "\n"
-        << "  max_detections: " << common.int_or("inference.max_detections", 50) << "\n"
-        << "runtime:\n"
-        << "  profile: " << (common.bool_or("runtime.profile", false) ? "true" : "false") << "\n"
-        << "  profile_interval: " << common.int_or("runtime.profile_interval", 100) << "\n"
-        << "output:\n"
-        << "  save_dir: " << output_dir << "\n"
-        << "  save_every: " << save_every << "\n"
-        << "  mask_alpha: " << common.double_or("output.mask_alpha", 0.55) << "\n"
-        << "  mask_threshold: " << common.double_or("output.mask_threshold", 0.50) << "\n"
-        << "  draw_boxes: " << (common.bool_or("output.draw_boxes", true) ? "true" : "false")
-        << "\n"
-        << "  insight:\n"
-        << "    host: " << insight_host << "\n"
-        << "    video_port: " << video_port << "\n"
-        << "    metadata_port: " << metadata_port << "\n";
-  }
+  write_e2e_config("single-stream-instance-segmenter", config_path,
+                   {{"source.rtsp_url", rtsp_url},
+                    {"model.path", model_path},
+                    {"output.save_dir", output_dir},
+                    {"output.insight.host", insight_host},
+                    {"output.insight.video_port", std::to_string(video_port)},
+                    {"output.insight.metadata_port", std::to_string(metadata_port)}});
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   const ProcessResult result = spawn_until_output_files(argv[1], {"--config", config_path.string()},

--- a/examples/segmentation/yolov8-instance-segmenter/tests/cpp/test_e2e.cpp
+++ b/examples/segmentation/yolov8-instance-segmenter/tests/cpp/test_e2e.cpp
@@ -4,7 +4,6 @@
 #include "support/testing/test_config.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -38,33 +37,14 @@ int main(int argc, char** argv) {
   if (out_dir.empty())
     return 1;
 
-  const double score_threshold =
-      e2e_double("yolov8-instance-segmenter", "decode", "score_threshold");
-  const double nms_iou = e2e_double("yolov8-instance-segmenter", "decode", "nms_iou");
-  const int max_detections = e2e_int("yolov8-instance-segmenter", "decode", "max_detections");
-  const std::string config_path = (fs::path(out_dir).parent_path() / "config.yaml").string();
-  {
-    std::ofstream config(config_path);
-    config << "model:\n"
-           << "  path: " << model_path << "\n"
-           << "io:\n"
-           << "  input_dir: " << input_dir << "\n"
-           << "  output_dir: " << out_dir << "\n"
-           << "runtime:\n"
-           << "  infer_size: 640\n"
-           << "  timeout_ms: 20000\n"
-           << "  queue_depth: 8\n"
-           << "decode:\n"
-           << "  score_threshold: " << score_threshold << "\n"
-           << "  nms_iou: " << nms_iou << "\n"
-           << "  max_detections: " << max_detections << "\n"
-           << "visualization:\n"
-           << "  mask_alpha: 0.65\n";
-  }
+  const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
+  write_e2e_config(
+      "yolov8-instance-segmenter", config_path,
+      {{"model.path", model_path}, {"io.input_dir", input_dir}, {"io.output_dir", out_dir}});
 
   int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
 
-  auto r = spawn_and_wait(binary, {"--config", config_path}, timeout);
+  auto r = spawn_and_wait(binary, {"--config", config_path.string()}, timeout);
 
   const int output_files = count_output_files(out_dir);
 

--- a/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
+++ b/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
@@ -2,7 +2,6 @@
 #include "support/testing/test_process.h"
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -39,92 +38,21 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const sima_examples::ScalarConfig& common = example_common_config("multi-stream-people-tracker");
   const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
                                        : "127.0.0.1";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
-  const bool input_tcp = common.bool_or("input.tcp", true);
-  const int input_latency_ms = common.int_or("input.latency_ms", 100);
-  const int frames = common.int_or("inference.frames", 0);
-  const int fps = common.int_or("inference.fps", 0);
-  const int bitrate_kbps = common.int_or("inference.bitrate_kbps", 2500);
-  const bool profile = common.bool_or("inference.profile", false);
-  const int person_class_id = common.int_or("inference.person_class_id", 0);
-  const std::string video_mode = common.string_or("output.video_mode", "clean");
-  const int save_every = e2e_int("multi-stream-people-tracker", "testing.e2e.output", "save_every");
   const int total_saved_frames =
       e2e_int("multi-stream-people-tracker", "testing.e2e.output", "total_saved_frames");
-  const double detection_threshold =
-      e2e_double("multi-stream-people-tracker", "inference", "detection_threshold");
-  const double nms_iou_threshold =
-      e2e_double("multi-stream-people-tracker", "inference", "nms_iou_threshold");
-  const int top_k = e2e_int("multi-stream-people-tracker", "inference", "top_k");
-  const double tracker_iou_threshold =
-      e2e_double("multi-stream-people-tracker", "tracking", "iou_threshold");
-  const int tracker_max_missing =
-      e2e_int("multi-stream-people-tracker", "tracking", "max_missing_frames");
-  {
-    std::ofstream out(config_path);
-    out << "model: " << model_path
-        << "\n"
-           "\n"
-           "input:\n"
-           "  tcp: "
-        << (input_tcp ? "true" : "false") << "\n"
-        << "  latency_ms: " << input_latency_ms << "\n"
-        << "\n"
-           "inference:\n"
-           "  frames: "
-        << frames
-        << "\n"
-           "  fps: "
-        << fps
-        << "\n"
-           "  bitrate_kbps: "
-        << bitrate_kbps
-        << "\n"
-           "  profile: "
-        << (profile ? "true" : "false")
-        << "\n"
-           "  person_class_id: "
-        << person_class_id << "\n"
-        << "  detection_threshold: " << detection_threshold << "\n"
-        << "  nms_iou_threshold: " << nms_iou_threshold << "\n"
-        << "  top_k: " << top_k << "\n"
-        << "\n"
-           "tracking:\n"
-        << "  iou_threshold: " << tracker_iou_threshold << "\n"
-        << "  max_missing_frames: " << tracker_max_missing << "\n"
-        << "\n"
-           "output:\n"
-           "  insight:\n"
-           "    host: "
-        << insight_host
-        << "\n"
-           "    video_port_base: "
-        << video_port_base
-        << "\n"
-           "    metadata_port_base: "
-        << metadata_port_base
-        << "\n"
-           "  video_mode: "
-        << video_mode
-        << "\n"
-           "  debug_dir: "
-        << output_dir
-        << "\n"
-           "  save_every: "
-        << save_every
-        << "\n"
-           "\n"
-           "streams:\n";
-    for (std::size_t index = 0; index < 2; ++index) {
-      out << "  - " << rtsp_urls[index] << "\n";
-    }
-  }
+  write_e2e_config("multi-stream-people-tracker", config_path,
+                   {{"model.path", model_path},
+                    {"output.debug_dir", output_dir},
+                    {"output.insight.host", insight_host},
+                    {"output.insight.video_port_base", std::to_string(video_port_base)},
+                    {"output.insight.metadata_port_base", std::to_string(metadata_port_base)}},
+                   {{"streams", {rtsp_urls[0], rtsp_urls[1]}}});
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},

--- a/support/runtime/config_utils.cpp
+++ b/support/runtime/config_utils.cpp
@@ -193,6 +193,10 @@ bool ScalarConfig::bool_or(const std::string& key, bool default_value) const {
   throw std::runtime_error(key + " must be true or false");
 }
 
+std::map<std::string, std::string> ScalarConfig::scalars() const {
+  return {scalars_.begin(), scalars_.end()};
+}
+
 std::filesystem::path default_config_path(const char* source_dir) {
   return std::filesystem::path(source_dir) / ".." / "common" / "config.yaml";
 }

--- a/support/runtime/config_utils.h
+++ b/support/runtime/config_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -17,6 +18,7 @@ public:
   [[nodiscard]] int int_or(const std::string& key, int default_value) const;
   [[nodiscard]] double double_or(const std::string& key, double default_value) const;
   [[nodiscard]] bool bool_or(const std::string& key, bool default_value) const;
+  [[nodiscard]] std::map<std::string, std::string> scalars() const;
 
 private:
   std::unordered_map<std::string, std::string> scalars_;

--- a/support/testing/test_config.cpp
+++ b/support/testing/test_config.cpp
@@ -1,6 +1,7 @@
 #include "support/testing/test_config.h"
 
 #include <cstdlib>
+#include <fstream>
 #include <filesystem>
 #include <map>
 #include <stdexcept>
@@ -55,6 +56,118 @@ std::string scoped_model_file_from_env(const std::string& example_name) {
     }
   }
   return {};
+}
+
+bool starts_with(const std::string& value, const std::string& prefix) {
+  return value.rfind(prefix, 0) == 0;
+}
+
+std::vector<std::string> split_dot_key(const std::string& key) {
+  std::vector<std::string> parts;
+  std::istringstream stream(key);
+  std::string part;
+  while (std::getline(stream, part, '.')) {
+    if (part.empty()) {
+      throw std::runtime_error("invalid empty config key segment in: " + key);
+    }
+    parts.push_back(part);
+  }
+  return parts;
+}
+
+std::string quote_scalar(const std::string& value) {
+  std::string quoted = "'";
+  for (const char c : value) {
+    if (c == '\'') {
+      quoted += "''";
+    } else {
+      quoted.push_back(c);
+    }
+  }
+  quoted += "'";
+  return quoted;
+}
+
+struct ConfigNode {
+  std::map<std::string, ConfigNode> children;
+  std::vector<std::string> list;
+  std::string value;
+  bool has_value = false;
+};
+
+ConfigNode& node_for_key(ConfigNode& root, const std::string& key) {
+  ConfigNode* node = &root;
+  for (const auto& part : split_dot_key(key)) {
+    node = &node->children[part];
+  }
+  return *node;
+}
+
+void write_node(std::ostream& out, const ConfigNode& node, int indent) {
+  const std::string spaces(static_cast<std::size_t>(indent), ' ');
+  for (const auto& [key, child] : node.children) {
+    if (!child.list.empty()) {
+      out << spaces << key << ":\n";
+      for (const auto& value : child.list) {
+        out << spaces << "  - " << quote_scalar(value) << "\n";
+      }
+    } else if (child.has_value) {
+      out << spaces << key << ": " << quote_scalar(child.value) << "\n";
+    } else {
+      out << spaces << key << ":\n";
+      write_node(out, child, indent + 2);
+    }
+  }
+}
+
+std::map<std::string, std::string> runtime_scalars_for_e2e(const ScalarConfig& common) {
+  std::map<std::string, std::string> values = common.scalars();
+  std::map<std::string, std::string> e2e_overrides;
+
+  for (const auto& [key, value] : values) {
+    constexpr const char* prefix = "testing.e2e.";
+    if (!starts_with(key, prefix)) {
+      continue;
+    }
+
+    const std::string runtime_key = key.substr(std::string(prefix).size());
+    if (runtime_key == "output.total_saved_frames") {
+      continue;
+    }
+    e2e_overrides[runtime_key] = value;
+  }
+
+  for (auto it = values.begin(); it != values.end();) {
+    if (starts_with(it->first, "testing.")) {
+      it = values.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  for (const auto& [key, value] : e2e_overrides) {
+    values[key] = value;
+  }
+  return values;
+}
+
+void write_nested_config(std::ostream& out, const ConfigScalars& values,
+                         const ConfigLists& list_values) {
+  ConfigNode root;
+  for (const auto& [key, value] : values) {
+    ConfigNode& node = node_for_key(root, key);
+    node.value = value;
+    node.has_value = true;
+    node.children.clear();
+    node.list.clear();
+  }
+  for (const auto& [key, values] : list_values) {
+    ConfigNode& node = node_for_key(root, key);
+    node.list = values;
+    node.has_value = false;
+    node.children.clear();
+  }
+  write_node(out, root, 0);
 }
 
 } // namespace
@@ -128,6 +241,29 @@ bool e2e_bool(const std::string& example_name, const std::string& section, const
               bool default_value) {
   return example_common_config(example_name)
       .bool_or(full_key(example_name, section, key), default_value);
+}
+
+std::filesystem::path write_e2e_config(const std::string& example_name,
+                                       const std::filesystem::path& config_path,
+                                       const ConfigScalars& overrides,
+                                       const ConfigLists& list_overrides) {
+  std::map<std::string, std::string> values =
+      runtime_scalars_for_e2e(example_common_config(example_name));
+  for (const auto& [key, value] : overrides) {
+    values[key] = value;
+  }
+  for (const auto& [key, list] : list_overrides) {
+    static_cast<void>(list);
+    values.erase(key);
+  }
+
+  std::filesystem::create_directories(config_path.parent_path());
+  std::ofstream out(config_path);
+  if (!out.is_open()) {
+    throw std::runtime_error("failed to write e2e config: " + config_path.string());
+  }
+  write_nested_config(out, values, list_overrides);
+  return config_path;
 }
 
 } // namespace sima_examples::testing

--- a/support/testing/test_config.h
+++ b/support/testing/test_config.h
@@ -3,9 +3,14 @@
 #include "support/runtime/config_utils.h"
 
 #include <filesystem>
+#include <map>
 #include <string>
+#include <vector>
 
 namespace sima_examples::testing {
+
+using ConfigScalars = std::map<std::string, std::string>;
+using ConfigLists = std::map<std::string, std::vector<std::string>>;
 
 // Locate examples/*/<example_name>/src/common/config.yaml from the apps root.
 std::filesystem::path example_common_config_path(const std::string& example_name);
@@ -25,5 +30,12 @@ int e2e_int(const std::string& example_name, const std::string& section, const s
 
 bool e2e_bool(const std::string& example_name, const std::string& section, const std::string& key,
               bool default_value);
+
+// Write an e2e runtime config by starting from src/common/config.yaml and applying
+// only test-harness overrides. The generated config omits testing.* keys.
+std::filesystem::path write_e2e_config(const std::string& example_name,
+                                       const std::filesystem::path& config_path,
+                                       const ConfigScalars& overrides,
+                                       const ConfigLists& list_overrides = {});
 
 } // namespace sima_examples::testing


### PR DESCRIPTION
## Summary

Add a shared C++ e2e config writer so C++ tests use the same source-of-truth flow as Python e2e tests:

- start from each example's `src/common/config.yaml`
- apply `testing.e2e.*` runtime overrides
- omit test-harness-only values such as `testing.e2e.output.total_saved_frames`
- apply explicit test overrides for model paths, input/output paths, RTSP URLs, and Insight ports
- write generated nested YAML config files for the runtime

This removes duplicated manual YAML reconstruction from C++ e2e tests and reduces drift between customer-facing example configs and test configs.

## Why

C++ e2e tests were manually rebuilding config files with `std::ofstream`. That meant every config field had to be duplicated in each test, while Python e2e already used a generic merged-config writer.

This keeps C++ and Python e2e behavior aligned without changing any example runtime schema.

## Scope

- Adds `write_e2e_config()` to `support/testing/test_config.*`
- Adds a sorted scalar accessor to `ScalarConfig`
- Converts C++ e2e tests to call the shared writer
- Leaves existing `common/config.yaml` structure unchanged
- Leaves Python e2e unchanged
- Leaves runtime behavior unchanged

## Validation

Ran locally:

```bash
git diff --check
python3 tests/utils/test_scope.py validate --quiet
clang++ -std=c++20 -I. -fsyntax-only support/runtime/config_utils.cpp support/testing/test_config.cpp
```

Also ran `clang-format` on all changed C++/header files.

Closes #201
