### PR TITLE
Link apps C++ examples against shared Neat core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,42 +11,49 @@ option(SIMANEAT_APPS_BUILD_CPP "Build C++ examples" ON)
 option(SIMANEAT_APPS_BUILD_OPTIVIEW_SUPPORT "Build legacy OptiView support library" OFF)
 
 function(_sima_neat_apps_ensure_neat_target)
-  if (TARGET SimaNeat::sima_neat)
+  if (TARGET SimaNeatApps::sima_neat)
     return()
   endif()
 
   find_package(SimaNeat CONFIG QUIET)
-  if (TARGET SimaNeat::sima_neat)
-    return()
+  if (TARGET SimaNeat::sima_neat_shared)
+    set(_core_target SimaNeat::sima_neat_shared)
+  elseif (TARGET SimaNeat::sima_neat)
+    set(_core_target SimaNeat::sima_neat)
+  else()
+    set(_core_root "${CMAKE_CURRENT_LIST_DIR}/../core")
+    set(_core_lib "${_core_root}/build/libsima_neat.so")
+    set(_core_include "${_core_root}/include")
+    if (NOT EXISTS "${_core_lib}" OR NOT EXISTS "${_core_include}")
+      message(FATAL_ERROR
+        "Could not find a usable SimaNeat package or local core build. "
+        "Expected ${_core_lib} and ${_core_include}.")
+    endif()
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GST REQUIRED IMPORTED_TARGET
+      gstreamer-1.0
+      gstreamer-app-1.0
+      gstreamer-video-1.0
+      gstreamer-sdp-1.0
+      gstreamer-rtsp-server-1.0
+      glib-2.0
+    )
+    pkg_check_modules(OPENCV REQUIRED IMPORTED_TARGET opencv4)
+
+    add_library(SimaNeat::sima_neat_shared SHARED IMPORTED GLOBAL)
+    set_target_properties(SimaNeat::sima_neat_shared PROPERTIES
+      IMPORTED_LOCATION "${_core_lib}"
+      INTERFACE_COMPILE_DEFINITIONS "SIMA_WITH_OPENCV;SIMA_HAS_SIMAAI_POOL=1"
+      INTERFACE_INCLUDE_DIRECTORIES "${_core_include};${_core_include}/pipeline"
+      INTERFACE_LINK_LIBRARIES "PkgConfig::GST;PkgConfig::OPENCV;gstsimaallocator;gstsimaaibufferpool"
+    )
+    set(_core_target SimaNeat::sima_neat_shared)
   endif()
 
-  set(_core_root "${CMAKE_CURRENT_LIST_DIR}/../core")
-  set(_core_lib "${_core_root}/build/libsima_neat.a")
-  set(_core_include "${_core_root}/include")
-  if (NOT EXISTS "${_core_lib}" OR NOT EXISTS "${_core_include}")
-    message(FATAL_ERROR
-      "Could not find a usable SimaNeat package or local core build. "
-      "Expected ${_core_lib} and ${_core_include}.")
-  endif()
-
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(GST REQUIRED IMPORTED_TARGET
-    gstreamer-1.0
-    gstreamer-app-1.0
-    gstreamer-video-1.0
-    gstreamer-sdp-1.0
-    gstreamer-rtsp-server-1.0
-    glib-2.0
-  )
-  pkg_check_modules(OPENCV REQUIRED IMPORTED_TARGET opencv4)
-
-  add_library(SimaNeat::sima_neat STATIC IMPORTED GLOBAL)
-  set_target_properties(SimaNeat::sima_neat PROPERTIES
-    IMPORTED_LOCATION "${_core_lib}"
-    INTERFACE_COMPILE_DEFINITIONS "SIMA_WITH_OPENCV;SIMA_HAS_SIMAAI_POOL=1"
-    INTERFACE_INCLUDE_DIRECTORIES "${_core_include};${_core_include}/pipeline"
-    INTERFACE_LINK_LIBRARIES "PkgConfig::GST;PkgConfig::OPENCV;gstsimaallocator;gstsimaaibufferpool"
-  )
+  add_library(sima_neat_apps_neat_core INTERFACE)
+  add_library(SimaNeatApps::sima_neat ALIAS sima_neat_apps_neat_core)
+  target_link_libraries(sima_neat_apps_neat_core INTERFACE "${_core_target}")
 endfunction()
 
 message(STATUS "Configuring SimaNeatApps")

--- a/cmake/ExampleModule.cmake
+++ b/cmake/ExampleModule.cmake
@@ -17,42 +17,49 @@ function(_sima_neat_apps_find_sources out_var module_dir)
 endfunction()
 
 function(_sima_neat_apps_ensure_neat_target apps_root)
-  if (TARGET SimaNeat::sima_neat)
+  if (TARGET SimaNeatApps::sima_neat)
     return()
   endif()
 
   find_package(SimaNeat CONFIG QUIET)
-  if (TARGET SimaNeat::sima_neat)
-    return()
+  if (TARGET SimaNeat::sima_neat_shared)
+    set(_core_target SimaNeat::sima_neat_shared)
+  elseif (TARGET SimaNeat::sima_neat)
+    set(_core_target SimaNeat::sima_neat)
+  else()
+    set(_core_root "${apps_root}/../core")
+    set(_core_lib "${_core_root}/build/libsima_neat.so")
+    set(_core_include "${_core_root}/include")
+    if (NOT EXISTS "${_core_lib}" OR NOT EXISTS "${_core_include}")
+      message(FATAL_ERROR
+        "Could not find a usable SimaNeat package or local core build. "
+        "Expected ${_core_lib} and ${_core_include}.")
+    endif()
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GST REQUIRED IMPORTED_TARGET
+      gstreamer-1.0
+      gstreamer-app-1.0
+      gstreamer-video-1.0
+      gstreamer-sdp-1.0
+      gstreamer-rtsp-server-1.0
+      glib-2.0
+    )
+    pkg_check_modules(OPENCV REQUIRED IMPORTED_TARGET opencv4)
+
+    add_library(SimaNeat::sima_neat_shared SHARED IMPORTED GLOBAL)
+    set_target_properties(SimaNeat::sima_neat_shared PROPERTIES
+      IMPORTED_LOCATION "${_core_lib}"
+      INTERFACE_COMPILE_DEFINITIONS "SIMA_WITH_OPENCV;SIMA_HAS_SIMAAI_POOL=1"
+      INTERFACE_INCLUDE_DIRECTORIES "${_core_include};${_core_include}/pipeline"
+      INTERFACE_LINK_LIBRARIES "PkgConfig::GST;PkgConfig::OPENCV;gstsimaallocator;gstsimaaibufferpool"
+    )
+    set(_core_target SimaNeat::sima_neat_shared)
   endif()
 
-  set(_core_root "${apps_root}/../core")
-  set(_core_lib "${_core_root}/build/libsima_neat.a")
-  set(_core_include "${_core_root}/include")
-  if (NOT EXISTS "${_core_lib}" OR NOT EXISTS "${_core_include}")
-    message(FATAL_ERROR
-      "Could not find a usable SimaNeat package or local core build. "
-      "Expected ${_core_lib} and ${_core_include}.")
-  endif()
-
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(GST REQUIRED IMPORTED_TARGET
-    gstreamer-1.0
-    gstreamer-app-1.0
-    gstreamer-video-1.0
-    gstreamer-sdp-1.0
-    gstreamer-rtsp-server-1.0
-    glib-2.0
-  )
-  pkg_check_modules(OPENCV REQUIRED IMPORTED_TARGET opencv4)
-
-  add_library(SimaNeat::sima_neat STATIC IMPORTED GLOBAL)
-  set_target_properties(SimaNeat::sima_neat PROPERTIES
-    IMPORTED_LOCATION "${_core_lib}"
-    INTERFACE_COMPILE_DEFINITIONS "SIMA_WITH_OPENCV;SIMA_HAS_SIMAAI_POOL=1"
-    INTERFACE_INCLUDE_DIRECTORIES "${_core_include};${_core_include}/pipeline"
-    INTERFACE_LINK_LIBRARIES "PkgConfig::GST;PkgConfig::OPENCV;gstsimaallocator;gstsimaaibufferpool"
-  )
+  add_library(sima_neat_apps_neat_core INTERFACE)
+  add_library(SimaNeatApps::sima_neat ALIAS sima_neat_apps_neat_core)
+  target_link_libraries(sima_neat_apps_neat_core INTERFACE "${_core_target}")
 endfunction()
 
 function(_sima_neat_apps_ensure_support_runtime apps_root)
@@ -72,7 +79,7 @@ function(_sima_neat_apps_ensure_support_runtime apps_root)
 
   target_link_libraries(sima_neat_apps_support_runtime
     PUBLIC
-      SimaNeat::sima_neat
+      SimaNeatApps::sima_neat
       nlohmann_json::nlohmann_json
   )
 
@@ -97,7 +104,7 @@ function(_sima_neat_apps_ensure_support_optiview apps_root)
   target_link_libraries(sima_neat_apps_support_optiview
     PUBLIC
       SimaNeatApps::support_runtime
-      SimaNeat::sima_neat
+      SimaNeatApps::sima_neat
   )
 
   target_include_directories(sima_neat_apps_support_optiview
@@ -280,7 +287,7 @@ function(sima_neat_apps_module example_name)
 
   target_link_libraries(${example_name}
     PRIVATE
-      SimaNeat::sima_neat
+      SimaNeatApps::sima_neat
       SimaNeatApps::support_runtime
   )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,7 +18,7 @@ function(sima_neat_apps_add_example example_name)
 
   target_link_libraries("${target_name}"
     PRIVATE
-      SimaNeat::sima_neat
+      SimaNeatApps::sima_neat
       SimaNeatApps::support_runtime
   )
 

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/CMakeLists.txt
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/CMakeLists.txt
@@ -11,12 +11,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/ExampleModule.cmake")
 
 get_filename_component(APPS_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
-set(MODALIX_TOOLCHAIN_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu")
-set(MODALIX_TOOLCHAIN_USR_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib")
-set(MODALIX_NEAT_PLUGIN_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/neat/gst-plugins")
-set(MODALIX_NEAT_RUNTIME_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/neat/runtime")
-set(MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/sima-neat/gst-plugins")
-if (NOT TARGET SimaNeat::sima_neat)
+if (NOT TARGET SimaNeatApps::sima_neat)
   _sima_neat_apps_ensure_neat_target("${APPS_ROOT}")
 endif()
 if (NOT TARGET SimaNeatApps::support_runtime)
@@ -33,7 +28,7 @@ add_library(multi_stream_object_detector_lib STATIC
 )
 target_link_libraries(multi_stream_object_detector_lib
   PUBLIC
-    SimaNeat::sima_neat
+    SimaNeatApps::sima_neat
     SimaNeatApps::support_runtime
 )
 target_include_directories(multi_stream_object_detector_lib
@@ -62,46 +57,4 @@ if (TARGET multi-stream-object-detector_unit_test)
     PRIVATE
       multi_stream_object_detector_lib
   )
-endif()
-
-foreach(target_name
-    multi_stream_object_detector_lib
-    "${MULTISTREAM_OBJECT_DETECTION_INSIGHT_TARGET}"
-    multi-stream-object-detector_unit_test
-    multi-stream-object-detector_e2e_test)
-  if (TARGET "${target_name}" AND EXISTS "${MODALIX_TOOLCHAIN_LIB_DIR}")
-    set_target_properties("${target_name}" PROPERTIES
-      BUILD_RPATH "${MODALIX_TOOLCHAIN_LIB_DIR}"
-      INSTALL_RPATH "${MODALIX_TOOLCHAIN_LIB_DIR}"
-    )
-  endif()
-endforeach()
-
-if (BUILD_TESTING AND EXISTS "${MODALIX_TOOLCHAIN_LIB_DIR}")
-  set(MODALIX_TEST_LD_LIBRARY_PATH "${MODALIX_TOOLCHAIN_LIB_DIR}")
-  if (EXISTS "${MODALIX_TOOLCHAIN_USR_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_TOOLCHAIN_USR_LIB_DIR}")
-  endif()
-  if (EXISTS "${MODALIX_NEAT_RUNTIME_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_NEAT_RUNTIME_LIB_DIR}")
-  endif()
-  if (EXISTS "${MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR}")
-  endif()
-  string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":$ENV{LD_LIBRARY_PATH}")
-
-  set(MODALIX_TEST_ENV "LD_LIBRARY_PATH=${MODALIX_TEST_LD_LIBRARY_PATH}")
-  if (EXISTS "${MODALIX_NEAT_PLUGIN_DIR}")
-    list(APPEND MODALIX_TEST_ENV "SIMA_GST_PLUGIN_DIR=${MODALIX_NEAT_PLUGIN_DIR}")
-  endif()
-  if (TEST multi-stream-object-detector.unit)
-    set_tests_properties(multi-stream-object-detector.unit PROPERTIES
-      ENVIRONMENT "${MODALIX_TEST_ENV}"
-    )
-  endif()
-  if (TEST multi-stream-object-detector.e2e)
-    set_tests_properties(multi-stream-object-detector.e2e PROPERTIES
-      ENVIRONMENT "${MODALIX_TEST_ENV}"
-    )
-  endif()
 endif()

--- a/examples/object-detection/single-stream-object-detector/src/cpp/CMakeLists.txt
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/CMakeLists.txt
@@ -10,12 +10,6 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/ExampleModule.cmake")
 
-set(MODALIX_TOOLCHAIN_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu")
-set(MODALIX_TOOLCHAIN_USR_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib")
-set(MODALIX_NEAT_PLUGIN_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/neat/gst-plugins")
-set(MODALIX_NEAT_RUNTIME_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/neat/runtime")
-set(MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/sima-neat/gst-plugins")
-
 sima_neat_apps_module(
   "single-stream-object-detector"
   OUTPUT_TARGET_VAR YOLO26_ONE_RTSP_INSIGHT_TARGET
@@ -32,45 +26,4 @@ if (BUILD_TESTING)
     WILL_FAIL TRUE
     LABELS "unit"
   )
-endif()
-
-foreach(target_name
-    "${YOLO26_ONE_RTSP_INSIGHT_TARGET}"
-    single-stream-object-detector_unit_test
-    single-stream-object-detector_e2e_test)
-  if (TARGET "${target_name}" AND EXISTS "${MODALIX_TOOLCHAIN_LIB_DIR}")
-    set_target_properties("${target_name}" PROPERTIES
-      BUILD_RPATH "${MODALIX_TOOLCHAIN_LIB_DIR}"
-      INSTALL_RPATH "${MODALIX_TOOLCHAIN_LIB_DIR}"
-    )
-  endif()
-endforeach()
-
-if (BUILD_TESTING AND EXISTS "${MODALIX_TOOLCHAIN_LIB_DIR}")
-  set(MODALIX_TEST_LD_LIBRARY_PATH "${MODALIX_TOOLCHAIN_LIB_DIR}")
-  if (EXISTS "${MODALIX_TOOLCHAIN_USR_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_TOOLCHAIN_USR_LIB_DIR}")
-  endif()
-  if (EXISTS "${MODALIX_NEAT_RUNTIME_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_NEAT_RUNTIME_LIB_DIR}")
-  endif()
-  if (EXISTS "${MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR}")
-  endif()
-  string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":$ENV{LD_LIBRARY_PATH}")
-
-  set(MODALIX_TEST_ENV "LD_LIBRARY_PATH=${MODALIX_TEST_LD_LIBRARY_PATH}")
-  if (EXISTS "${MODALIX_NEAT_PLUGIN_DIR}")
-    list(APPEND MODALIX_TEST_ENV "SIMA_GST_PLUGIN_DIR=${MODALIX_NEAT_PLUGIN_DIR}")
-  endif()
-  foreach(test_name
-      single-stream-object-detector.metadata_json_e2e
-      single-stream-object-detector.unit
-      single-stream-object-detector.requires_rtsp)
-    if (TEST "${test_name}")
-      set_tests_properties("${test_name}" PROPERTIES
-        ENVIRONMENT "${MODALIX_TEST_ENV}"
-      )
-    endif()
-  endforeach()
 endif()

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/CMakeLists.txt
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/CMakeLists.txt
@@ -11,13 +11,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/ExampleModule.cmake")
 
 get_filename_component(APPS_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
-set(MODALIX_TOOLCHAIN_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu")
-set(MODALIX_TOOLCHAIN_USR_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib")
-set(MODALIX_NEAT_PLUGIN_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/neat/gst-plugins")
-set(MODALIX_NEAT_RUNTIME_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/neat/runtime")
-set(MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR "/opt/toolchain/aarch64/modalix/usr/lib/sima-neat/gst-plugins")
-
-if (NOT TARGET SimaNeat::sima_neat)
+if (NOT TARGET SimaNeatApps::sima_neat)
   _sima_neat_apps_ensure_neat_target("${APPS_ROOT}")
 endif()
 if (NOT TARGET SimaNeatApps::support_runtime)
@@ -34,7 +28,7 @@ add_library(multi_stream_people_tracker_lib STATIC
 )
 target_link_libraries(multi_stream_people_tracker_lib
   PUBLIC
-    SimaNeat::sima_neat
+    SimaNeatApps::sima_neat
     SimaNeatApps::support_runtime
 )
 target_include_directories(multi_stream_people_tracker_lib
@@ -65,46 +59,4 @@ if (TARGET multi-stream-people-tracker_unit_test)
     PRIVATE
       multi_stream_people_tracker_lib
   )
-endif()
-
-foreach(target_name
-    multi_stream_people_tracker_lib
-    "${MULTI_CAMERA_PEOPLE_TRACKING_TARGET}"
-    multi-stream-people-tracker_unit_test
-    multi-stream-people-tracker_e2e_test)
-  if (TARGET "${target_name}" AND EXISTS "${MODALIX_TOOLCHAIN_LIB_DIR}")
-    set_target_properties("${target_name}" PROPERTIES
-      BUILD_RPATH "${MODALIX_TOOLCHAIN_LIB_DIR}"
-      INSTALL_RPATH "${MODALIX_TOOLCHAIN_LIB_DIR}"
-    )
-  endif()
-endforeach()
-
-if (BUILD_TESTING AND EXISTS "${MODALIX_TOOLCHAIN_LIB_DIR}")
-  set(MODALIX_TEST_LD_LIBRARY_PATH "${MODALIX_TOOLCHAIN_LIB_DIR}")
-  if (EXISTS "${MODALIX_TOOLCHAIN_USR_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_TOOLCHAIN_USR_LIB_DIR}")
-  endif()
-  if (EXISTS "${MODALIX_NEAT_RUNTIME_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_NEAT_RUNTIME_LIB_DIR}")
-  endif()
-  if (EXISTS "${MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR}")
-    string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":${MODALIX_SIMA_NEAT_PLUGIN_LIB_DIR}")
-  endif()
-  string(APPEND MODALIX_TEST_LD_LIBRARY_PATH ":$ENV{LD_LIBRARY_PATH}")
-
-  set(MODALIX_TEST_ENV "LD_LIBRARY_PATH=${MODALIX_TEST_LD_LIBRARY_PATH}")
-  if (EXISTS "${MODALIX_NEAT_PLUGIN_DIR}")
-    list(APPEND MODALIX_TEST_ENV "SIMA_GST_PLUGIN_DIR=${MODALIX_NEAT_PLUGIN_DIR}")
-  endif()
-  if (TEST multi-stream-people-tracker.unit)
-    set_tests_properties(multi-stream-people-tracker.unit PROPERTIES
-      ENVIRONMENT "${MODALIX_TEST_ENV}"
-    )
-  endif()
-  if (TEST multi-stream-people-tracker.e2e)
-    set_tests_properties(multi-stream-people-tracker.e2e PROPERTIES
-      ENVIRONMENT "${MODALIX_TEST_ENV}"
-    )
-  endif()
 endif()

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(SimaNeatApps::support_runtime ALIAS sima_neat_apps_support_runtime)
 
 target_link_libraries(sima_neat_apps_support_runtime
   PUBLIC
-    SimaNeat::sima_neat
+    SimaNeatApps::sima_neat
 )
 
 target_link_libraries(sima_neat_apps_support_runtime PUBLIC nlohmann_json::nlohmann_json)
@@ -26,7 +26,7 @@ if (SIMANEAT_APPS_BUILD_OPTIVIEW_SUPPORT)
   target_link_libraries(sima_neat_apps_support_optiview
     PUBLIC
       SimaNeatApps::support_runtime
-      SimaNeat::sima_neat
+      SimaNeatApps::sima_neat
   )
   target_include_directories(sima_neat_apps_support_optiview
     PUBLIC


### PR DESCRIPTION
## Summary

Link C++ apps examples against the shared Neat core library instead of embedding the static core archive.

This keeps the apps repo focused on example binaries and lets the core/runtime packages own shared-library discovery. Runtime loader paths are intentionally not worked around in apps; they should be handled by the core/internals package fix.

## Changes

- Add an apps-local `SimaNeatApps::sima_neat` alias that prefers `SimaNeat::sima_neat_shared`.
- Keep a local shared-core fallback for source builds that use `../core/build/libsima_neat.so`.
- Switch apps support libraries and example targets to the apps-local alias.
- Remove per-example `/opt/toolchain/...` RPATH and `LD_LIBRARY_PATH` test overrides from multistream/RTSP examples.

## Validation

- Built all C++ examples/tests in the Neat SDK:
  ```bash
  ./build.sh --build-dir build-test/build-vscode-tests --clean
  ```
- Verified representative binaries now dynamically depend on `libsima_neat.so.2`:
  ```bash
  aarch64-linux-gnu-readelf -d build-test/build-vscode-tests/examples/object-detection/yolo26-object-detector/yolo26-object-detector | grep NEEDED
  ```
- Ran C++ unit tests on Modalix with temporary runtime loader paths while the package-side loader fix lands:
  ```bash
  ctest -L unit --output-on-failure
  ```
  Result: 11/11 passed.
- Ran lightweight repo checks:
  ```bash
  git diff --check
  python3 tests/utils/test_scope.py validate --quiet
  bash -n build.sh scripts/install-neat-apps.sh scripts/install-vulcan-apps-package.sh
  ```

Closes #217
