### PR TITLE
Optimize single-stream detector graph topology

### DIFF
--- a/examples/object-detection/single-stream-object-detector/src/common/coco_label.txt
+++ b/examples/object-detection/single-stream-object-detector/src/common/coco_label.txt
@@ -1,0 +1,80 @@
+person
+bicycle
+car
+motorcycle
+airplane
+bus
+train
+truck
+boat
+traffic light
+fire hydrant
+stop sign
+parking meter
+bench
+bird
+cat
+dog
+horse
+sheep
+cow
+elephant
+bear
+zebra
+giraffe
+backpack
+umbrella
+handbag
+tie
+suitcase
+frisbee
+skis
+snowboard
+sports ball
+kite
+baseball bat
+baseball glove
+skateboard
+surfboard
+tennis racket
+bottle
+wine glass
+cup
+fork
+knife
+spoon
+bowl
+banana
+apple
+sandwich
+orange
+broccoli
+carrot
+hot dog
+pizza
+donut
+cake
+chair
+couch
+potted plant
+bed
+dining table
+toilet
+tv
+laptop
+mouse
+remote
+keyboard
+cell phone
+microwave
+oven
+toaster
+sink
+refrigerator
+book
+clock
+vase
+scissors
+teddy bear
+hair drier
+toothbrush

--- a/examples/object-detection/single-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/single-stream-object-detector/src/common/config.yaml
@@ -1,5 +1,6 @@
 model:
   path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
+  labels: examples/object-detection/single-stream-object-detector/src/common/coco_label.txt
 
 source:
   rtsp_url: <rtsp-url-1>     # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -312,9 +312,10 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   runtime.labels = load_labels(cfg.labels_path);
 
   auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
+  const bool save_debug_frames = !cfg.save_dir.empty() && cfg.save_every > 0;
   std::vector<std::string> source_outputs = {"video", "model"};
-  if (!cfg.save_dir.empty() && cfg.save_every > 0) {
-    source_outputs.push_back("frames");
+  if (save_debug_frames) {
+    source_outputs.push_back("debug_frame");
   }
   auto branch = simaai::neat::graphs::Branch("source", source_outputs);
 
@@ -331,17 +332,23 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
 
   simaai::neat::Graph model_graph("model");
   model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
-  auto detections =
-      simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4));
+  simaai::neat::Graph detections_graph("detections");
+  detections_graph.add(
+      simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
 
   runtime.graph.connect(source, branch);
   runtime.graph.connect(branch, video_graph);
   runtime.graph.connect(branch, model_graph);
-  runtime.graph.connect(model_graph, detections);
-  if (!cfg.save_dir.empty() && cfg.save_every > 0) {
-    simaai::neat::Graph frames("frames");
-    frames.add(simaai::neat::nodes::Output("frames", simaai::neat::OutputOptions::Latest()));
+  runtime.graph.connect(model_graph, detections_graph);
+  if (save_debug_frames) {
+    simaai::neat::Graph frames("debug_frame");
+    frames.add(
+        simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
+    auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
+                                                    simaai::neat::CombinePolicy::ByPts);
     runtime.graph.connect(branch, frames);
+    runtime.graph.connect(frames, debug_join);
+    runtime.graph.connect(detections_graph, debug_join);
   }
   if (cfg.profile) {
     std::cout << "Backend:\n" << runtime.graph.describe_backend() << "\n";
@@ -386,17 +393,13 @@ void send_metadata(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
   }
 }
 
-void maybe_save_debug_frame(PipelineRuntime& runtime, const AppConfig& cfg, int processed,
+void maybe_save_debug_frame(const AppConfig& cfg, int processed, const simaai::neat::Sample& sample,
                             const std::vector<objdet::Box>& boxes) {
   if (cfg.save_dir.empty() || cfg.save_every <= 0 || processed % cfg.save_every != 0) {
     return;
   }
 
-  auto frame_sample = runtime.run.pull("frames", 0);
-  if (!frame_sample.has_value()) {
-    return;
-  }
-  const auto tensors = simaai::neat::tensors_from_sample(*frame_sample, false);
+  const auto tensors = simaai::neat::tensors_from_sample(sample, false);
   if (tensors.empty()) {
     return;
   }
@@ -419,12 +422,14 @@ void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
   profile.enabled = cfg.profile;
   profile.interval = cfg.profile_interval;
 
+  const std::string output_name =
+      (!cfg.save_dir.empty() && cfg.save_every > 0) ? "debug_output" : "detections";
   int processed = 0;
   while (cfg.frames <= 0 || processed < cfg.frames) {
     simaai::neat::Sample detection_sample;
     simaai::neat::PullError pull_error;
     const double pull_start = sima_examples::time_ms();
-    const auto status = runtime.run.pull("detections", 20000, detection_sample, &pull_error);
+    const auto status = runtime.run.pull(output_name, 20000, detection_sample, &pull_error);
     const double pull_end = sima_examples::time_ms();
     if (status == simaai::neat::PullStatus::Timeout) {
       std::cerr << "[warn] timed out waiting for detections\n";
@@ -450,7 +455,7 @@ void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
     const double metadata_end = sima_examples::time_ms();
 
     ++processed;
-    maybe_save_debug_frame(runtime, cfg, processed, boxes);
+    maybe_save_debug_frame(cfg, processed, detection_sample, boxes);
     profile.add(pull_end - pull_start, metadata_end - metadata_start,
                 static_cast<int>(boxes.size()));
   }

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -343,6 +343,9 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
     frames.add(simaai::neat::nodes::Output("frames", simaai::neat::OutputOptions::Latest()));
     runtime.graph.connect(branch, frames);
   }
+  if (cfg.profile) {
+    std::cout << "Backend:\n" << runtime.graph.describe_backend() << "\n";
+  }
 
   // Runtime options
   simaai::neat::RunOptions run_options;

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -12,80 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "support/runtime/example_utils.h"
-#include "support/runtime/config_utils.h"
-#include "support/object_detection/obj_detection_utils.h"
 #include "neat.h"
 #include "neat/models.h"
 #include "neat/nodes.h"
 #include "neat/node_groups.h"
+#include "support/object_detection/obj_detection_utils.h"
+#include "support/runtime/config_utils.h"
+#include "support/runtime/example_utils.h"
+
 #include <nodes/groups/VideoSender.h>
 #include <nodes/io/MetadataSender.h>
 
 #include <opencv2/imgcodecs.hpp>
 
-#include <atomic>
+#include <algorithm>
 #include <chrono>
-#include <condition_variable>
-#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
-#include <deque>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
 
-using sima_examples::time_ms;
-
 namespace {
 
-// single-stream-object-detector is a reference pipeline for the common deployment:
-// one RTSP source, one YOLO detector, and Insight video/metadata output.
-//
-// The code keeps ingest, inference, and output transport separate so each
-// stage can be reasoned about and debugged independently.
-
-struct ModelConfig {
-  std::string path;
-};
-
-struct SourceConfig {
+struct AppConfig {
+  std::string model_path;
+  fs::path labels_path;
   std::string rtsp_url;
   int latency_ms = 200;
   bool tcp = true;
-};
-
-struct InferenceConfig {
   int frames = 0;
   double min_score = 0.55;
-  double nms_iou = 0.50;
-  int max_detections = 100;
-};
-
-struct RuntimeConfig {
+  double nms_iou = 0.60;
+  int max_detections = 50;
   bool profile = false;
   int profile_interval = 100;
-};
-
-struct InsightConfig {
-  std::string host = "127.0.0.1";
+  std::string insight_host = "127.0.0.1";
   int video_port = 9000;
   int metadata_port = 9100;
-};
-
-struct AppConfig {
-  ModelConfig model;
-  SourceConfig source;
-  InferenceConfig inference;
-  RuntimeConfig runtime;
-  InsightConfig insight;
   fs::path save_dir;
   int save_every = 0;
 };
@@ -93,6 +63,58 @@ struct AppConfig {
 struct CliOptions {
   fs::path config_path;
   bool validate_config_only = false;
+};
+
+struct ProfileWindow {
+  bool enabled = false;
+  int interval = 100;
+  int frames = 0;
+  int boxes = 0;
+  double start_ms = 0.0;
+  double detection_pull_ms = 0.0;
+  double metadata_send_ms = 0.0;
+
+  void add(double detection_pull, double metadata_send, int box_count) {
+    if (!enabled)
+      return;
+    if (frames == 0)
+      start_ms = sima_examples::time_ms();
+    ++frames;
+    boxes += box_count;
+    detection_pull_ms += detection_pull;
+    metadata_send_ms += metadata_send;
+    if (frames >= interval)
+      flush();
+  }
+
+  void flush() {
+    if (!enabled || frames == 0)
+      return;
+    const double elapsed = sima_examples::time_ms() - start_ms;
+    const auto avg = [this](double value) { return value / static_cast<double>(frames); };
+    const double output_fps = elapsed > 0.0 ? static_cast<double>(frames) * 1000.0 / elapsed : 0.0;
+    std::cout << "[profile] frames=" << frames << " output_fps=" << output_fps
+              << " avg_detection_pull_ms=" << avg(detection_pull_ms)
+              << " avg_metadata_send_ms=" << avg(metadata_send_ms)
+              << " avg_boxes=" << static_cast<double>(boxes) / static_cast<double>(frames) << "\n";
+    frames = 0;
+    boxes = 0;
+    start_ms = 0.0;
+    detection_pull_ms = 0.0;
+    metadata_send_ms = 0.0;
+  }
+};
+
+struct PipelineRuntime {
+  std::unique_ptr<simaai::neat::Model> model;
+  simaai::neat::Graph graph;
+  simaai::neat::Run run;
+  std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
+  std::vector<std::string> labels;
+  int frame_w = 0;
+  int frame_h = 0;
+  int output_fps = 0;
+  int video_port = 0;
 };
 
 CliOptions parse_args(int argc, char** argv) {
@@ -118,81 +140,64 @@ CliOptions parse_args(int argc, char** argv) {
 }
 
 void validate_config(const AppConfig& cfg) {
-  sima_examples::require(!cfg.source.rtsp_url.empty(), "source.rtsp_url must be set");
-  sima_examples::require(!cfg.model.path.empty(), "model.path must be set");
-  sima_examples::require(!cfg.insight.host.empty(), "output.insight.host must be set");
-  sima_examples::require(cfg.source.latency_ms >= 0, "source.latency_ms must be >= 0");
-  sima_examples::require(cfg.inference.frames >= 0, "inference.frames must be >= 0");
-  sima_examples::require(cfg.inference.min_score >= 0.0 && cfg.inference.min_score <= 1.0,
+  sima_examples::require(!cfg.rtsp_url.empty(), "source.rtsp_url must be set");
+  sima_examples::require(!cfg.model_path.empty(), "model.path must be set");
+  sima_examples::require(!cfg.labels_path.empty(), "model.labels must be set");
+  sima_examples::require(!cfg.insight_host.empty(), "output.insight.host must be set");
+  sima_examples::require(cfg.latency_ms >= 0, "source.latency_ms must be >= 0");
+  sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
+  sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
-  sima_examples::require(cfg.inference.nms_iou >= 0.0 && cfg.inference.nms_iou <= 1.0,
+  sima_examples::require(cfg.nms_iou >= 0.0 && cfg.nms_iou <= 1.0,
                          "inference.nms_iou must be between 0 and 1");
-  sima_examples::require(cfg.inference.max_detections > 0, "inference.max_detections must be > 0");
-  sima_examples::require(cfg.runtime.profile_interval > 0, "runtime.profile_interval must be > 0");
-  sima_examples::require(cfg.insight.video_port > 0, "output.insight.video_port must be > 0");
-  sima_examples::require(cfg.insight.metadata_port > 0, "output.insight.metadata_port must be > 0");
+  sima_examples::require(cfg.max_detections > 0, "inference.max_detections must be > 0");
+  sima_examples::require(cfg.profile_interval > 0, "runtime.profile_interval must be > 0");
+  sima_examples::require(cfg.video_port > 0, "output.insight.video_port must be > 0");
+  sima_examples::require(cfg.metadata_port > 0, "output.insight.metadata_port must be > 0");
   sima_examples::require(cfg.save_every >= 0, "output.save_every must be >= 0");
 }
 
 AppConfig load_app_config(const fs::path& config_path) {
   const auto raw = sima_examples::ScalarConfig::load(config_path);
   AppConfig cfg;
-  cfg.model.path = raw.string_or("model.path", "");
-  cfg.source.rtsp_url = raw.string_or("source.rtsp_url", "");
-  cfg.source.latency_ms = raw.int_or("source.latency_ms", 200);
-  cfg.source.tcp = raw.bool_or("source.tcp", true);
-  cfg.inference.frames = raw.int_or("inference.frames", 0);
-  cfg.inference.min_score = raw.double_or("inference.min_score", 0.55);
-  cfg.inference.nms_iou = raw.double_or("inference.nms_iou", 0.50);
-  cfg.inference.max_detections = raw.int_or("inference.max_detections", 100);
-  cfg.runtime.profile = raw.bool_or("runtime.profile", false);
-  cfg.runtime.profile_interval = raw.int_or("runtime.profile_interval", 100);
-  cfg.insight.host = raw.string_or("output.insight.host", "");
-  cfg.insight.video_port = raw.int_or("output.insight.video_port", 9000);
-  cfg.insight.metadata_port = raw.int_or("output.insight.metadata_port", 9100);
+  const auto default_labels =
+      fs::path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR).parent_path() / "common" / "coco_label.txt";
+  cfg.model_path = raw.string_or("model.path", "");
+  cfg.labels_path = raw.string_or("model.labels", default_labels.string());
+  cfg.rtsp_url = raw.string_or("source.rtsp_url", "");
+  cfg.latency_ms = raw.int_or("source.latency_ms", 200);
+  cfg.tcp = raw.bool_or("source.tcp", true);
+  cfg.frames = raw.int_or("inference.frames", 0);
+  cfg.min_score = raw.double_or("inference.min_score", 0.55);
+  cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
+  cfg.max_detections = raw.int_or("inference.max_detections", 50);
+  cfg.profile = raw.bool_or("runtime.profile", false);
+  cfg.profile_interval = raw.int_or("runtime.profile_interval", 100);
+  cfg.insight_host = raw.string_or("output.insight.host", "");
+  cfg.video_port = raw.int_or("output.insight.video_port", 9000);
+  cfg.metadata_port = raw.int_or("output.insight.metadata_port", 9100);
   cfg.save_dir = raw.string_or("output.save_dir", "");
   cfg.save_every = raw.int_or("output.save_every", 0);
   validate_config(cfg);
   return cfg;
 }
 
-using sima_examples::infer_dims;
-using sima_examples::make_blank_nv12_tensor;
-using sima_examples::nv12_copy_to_cpu_tensor;
-
-// This sample uses the standard 80-class COCO label order expected by the
-// bundled YOLO26 detector model. Keeping the mapping local to the sample avoids baking
-// model-specific semantics into generic Insight helpers used by other models.
-std::vector<std::string> yolo_coco_labels() {
-  return {
-      "person",        "bicycle",      "car",
-      "motorcycle",    "airplane",     "bus",
-      "train",         "truck",        "boat",
-      "traffic light", "fire hydrant", "stop sign",
-      "parking meter", "bench",        "bird",
-      "cat",           "dog",          "horse",
-      "sheep",         "cow",          "elephant",
-      "bear",          "zebra",        "giraffe",
-      "backpack",      "umbrella",     "handbag",
-      "tie",           "suitcase",     "frisbee",
-      "skis",          "snowboard",    "sports ball",
-      "kite",          "baseball bat", "baseball glove",
-      "skateboard",    "surfboard",    "tennis racket",
-      "bottle",        "wine glass",   "cup",
-      "fork",          "knife",        "spoon",
-      "bowl",          "banana",       "apple",
-      "sandwich",      "orange",       "broccoli",
-      "carrot",        "hot dog",      "pizza",
-      "donut",         "cake",         "chair",
-      "couch",         "potted plant", "bed",
-      "dining table",  "toilet",       "tv",
-      "laptop",        "mouse",        "remote",
-      "keyboard",      "cell phone",   "microwave",
-      "oven",          "toaster",      "sink",
-      "refrigerator",  "book",         "clock",
-      "vase",          "scissors",     "teddy bear",
-      "hair drier",    "toothbrush",
-  };
+std::vector<std::string> load_labels(const fs::path& labels_path) {
+  std::ifstream in(labels_path);
+  if (!in.good()) {
+    throw std::runtime_error("labels file does not exist: " + labels_path.string());
+  }
+  std::vector<std::string> labels;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) {
+      labels.push_back(line);
+    }
+  }
+  if (labels.empty()) {
+    throw std::runtime_error("labels file is empty: " + labels_path.string());
+  }
+  return labels;
 }
 
 bool extract_bbox_payload(const simaai::neat::Sample& sample, std::vector<std::uint8_t>& payload,
@@ -216,434 +221,22 @@ bool extract_bbox_payload(const simaai::neat::Sample& sample, std::vector<std::u
   return objdet::extract_bbox_payload(sample, payload, err);
 }
 
-void enable_insight_diagnostics(bool enabled) {
-  if (!enabled)
-    return;
-  setenv("SIMA_GST_ELEMENT_TIMINGS", "1", 0);
-  setenv("SIMA_GST_FLOW_DEBUG", "1", 0);
-  setenv("SIMA_GST_BOUNDARY_PROBES", "1", 0);
-}
-
-double fps_from_count(int count, double elapsed_ms) {
-  if (elapsed_ms <= 0.0)
-    return 0.0;
-  return static_cast<double>(count) * 1000.0 / elapsed_ms;
-}
-
-void print_throughput_summary(int produced, int det_outputs, int published,
-                              double producer_start_ms, double producer_end_ms,
-                              double consumer_start_ms, double consumer_end_ms) {
-  const double producer_elapsed_ms =
-      (producer_end_ms > producer_start_ms) ? (producer_end_ms - producer_start_ms) : 0.0;
-  const double consumer_elapsed_ms =
-      (consumer_end_ms > consumer_start_ms) ? (consumer_end_ms - consumer_start_ms) : 0.0;
-  std::cout << "[THROUGHPUT] produced=" << produced
-            << " fps=" << fps_from_count(produced, producer_elapsed_ms)
-            << " yolo_out=" << det_outputs
-            << " fps=" << fps_from_count(det_outputs, consumer_elapsed_ms)
-            << " published=" << published
-            << " fps=" << fps_from_count(published, consumer_elapsed_ms)
-            << " producer_ms=" << producer_elapsed_ms << " consumer_ms=" << consumer_elapsed_ms
-            << "\n";
-}
-
-struct FrameItem {
-  int index = 0;
-  simaai::neat::Tensor frame;
-  double pull_ts_ms = 0.0;
-  double rtsp_pull_ms = 0.0;
-};
-
-struct PendingFrame {
-  int index = 0;
-  double pull_ts_ms = 0.0;
-  simaai::neat::Tensor frame;
-};
-
-struct FrameQueue {
-  explicit FrameQueue(size_t max_size_in) : max_size(max_size_in) {}
-
-  bool push(FrameItem item) {
-    std::unique_lock<std::mutex> lock(mu);
-    cond.wait(lock, [&]() { return closed || items.size() < max_size; });
-    if (closed)
-      return false;
-    items.push_back(std::move(item));
-    lock.unlock();
-    cond.notify_all();
-    return true;
-  }
-
-  bool pop(FrameItem& out) {
-    std::unique_lock<std::mutex> lock(mu);
-    cond.wait(lock, [&]() { return closed || !items.empty(); });
-    if (items.empty())
-      return false;
-    out = std::move(items.front());
-    items.pop_front();
-    lock.unlock();
-    cond.notify_all();
-    return true;
-  }
-
-  void close() {
-    std::lock_guard<std::mutex> lock(mu);
-    closed = true;
-    cond.notify_all();
-  }
-
-private:
-  size_t max_size = 0;
-  std::mutex mu;
-  std::condition_variable cond;
-  std::deque<FrameItem> items;
-  bool closed = false;
-};
-
-struct ProducerStats {
-  int count = 0;
-};
-
-struct TimingAccumulator {
-  int count = 0;
-  double sum_ms = 0.0;
-  double max_ms = 0.0;
-
-  void add(double ms) {
-    sum_ms += ms;
-    if (ms > max_ms)
-      max_ms = ms;
-    count += 1;
-  }
-
-  double avg() const {
-    return count > 0 ? sum_ms / static_cast<double>(count) : 0.0;
-  }
-
-  void reset() {
-    count = 0;
-    sum_ms = 0.0;
-    max_ms = 0.0;
-  }
-};
-
-struct FrameProfile {
-  double rtsp_pull_ms = 0.0;
-  double queue_pop_ms = 0.0;
-  double yolo_push_ms = 0.0;
-  double yolo_pull_ms = 0.0;
-  double bbox_extract_ms = 0.0;
-  double bbox_parse_ms = 0.0;
-  double video_input_ms = 0.0;
-  double video_push_ms = 0.0;
-  double metadata_ms = 0.0;
-  double e2e_ms = 0.0;
-  int boxes = 0;
-};
-
-struct ProfileWindow {
-  bool enabled = false;
-  int interval = 100;
-  int frames = 0;
-  int boxes = 0;
-  double start_ms = 0.0;
-  TimingAccumulator rtsp_pull;
-  TimingAccumulator queue_pop;
-  TimingAccumulator yolo_push;
-  TimingAccumulator yolo_pull;
-  TimingAccumulator bbox_extract;
-  TimingAccumulator bbox_parse;
-  TimingAccumulator video_input;
-  TimingAccumulator video_push;
-  TimingAccumulator metadata;
-  TimingAccumulator e2e;
-
-  void add(const FrameProfile& profile, int published_total) {
-    if (!enabled)
-      return;
-    if (frames == 0)
-      start_ms = time_ms();
-    frames += 1;
-    boxes += profile.boxes;
-    rtsp_pull.add(profile.rtsp_pull_ms);
-    queue_pop.add(profile.queue_pop_ms);
-    yolo_push.add(profile.yolo_push_ms);
-    yolo_pull.add(profile.yolo_pull_ms);
-    bbox_extract.add(profile.bbox_extract_ms);
-    bbox_parse.add(profile.bbox_parse_ms);
-    video_input.add(profile.video_input_ms);
-    video_push.add(profile.video_push_ms);
-    metadata.add(profile.metadata_ms);
-    e2e.add(profile.e2e_ms);
-    if (frames >= interval)
-      flush(published_total);
-  }
-
-  void flush(int published_total) {
-    if (!enabled || frames <= 0)
-      return;
-    const double elapsed_ms = time_ms() - start_ms;
-    std::cout << "[profile] frames=" << frames << " published=" << published_total
-              << " fps=" << fps_from_count(frames, elapsed_ms)
-              << " avg_rtsp_pull_ms=" << rtsp_pull.avg() << " avg_queue_pop_ms=" << queue_pop.avg()
-              << " avg_yolo_ms=" << (yolo_push.avg() + yolo_pull.avg())
-              << " avg_bbox_ms=" << (bbox_extract.avg() + bbox_parse.avg())
-              << " avg_video_input_ms=" << video_input.avg()
-              << " avg_video_push_ms=" << video_push.avg() << " avg_metadata_ms=" << metadata.avg()
-              << " avg_e2e_ms=" << e2e.avg()
-              << " avg_boxes=" << (static_cast<double>(boxes) / static_cast<double>(frames))
-              << " max_e2e_ms=" << e2e.max_ms << "\n";
-    reset();
-  }
-
-  void reset() {
-    frames = 0;
-    boxes = 0;
-    start_ms = 0.0;
-    rtsp_pull.reset();
-    queue_pop.reset();
-    yolo_push.reset();
-    yolo_pull.reset();
-    bbox_extract.reset();
-    bbox_parse.reset();
-    video_input.reset();
-    video_push.reset();
-    metadata.reset();
-    e2e.reset();
-  }
-};
-
-struct RtspRuntime {
-  simaai::neat::Graph source_graph;
-  simaai::neat::Run source_run;
-  simaai::neat::Tensor first_frame;
-  double first_pull_ms = 0.0;
-  double first_pull_ts = 0.0;
-  int frame_w = 0;
-  int frame_h = 0;
-  int output_fps = 30;
-};
-
-struct InsightRuntime {
-  std::string host;
-  int video_port = 0;
-  simaai::neat::Graph video_graph;
-  simaai::neat::Run video_run;
-  std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
-  std::vector<std::string> labels;
-};
-
-struct DetectorRuntime {
-  std::unique_ptr<simaai::neat::Model> model;
-  simaai::neat::Graph detector_graph;
-  simaai::neat::Run detector_run;
-};
-
-struct WorkerSharedState {
-  std::optional<int> frame_limit;
-  FrameQueue& queue;
-  ProducerStats& producer_stats;
-  ProfileWindow& profile_window;
-  std::atomic<bool>& stop;
-  std::atomic<int>& published;
-  std::atomic<int>& det_outputs;
-  double& producer_start_ms;
-  double& producer_end_ms;
-  double& consumer_start_ms;
-  double& consumer_end_ms;
-};
-
-RtspRuntime build_rtsp_runtime(const AppConfig& cfg) {
-  RtspRuntime runtime;
-
-  sima_examples::RtspStreamInfo rtsp_probe;
-  sima_examples::RtspProbeOptions rtsp_probe_opt;
-  rtsp_probe_opt.payload_type = 96;
-  rtsp_probe_opt.latency_ms = cfg.source.latency_ms;
-  rtsp_probe_opt.rtsp_tcp = cfg.source.tcp;
-  rtsp_probe_opt.debug = cfg.runtime.profile;
-  (void)sima_examples::probe_rtsp_stream_info(cfg.source.rtsp_url, rtsp_probe_opt, rtsp_probe);
-
-  simaai::neat::nodes::groups::RtspDecodedInputOptions source_options;
-  source_options.url = cfg.source.rtsp_url;
-  source_options.latency_ms = cfg.source.latency_ms;
-  source_options.tcp = cfg.source.tcp;
-  source_options.payload_type = 96;
-  source_options.insert_queue = true;
-  source_options.out_format = "NV12";
-  source_options.decoder_name = "decoder";
-  source_options.decoder_raw_output = true;
-  source_options.auto_caps_from_stream = true;
-  if (rtsp_probe.width > 0 && rtsp_probe.height > 0) {
-    source_options.fallback_h264_width = rtsp_probe.width;
-    source_options.fallback_h264_height = rtsp_probe.height;
-    std::cout << "[init] probed RTSP decode dims " << rtsp_probe.width << "x" << rtsp_probe.height;
-    if (rtsp_probe.fps > 0)
-      std::cout << " @" << rtsp_probe.fps << " fps";
-    std::cout << "\n";
-  }
-  if (rtsp_probe.fps > 0)
-    source_options.fallback_h264_fps = rtsp_probe.fps;
-  runtime.output_fps = (rtsp_probe.fps > 0) ? rtsp_probe.fps : 30;
-
-  runtime.source_graph.add(simaai::neat::nodes::groups::RtspDecodedInput(source_options));
-  runtime.source_graph.add(simaai::neat::nodes::Output());
-  simaai::neat::RunOptions source_run_options;
-  source_run_options.queue_depth = 4;
-  source_run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  runtime.source_run = runtime.source_graph.build(source_run_options);
-
-  const double first_pull_start = time_ms();
-  simaai::neat::Sample first_sample;
-  simaai::neat::PullError first_pull_error;
-  const auto first_pull_status = runtime.source_run.pull(20000, first_sample, &first_pull_error);
-  if (first_pull_status != simaai::neat::PullStatus::Ok) {
-    if (first_pull_status == simaai::neat::PullStatus::Timeout) {
-      throw std::runtime_error(
-          "Timed out waiting for first RTSP frame. This is usually upstream connectivity or stream "
-          "delivery, not framerate derivation. If diagnostics show zero buffers at rtspsrc/depay/"
-          "decoder, the device is not receiving RTP from the source.");
-    }
-    throw std::runtime_error("Failed waiting for first RTSP frame: " + first_pull_error.message);
-  }
-  auto first_tensors = simaai::neat::tensors_from_sample(first_sample);
-  runtime.first_frame = std::move(first_tensors.front());
-  const double first_pull_end = time_ms();
-  runtime.first_pull_ms = first_pull_end - first_pull_start;
-  runtime.first_pull_ts = first_pull_end;
-  sima_examples::require(infer_dims(runtime.first_frame, runtime.frame_w, runtime.frame_h),
-                         "first frame missing dimensions");
-  if (runtime.frame_w == 1280 && runtime.frame_h == 720 && source_options.h264_width <= 0 &&
-      source_options.h264_height <= 0 && source_options.fallback_h264_width <= 0 &&
-      source_options.fallback_h264_height <= 0) {
-    std::fprintf(stderr, "[WARN] deriving width=1280 and height=720 from SDP or timestamp\n");
-  }
-  return runtime;
-}
-
-InsightRuntime build_insight_runtime(const AppConfig& cfg, int frame_w, int frame_h,
-                                     int output_fps) {
-  InsightRuntime runtime;
-  runtime.host = cfg.insight.host;
-  runtime.video_port = cfg.insight.video_port;
-
-  simaai::neat::InputOptions video_input_options;
-  video_input_options.format = "NV12";
-  video_input_options.width = frame_w;
-  video_input_options.height = frame_h;
-  video_input_options.caps_override = "video/x-raw,format=NV12,width=" + std::to_string(frame_w) +
-                                      ",height=" + std::to_string(frame_h) +
-                                      ",framerate=" + std::to_string(output_fps) + "/1";
-  video_input_options.use_simaai_pool = false;
-  runtime.video_graph.add(simaai::neat::nodes::Input(video_input_options));
-  auto video_sender_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
-      frame_w, frame_h, output_fps);
-  video_sender_options.host = runtime.host;
-  video_sender_options.channel = 0;
-  video_sender_options.video_port_base = cfg.insight.video_port;
-  runtime.video_port = video_sender_options.video_port();
-  video_sender_options.encoder.bitrate_kbps = 4000;
-  runtime.video_graph.add(simaai::neat::nodes::groups::VideoSender(video_sender_options));
-
-  simaai::neat::Tensor video_seed;
-  std::string video_seed_err;
-  sima_examples::require(make_blank_nv12_tensor(frame_w, frame_h, video_seed, video_seed_err),
-                         video_seed_err);
-  simaai::neat::RunOptions video_run_options;
-  runtime.video_run =
-      runtime.video_graph.build(simaai::neat::TensorList{video_seed}, video_run_options);
-  std::cout << "video_sender=" << runtime.host << ":" << runtime.video_port << "\n";
-
-  simaai::neat::MetadataSenderOptions metadata_options;
-  metadata_options.host = cfg.insight.host;
-  metadata_options.channel = 0;
-  metadata_options.metadata_port_base = cfg.insight.metadata_port;
-  std::string metadata_err;
-  runtime.metadata_sender =
-      std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
-  sima_examples::require(runtime.metadata_sender->ok(), metadata_err);
-  runtime.labels = yolo_coco_labels();
-  std::cout << "insight host=" << runtime.metadata_sender->host()
-            << " video_port=" << runtime.video_port
-            << " metadata_port=" << runtime.metadata_sender->metadata_port() << " channel=0\n";
-  return runtime;
-}
-
-DetectorRuntime build_detector_runtime(const AppConfig& cfg, int frame_w, int frame_h) {
-  // NEAT boundary: build detection Graph/Run pipeline.
-  DetectorRuntime runtime;
-
-  // NEAT boundary: build model + async inference runtime.
-  simaai::neat::Model::Options model_opt;
-  model_opt.preprocess.kind = simaai::neat::InputKind::Image;
-  model_opt.preprocess.enable = simaai::neat::AutoFlag::On;
-  model_opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::BGR;
-  model_opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
-  model_opt.decode_type = simaai::neat::BoxDecodeType::YoloV26;
-  model_opt.score_threshold = cfg.inference.min_score;
-  model_opt.nms_iou_threshold = cfg.inference.nms_iou;
-  model_opt.top_k = cfg.inference.max_detections;
-  runtime.model = std::make_unique<simaai::neat::Model>(cfg.model.path, model_opt);
-  std::cout << "[init] model configured for " << frame_w << "x" << frame_h << " BGR\n";
-
-  simaai::neat::InputOptions appsrc_options = runtime.model->input_appsrc_options(false);
-  appsrc_options.payload_type = simaai::neat::PayloadType::Image;
-  appsrc_options.format = "BGR";
-  appsrc_options.width = frame_w;
-  appsrc_options.height = frame_h;
-  appsrc_options.depth = 3;
-
-  runtime.detector_graph.add(simaai::neat::nodes::Input(appsrc_options));
-  runtime.detector_graph.add(runtime.model->graph());
-  runtime.detector_graph.add(simaai::neat::nodes::Output());
-
-  simaai::neat::RunOptions detector_run_options;
-  detector_run_options.preset = simaai::neat::RunPreset::Reliable;
-  detector_run_options.queue_depth = 4;
-  detector_run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  detector_run_options.output_memory = simaai::neat::OutputMemory::Owned;
-  cv::Mat detector_seed(frame_h, frame_w, CV_8UC3, cv::Scalar(0, 0, 0));
-  std::cout << "[init] building YOLO pipeline\n";
-  runtime.detector_run =
-      runtime.detector_graph.build(std::vector<cv::Mat>{detector_seed}, detector_run_options);
-  std::cout << "[init] YOLO pipeline ready\n";
-  return runtime;
-}
-
-std::optional<int> frame_limit_from_config(const AppConfig& cfg) {
-  if (cfg.inference.frames > 0) {
-    return cfg.inference.frames;
-  }
-  return std::nullopt;
-}
-
-std::vector<sima_examples::MetadataBox>
-build_detection_metadata_boxes(const std::vector<objdet::Box>& boxes,
-                               const std::vector<std::string>& labels, int frame_w, int frame_h) {
+std::vector<sima_examples::MetadataBox> build_metadata_boxes(const std::vector<objdet::Box>& boxes,
+                                                             const std::vector<std::string>& labels,
+                                                             int frame_w, int frame_h) {
   std::vector<sima_examples::MetadataBox> metadata_boxes;
   metadata_boxes.reserve(boxes.size());
   int object_index = 1;
   for (const auto& box : boxes) {
-    int x1 = static_cast<int>(box.x1);
-    int y1 = static_cast<int>(box.y1);
-    int w = static_cast<int>(box.x2 - box.x1);
-    int h = static_cast<int>(box.y2 - box.y1);
-    if (x1 < 0)
-      x1 = 0;
-    if (y1 < 0)
-      y1 = 0;
-    if (w < 0)
-      w = 0;
-    if (h < 0)
-      h = 0;
+    int x1 = std::max(0, static_cast<int>(box.x1));
+    int y1 = std::max(0, static_cast<int>(box.y1));
+    int w = std::max(0, static_cast<int>(box.x2 - box.x1));
+    int h = std::max(0, static_cast<int>(box.y2 - box.y1));
     if (x1 + w > frame_w)
       w = frame_w - x1;
     if (y1 + h > frame_h)
       h = frame_h - y1;
-    if (w < 0)
-      w = 0;
-    if (h < 0)
-      h = 0;
+
     sima_examples::MetadataBox obj;
     obj.id = "obj_" + std::to_string(object_index++);
     obj.label = (box.class_id >= 0 && box.class_id < static_cast<int>(labels.size()))
@@ -652,187 +245,222 @@ build_detection_metadata_boxes(const std::vector<objdet::Box>& boxes,
     obj.confidence = box.score;
     obj.x = static_cast<float>(x1);
     obj.y = static_cast<float>(y1);
-    obj.w = static_cast<float>(w);
-    obj.h = static_cast<float>(h);
+    obj.w = static_cast<float>(std::max(0, w));
+    obj.h = static_cast<float>(std::max(0, h));
     metadata_boxes.push_back(obj);
   }
   return metadata_boxes;
 }
 
-void producer_worker(simaai::neat::Run& source_run, simaai::neat::Tensor first_frame,
-                     double first_pull_ms, double first_pull_ts, WorkerSharedState& state) {
-  state.producer_start_ms = time_ms();
-  int produced = 0;
-  bool use_first = true;
-  while (!state.stop.load() && (!state.frame_limit || produced < *state.frame_limit)) {
-    simaai::neat::Tensor frame;
-    double pull_ms = 0.0;
-    double pull_ts = 0.0;
-    if (use_first) {
-      frame = std::move(first_frame);
-      use_first = false;
-      pull_ms = first_pull_ms;
-      pull_ts = first_pull_ts;
-    } else {
-      const double t0 = time_ms();
-      auto frame_opt = source_run.pull();
-      if (!frame_opt.has_value())
-        continue;
-      const double t1 = time_ms();
-      auto tensors = simaai::neat::tensors_from_sample(*frame_opt);
-      frame = std::move(tensors.front());
-      pull_ms = t1 - t0;
-      pull_ts = t1;
-    }
-    FrameItem item;
-    item.index = produced;
-    item.frame = std::move(frame);
-    item.pull_ts_ms = pull_ts;
-    item.rtsp_pull_ms = pull_ms;
+simaai::neat::nodes::groups::RtspDecodedInputOptions
+make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& height_out) {
+  sima_examples::RtspStreamInfo probe;
+  sima_examples::RtspProbeOptions probe_options;
+  probe_options.payload_type = 96;
+  probe_options.latency_ms = cfg.latency_ms;
+  probe_options.rtsp_tcp = cfg.tcp;
+  probe_options.debug = cfg.profile;
+  (void)sima_examples::probe_rtsp_stream_info(cfg.rtsp_url, probe_options, probe);
 
-    if (!state.queue.push(std::move(item)))
-      break;
-
-    produced += 1;
-    state.producer_stats.count = produced;
+  // RTSP options
+  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
+  opt.url = cfg.rtsp_url;
+  opt.latency_ms = cfg.latency_ms;
+  opt.tcp = cfg.tcp;
+  opt.payload_type = 96;
+  opt.insert_queue = true;
+  opt.out_format = "NV12";
+  opt.decoder_name = "decoder";
+  opt.decoder_raw_output = true;
+  opt.auto_caps_from_stream = true;
+  if (probe.width > 0 && probe.height > 0) {
+    opt.fallback_h264_width = probe.width;
+    opt.fallback_h264_height = probe.height;
+    width_out = probe.width;
+    height_out = probe.height;
   }
-  state.queue.close();
-  state.producer_end_ms = time_ms();
+  if (probe.fps > 0) {
+    opt.fallback_h264_fps = probe.fps;
+    fps_out = probe.fps;
+  }
+  return opt;
 }
 
-void consumer_worker(simaai::neat::Run& detector_run, simaai::neat::Run& video_run,
-                     simaai::neat::MetadataSender& metadata_sender,
-                     const std::vector<std::string>& insight_labels, int frame_w, int frame_h,
-                     int max_detections, double min_score, const fs::path& save_dir, int save_every,
-                     WorkerSharedState& state) {
-  state.consumer_start_ms = time_ms();
-  int out_pulls = 0;
-  while (!state.stop.load() &&
-         (!state.frame_limit || state.published.load() < *state.frame_limit)) {
-    FrameProfile frame_profile;
-    FrameItem item;
-    const double q0 = time_ms();
-    if (!state.queue.pop(item))
-      break;
-    const double q1 = time_ms();
-    frame_profile.rtsp_pull_ms = item.rtsp_pull_ms;
-    frame_profile.queue_pop_ms = q1 - q0;
+std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg) {
+  // Model options
+  simaai::neat::Model::Options model_opt;
+  model_opt.preprocess.kind = simaai::neat::InputKind::Image;
+  model_opt.preprocess.enable = simaai::neat::AutoFlag::On;
+  model_opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::NV12;
+  model_opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
+  model_opt.decode_type = simaai::neat::BoxDecodeType::YoloV26;
+  model_opt.score_threshold = cfg.min_score;
+  model_opt.nms_iou_threshold = cfg.nms_iou;
+  model_opt.top_k = cfg.max_detections;
+  return std::make_unique<simaai::neat::Model>(cfg.model_path, model_opt);
+}
 
-    PendingFrame decoded_frame;
-    decoded_frame.index = item.index;
-    decoded_frame.pull_ts_ms = item.pull_ts_ms;
-    decoded_frame.frame = std::move(item.frame);
+PipelineRuntime build_pipeline(const AppConfig& cfg) {
+  PipelineRuntime runtime;
+  const auto source_options =
+      make_source_options(cfg, runtime.output_fps, runtime.frame_w, runtime.frame_h);
+  sima_examples::require(runtime.frame_w > 0 && runtime.frame_h > 0,
+                         "failed to probe RTSP frame dimensions");
+  sima_examples::require(runtime.output_fps > 0, "failed to probe RTSP frame rate");
 
-    // NEAT boundary: push current frame into async YOLO run, then pull next output.
-    const double t_push0 = time_ms();
-    const cv::Mat detector_input =
-        decoded_frame.frame.to_cv_mat_copy(simaai::neat::ImageSpec::PixelFormat::BGR);
-    const bool pushed = detector_run.push(std::vector<cv::Mat>{detector_input});
-    const double t_push1 = time_ms();
-    frame_profile.yolo_push_ms = t_push1 - t_push0;
-    if (!pushed) {
-      std::cerr << "[warn] push failed\n";
-      continue;
-    }
-    const double t_pull0 = time_ms();
-    auto detection_sample = detector_run.pull();
-    const double t_pull1 = time_ms();
-    frame_profile.yolo_pull_ms = t_pull1 - t_pull0;
-    if (!detection_sample.has_value())
-      continue;
-    out_pulls += 1;
-    state.det_outputs.store(out_pulls);
+  runtime.model = make_model(cfg);
+  runtime.labels = load_labels(cfg.labels_path);
 
-    PendingFrame pending = std::move(decoded_frame);
-
-    const double t_extract0 = time_ms();
-    std::vector<uint8_t> bbox_payload;
-    std::string err;
-    if (!extract_bbox_payload(*detection_sample, bbox_payload, err)) {
-      std::cerr << "[warn] bbox extract failed: " << err << "\n";
-      continue;
-    }
-    const double t_extract1 = time_ms();
-    frame_profile.bbox_extract_ms = t_extract1 - t_extract0;
-
-    const double t_parse0 = time_ms();
-    std::vector<objdet::Box> detections;
-    try {
-      detections =
-          objdet::parse_boxes_strict(bbox_payload, frame_w, frame_h, max_detections, false);
-    } catch (const std::exception& ex) {
-      std::cerr << "[warn] bbox parse failed: " << ex.what() << "\n";
-      continue;
-    }
-    const double t_parse1 = time_ms();
-    frame_profile.bbox_parse_ms = t_parse1 - t_parse0;
-    frame_profile.boxes = static_cast<int>(detections.size());
-
-    std::vector<sima_examples::MetadataBox> metadata_boxes =
-        build_detection_metadata_boxes(detections, insight_labels, frame_w, frame_h);
-
-    // Contract: publish video first, then publish the matching metadata side-channel payload.
-    double output_ts = 0.0;
-    const double t_video_input0 = time_ms();
-    simaai::neat::Tensor nv12_frame;
-    std::string nv12_err;
-    const bool converted = nv12_copy_to_cpu_tensor(pending.frame, nv12_frame, nv12_err);
-    if (!converted) {
-      std::cerr << "[warn] VideoSender input copy failed: " << nv12_err << "\n";
-      continue;
-    }
-    const double t_video_input1 = time_ms();
-    frame_profile.video_input_ms = t_video_input1 - t_video_input0;
-
-    // NEAT boundary: push the raw frame into VideoSender; the nodegroup owns conversion, H.264
-    // encoding, RTP packetization, and UDP output.
-    const double t_video_sender_push0 = time_ms();
-    if (!video_run.push(simaai::neat::TensorList{nv12_frame})) {
-      std::cerr << "[warn] VideoSender push failed\n";
-      continue;
-    }
-    const double t_video_sender_push1 = time_ms();
-    frame_profile.video_push_ms = t_video_sender_push1 - t_video_sender_push0;
-    output_ts = t_video_sender_push1;
-    const int64_t fid = detection_sample->frame_id >= 0 ? detection_sample->frame_id
-                                                        : static_cast<int64_t>(pending.index);
-    const auto now = std::chrono::system_clock::now().time_since_epoch();
-    const int64_t ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-    const std::string data_json =
-        sima_examples::metadata_boxes_data_json("objects", metadata_boxes);
-    std::string metadata_err;
-    const double t_metadata0 = time_ms();
-    const bool metadata_ok = metadata_sender.send_metadata("object-detection", data_json, ts_ms,
-                                                           std::to_string(fid), &metadata_err);
-    const double t_metadata1 = time_ms();
-    frame_profile.metadata_ms = t_metadata1 - t_metadata0;
-    if (!metadata_ok) {
-      std::cerr << "[warn] insight metadata send failed: " << metadata_err << "\n";
-    }
-    if (!save_dir.empty() && save_every > 0 && (state.published.load() + 1) % save_every == 0) {
-      cv::Mat annotated = detector_input.clone();
-      objdet::draw_boxes(annotated, detections, min_score, cv::Scalar(0, 255, 0), "");
-      const fs::path out_path = save_dir / ("frame_" + std::to_string(pending.index) + ".jpg");
-      if (!cv::imwrite(out_path.string(), annotated)) {
-        std::cerr << "[warn] failed to write output frame: " << out_path.string() << "\n";
-      }
-    }
-
-    frame_profile.e2e_ms = output_ts - pending.pull_ts_ms;
-
-    const int published_now = state.published.fetch_add(1) + 1;
-    state.profile_window.add(frame_profile, published_now);
+  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
+  std::vector<std::string> source_outputs = {"video", "model"};
+  if (!cfg.save_dir.empty() && cfg.save_every > 0) {
+    source_outputs.push_back("frames");
   }
-  state.stop.store(true);
-  state.queue.close();
-  state.consumer_end_ms = time_ms();
+  auto branch = simaai::neat::graphs::Branch("source", source_outputs);
+
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
+      runtime.frame_w, runtime.frame_h, runtime.output_fps);
+  video_options.host = cfg.insight_host;
+  video_options.channel = 0;
+  video_options.video_port_base = cfg.video_port;
+  video_options.encoder.bitrate_kbps = 600;
+  runtime.video_port = video_options.video_port();
+  simaai::neat::Graph video_graph("video");
+  video_graph.connect(simaai::neat::nodes::Input("video"),
+                      simaai::neat::nodes::groups::VideoSender(video_options));
+
+  simaai::neat::Graph model_graph("model");
+  model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
+  auto detections =
+      simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4));
+
+  runtime.graph.connect(source, branch);
+  runtime.graph.connect(branch, video_graph);
+  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(model_graph, detections);
+  if (!cfg.save_dir.empty() && cfg.save_every > 0) {
+    simaai::neat::Graph frames("frames");
+    frames.add(simaai::neat::nodes::Output("frames", simaai::neat::OutputOptions::Latest()));
+    runtime.graph.connect(branch, frames);
+  }
+
+  // Runtime options
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Reliable;
+  run_options.queue_depth = 4;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::Owned;
+  runtime.run = runtime.graph.build(run_options);
+
+  simaai::neat::MetadataSenderOptions metadata_options;
+  metadata_options.host = cfg.insight_host;
+  metadata_options.channel = 0;
+  metadata_options.metadata_port_base = cfg.metadata_port;
+  std::string metadata_err;
+  runtime.metadata_sender =
+      std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
+  sima_examples::require(runtime.metadata_sender->ok(), metadata_err);
+
+  std::cout << "rtsp=" << cfg.rtsp_url << " stream=" << runtime.frame_w << "x" << runtime.frame_h
+            << "@" << runtime.output_fps << " insight=" << cfg.insight_host
+            << " video=" << runtime.video_port
+            << " metadata=" << runtime.metadata_sender->metadata_port() << " channel=0\n";
+  return runtime;
+}
+
+void send_metadata(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
+                   const std::vector<objdet::Box>& boxes) {
+  const auto metadata_boxes =
+      build_metadata_boxes(boxes, runtime.labels, runtime.frame_w, runtime.frame_h);
+  const std::string data_json = sima_examples::metadata_boxes_data_json("objects", metadata_boxes);
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  const int64_t ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+  const int64_t frame_id = sample.frame_id >= 0 ? sample.frame_id : 0;
+  std::string err;
+  if (!runtime.metadata_sender->send_metadata("object-detection", data_json, ts_ms,
+                                              std::to_string(frame_id), &err)) {
+    std::cerr << "[warn] insight metadata send failed: " << err << "\n";
+  }
+}
+
+void maybe_save_debug_frame(PipelineRuntime& runtime, const AppConfig& cfg, int processed,
+                            const std::vector<objdet::Box>& boxes) {
+  if (cfg.save_dir.empty() || cfg.save_every <= 0 || processed % cfg.save_every != 0) {
+    return;
+  }
+
+  auto frame_sample = runtime.run.pull("frames", 0);
+  if (!frame_sample.has_value()) {
+    return;
+  }
+  const auto tensors = simaai::neat::tensors_from_sample(*frame_sample, false);
+  if (tensors.empty()) {
+    return;
+  }
+
+  cv::Mat bgr;
+  std::string err;
+  if (!sima_examples::nv12_to_bgr(tensors.front(), bgr, err)) {
+    std::cerr << "[warn] failed to prepare output frame: " << err << "\n";
+    return;
+  }
+  objdet::draw_boxes(bgr, boxes, cfg.min_score, cv::Scalar(0, 255, 0), "");
+  const auto out_path = cfg.save_dir / ("frame_" + std::to_string(processed) + ".jpg");
+  if (!cv::imwrite(out_path.string(), bgr)) {
+    std::cerr << "[warn] failed to write output frame: " << out_path.string() << "\n";
+  }
+}
+
+void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
+  ProfileWindow profile;
+  profile.enabled = cfg.profile;
+  profile.interval = cfg.profile_interval;
+
+  int processed = 0;
+  while (cfg.frames <= 0 || processed < cfg.frames) {
+    simaai::neat::Sample detection_sample;
+    simaai::neat::PullError pull_error;
+    const double pull_start = sima_examples::time_ms();
+    const auto status = runtime.run.pull("detections", 20000, detection_sample, &pull_error);
+    const double pull_end = sima_examples::time_ms();
+    if (status == simaai::neat::PullStatus::Timeout) {
+      std::cerr << "[warn] timed out waiting for detections\n";
+      continue;
+    }
+    if (status == simaai::neat::PullStatus::Closed) {
+      break;
+    }
+    if (status != simaai::neat::PullStatus::Ok) {
+      throw std::runtime_error("failed to pull detections: " + pull_error.message);
+    }
+
+    std::vector<std::uint8_t> payload;
+    std::string err;
+    if (!extract_bbox_payload(detection_sample, payload, err)) {
+      throw std::runtime_error("bbox extract failed: " + err);
+    }
+    const auto boxes = objdet::parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h,
+                                                  cfg.max_detections, false);
+
+    const double metadata_start = sima_examples::time_ms();
+    send_metadata(runtime, detection_sample, boxes);
+    const double metadata_end = sima_examples::time_ms();
+
+    ++processed;
+    maybe_save_debug_frame(runtime, cfg, processed, boxes);
+    profile.add(pull_end - pull_start, metadata_end - metadata_start,
+                static_cast<int>(boxes.size()));
+  }
+
+  profile.flush();
+  std::cout << "processed=" << processed << " video_sender=" << cfg.insight_host << ":"
+            << runtime.video_port << "\n";
 }
 
 } // namespace
 
 int main(int argc, char** argv) {
   try {
-    // Lifecycle: setup -> start workers -> join -> summary -> teardown.
     const CliOptions cli = parse_args(argc, argv);
     const AppConfig cfg = load_app_config(cli.config_path);
     if (cli.validate_config_only) {
@@ -843,70 +471,15 @@ int main(int argc, char** argv) {
       fs::create_directories(cfg.save_dir);
     }
 
-    enable_insight_diagnostics(cfg.runtime.profile);
-
-    RtspRuntime rtsp_runtime = build_rtsp_runtime(cfg);
-    InsightRuntime insight_runtime = build_insight_runtime(
-        cfg, rtsp_runtime.frame_w, rtsp_runtime.frame_h, rtsp_runtime.output_fps);
-    DetectorRuntime detector_runtime =
-        build_detector_runtime(cfg, rtsp_runtime.frame_w, rtsp_runtime.frame_h);
-
-    std::optional<int> frame_limit = frame_limit_from_config(cfg);
-    std::cout << "mode=insight"
-              << " frame_limit=" << (frame_limit ? std::to_string(*frame_limit) : "inf")
-              << " profile=" << (cfg.runtime.profile ? "1" : "0") << "\n";
-
-    // Contract: bounded queue preserves backpressure and producer closes it on exit.
-    FrameQueue queue(300);
-    ProducerStats producer_stats;
-    ProfileWindow profile_window;
-    profile_window.enabled = cfg.runtime.profile;
-    profile_window.interval = cfg.runtime.profile_interval;
-    std::atomic<bool> stop{false};
-    std::atomic<int> published{0};
-    std::atomic<int> det_outputs{0};
-    double producer_start_ms = 0.0;
-    double producer_end_ms = 0.0;
-    double consumer_start_ms = 0.0;
-    double consumer_end_ms = 0.0;
-
-    WorkerSharedState worker_state{
-        frame_limit,     queue,       producer_stats,    profile_window,  stop,
-        published,       det_outputs, producer_start_ms, producer_end_ms, consumer_start_ms,
-        consumer_end_ms,
-    };
-
-    // Contract: start producer first, then consumer; both terminate when queue closes or stop is
-    // set.
-    std::thread producer_thread(producer_worker, std::ref(rtsp_runtime.source_run),
-                                std::move(rtsp_runtime.first_frame), rtsp_runtime.first_pull_ms,
-                                rtsp_runtime.first_pull_ts, std::ref(worker_state));
-    std::thread consumer_thread(
-        consumer_worker, std::ref(detector_runtime.detector_run),
-        std::ref(insight_runtime.video_run), std::ref(*insight_runtime.metadata_sender),
-        std::cref(insight_runtime.labels), rtsp_runtime.frame_w, rtsp_runtime.frame_h,
-        cfg.inference.max_detections, cfg.inference.min_score, std::cref(cfg.save_dir),
-        cfg.save_every, std::ref(worker_state));
-
-    if (producer_thread.joinable())
-      producer_thread.join();
-    if (consumer_thread.joinable())
-      consumer_thread.join();
-
-    std::cout << "published=" << published.load() << " video_sender=" << insight_runtime.host << ":"
-              << insight_runtime.video_port << "\n";
-    print_throughput_summary(producer_stats.count, det_outputs.load(), published.load(),
-                             producer_start_ms, producer_end_ms, consumer_start_ms,
-                             consumer_end_ms);
-    profile_window.flush(published.load());
-
-    // Contract: worker threads are joined before pipeline teardown. Explicit close avoids handing
-    // live appsrc/encoder teardown to Run move-assignment while bounded examples are exiting.
-    detector_runtime.detector_run.close();
-    insight_runtime.video_run.close();
-    rtsp_runtime.source_run.close();
+    if (cfg.profile) {
+      setenv("SIMA_GST_ELEMENT_TIMINGS", "1", 0);
+      setenv("SIMA_GST_FLOW_DEBUG", "1", 0);
+      setenv("SIMA_GST_BOUNDARY_PROBES", "1", 0);
+    }
+    PipelineRuntime runtime = build_pipeline(cfg);
+    run_pipeline(runtime, cfg);
+    runtime.run.close();
     return 0;
-
   } catch (const std::exception& e) {
     std::cerr << "[ERR] " << e.what() << "\n";
     return 1;

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -323,7 +323,7 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   video_options.host = cfg.insight_host;
   video_options.channel = 0;
   video_options.video_port_base = cfg.video_port;
-  video_options.encoder.bitrate_kbps = 600;
+  video_options.encoder.bitrate_kbps = 1000;
   runtime.video_port = video_options.video_port();
   simaai::neat::Graph video_graph("video");
   video_graph.connect(simaai::neat::nodes::Input("video"),
@@ -349,10 +349,10 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
 
   // Runtime options
   simaai::neat::RunOptions run_options;
-  run_options.preset = simaai::neat::RunPreset::Reliable;
-  run_options.queue_depth = 4;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 3;
   run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  run_options.output_memory = simaai::neat::OutputMemory::Owned;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
   runtime.run = runtime.graph.build(run_options);
 
   simaai::neat::MetadataSenderOptions metadata_options;

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -1,16 +1,4 @@
-"""Single-camera RTSP YOLO26 Insight example using pyneat.
-
-This mirrors the intent of the C++ reference sample in the same folder:
-
-- pull one decoded RTSP stream
-- run one YOLO26 detector
-- publish H.264 video plus detection metadata to Insight
-
-The runtime path is one composed graph:
-
-RtspDecodedInput -> Branch -> VideoSender
-                         -> Model -> detections
-"""
+"""Single-camera RTSP YOLO26 Insight example using pyneat."""
 
 from __future__ import annotations
 
@@ -19,74 +7,102 @@ from dataclasses import dataclass
 import glob
 import json
 import os
+from pathlib import Path
 import struct
-import subprocess
 import sys
 import time
-from pathlib import Path
+
 import yaml
 
-DEFAULT_FPS = 30
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
+
 cv2 = None
 np = None
 pyneat = None
 
-@dataclass(frozen=True)
-class ModelConfig:
-    path: str
-    labels: Path
-
-
-@dataclass(frozen=True)
-class SourceConfig:
-    rtsp_url: str
-    latency_ms: int
-    tcp: bool
-
-
-@dataclass(frozen=True)
-class InferenceConfig:
-    frames: int
-    min_score: float
-    nms_iou: float
-    max_detections: int
-
-
-@dataclass(frozen=True)
-class RuntimeConfig:
-    profile: bool
-    profile_interval: int
-
-
-@dataclass(frozen=True)
-class InsightConfig:
-    host: str
-    video_port: int
-    metadata_port: int
-
 
 @dataclass(frozen=True)
 class AppConfig:
-    model: ModelConfig
-    source: SourceConfig
-    inference: InferenceConfig
-    runtime: RuntimeConfig
-    insight: InsightConfig
-    save_dir: str
-    save_every: int
+    model_path: str
+    labels_path: Path
+    rtsp_url: str
+    latency_ms: int = 200
+    tcp: bool = True
+    frames: int = 0
+    min_score: float = 0.55
+    nms_iou: float = 0.60
+    max_detections: int = 50
+    profile: bool = False
+    profile_interval: int = 100
+    insight_host: str = "127.0.0.1"
+    video_port: int = 9000
+    metadata_port: int = 9100
+    save_dir: str = ""
+    save_every: int = 0
+
+
+@dataclass
+class PipelineRuntime:
+    model: object
+    graph: object
+    run: object
+    metadata_sender: object
+    labels: list[str]
+    frame_w: int
+    frame_h: int
+    video_port: int
+
+
+class ProfileWindow:
+    def __init__(self, enabled: bool, interval: int) -> None:
+        self.enabled = enabled
+        self.interval = interval
+        self.frames = 0
+        self.boxes = 0
+        self.start_ms = 0.0
+        self.detection_pull_ms = 0.0
+        self.metadata_send_ms = 0.0
+
+    def add(self, detection_pull_ms: float, metadata_send_ms: float, box_count: int) -> None:
+        if not self.enabled:
+            return
+        if self.frames == 0:
+            self.start_ms = time_ms()
+        self.frames += 1
+        self.boxes += box_count
+        self.detection_pull_ms += detection_pull_ms
+        self.metadata_send_ms += metadata_send_ms
+        if self.frames >= self.interval:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self.enabled or self.frames == 0:
+            return
+        elapsed = time_ms() - self.start_ms
+        output_fps = self.frames * 1000.0 / elapsed if elapsed > 0.0 else 0.0
+        print(
+            f"[profile] frames={self.frames} "
+            f"output_fps={output_fps} "
+            f"avg_detection_pull_ms={self.detection_pull_ms / self.frames} "
+            f"avg_metadata_send_ms={self.metadata_send_ms / self.frames} "
+            f"avg_boxes={self.boxes / self.frames}",
+            flush=True,
+        )
+        self.frames = 0
+        self.boxes = 0
+        self.start_ms = 0.0
+        self.detection_pull_ms = 0.0
+        self.metadata_send_ms = 0.0
 
 
 def load_runtime_dependencies() -> None:
-    """Import runtime-only dependencies after argparse validation."""
     global cv2, np, pyneat
     if pyneat is not None:
         return
 
-    # Prefer system OpenCV (built with GStreamer) when running inside a venv.
-    for p in glob.glob("/usr/lib/python3*/dist-packages"):
-        if p not in sys.path:
-            sys.path.insert(0, p)
+    for path in glob.glob("/usr/lib/python3*/dist-packages"):
+        if path not in sys.path:
+            sys.path.insert(0, path)
 
     import cv2 as cv2_module
     import numpy as np_module
@@ -97,148 +113,225 @@ def load_runtime_dependencies() -> None:
     pyneat = pyneat_module
 
 
-def tensor_to_numpy(tensor: pyneat.Tensor) -> np.ndarray:
-    """Copy a pyneat tensor into a NumPy array owned by Python."""
-    return np.asarray(tensor.to_numpy(copy=True))
+def time_ms() -> float:
+    return time.perf_counter() * 1000.0
 
 
-def tensor_dim(tensor: pyneat.Tensor, name: str) -> int:
-    value = getattr(tensor, name)
-    return int(value() if callable(value) else value)
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Single-camera RTSP YOLO26 Insight example")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--validate-config-only", action="store_true")
+    return parser.parse_args(argv)
 
 
-def tensor_bgr_from_decoded(tensor: pyneat.Tensor) -> np.ndarray:
-    """Normalize decoded output into a writable HWC uint8 BGR frame."""
-    if tensor.is_nv12():
-        width = tensor_dim(tensor, "width")
-        height = tensor_dim(tensor, "height")
-        payload = np.frombuffer(tensor.copy_payload_bytes(), dtype=np.uint8)
-        expected = width * height * 3 // 2
-        if payload.size < expected:
-            raise ValueError(f"NV12 payload too small: {payload.size} < {expected}")
-        nv12 = payload[:expected].reshape((height * 3 // 2, width))
-        return np.ascontiguousarray(cv2.cvtColor(nv12, cv2.COLOR_YUV2BGR_NV12))
-
-    if tensor.is_i420():
-        width = tensor_dim(tensor, "width")
-        height = tensor_dim(tensor, "height")
-        payload = np.frombuffer(tensor.copy_payload_bytes(), dtype=np.uint8)
-        expected = width * height * 3 // 2
-        if payload.size < expected:
-            raise ValueError(f"I420 payload too small: {payload.size} < {expected}")
-        i420 = payload[:expected].reshape((height * 3 // 2, width))
-        return np.ascontiguousarray(cv2.cvtColor(i420, cv2.COLOR_YUV2BGR_I420))
-
-    arr = tensor_to_numpy(tensor)
-    if arr.ndim == 4 and arr.shape[0] == 1:
-        arr = arr[0]
-    if arr.ndim != 3:
-        raise ValueError(f"unexpected decoded tensor shape {arr.shape}")
-    if arr.dtype != np.uint8:
-        arr = np.clip(arr, 0, 255).astype(np.uint8)
-    return np.ascontiguousarray(arr)
+def section(raw: dict, key: str) -> dict:
+    value = raw.get(key) or {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a mapping")
+    return value
 
 
-def is_tensor_like(value) -> bool:
-    return hasattr(value, "copy_payload_bytes") and hasattr(value, "to_numpy")
+def string_or(raw: dict, key: str, default: str = "") -> str:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
 
 
-def is_sample_like(value) -> bool:
-    return hasattr(value, "kind") and hasattr(value, "fields")
+def int_or(raw: dict, key: str, default: int) -> int:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
 
 
-def extract_bbox_payload_from_tensors(tensors) -> bytes | None:
-    for tensor in tensors:
-        try:
-            payload = tensor.copy_payload_bytes()
-        except Exception:
-            continue
-        if payload:
-            return payload
-    return None
+def float_or(raw: dict, key: str, default: float) -> float:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{key} must be numeric")
+    return float(value)
 
 
-def extract_bbox_payload(result) -> bytes | None:
-    """Prefer the runtime's pre-decoded BBOX payload when the model emits it.
-
-    Some YOLO pipelines already attach a compact BBOX payload. When that exists
-    it is more reliable and cheaper to parse than re-decoding the raw YOLO head
-    tensors in Python.
-    """
-    if isinstance(result, (list, tuple)) and all(is_tensor_like(item) for item in result):
-        return extract_bbox_payload_from_tensors(result)
-
-    if not is_sample_like(result):
-        return None
-
-    stack = [result]
-    while stack:
-        current = stack.pop()
-        stack.extend(reversed(list(current.fields)))
-        if current.kind == pyneat.SampleKind.TensorSet:
-            payload = extract_bbox_payload_from_tensors(current.tensors)
-            if payload:
-                return payload
-            continue
-        if current.kind != pyneat.SampleKind.Tensor or current.tensor is None:
-            continue
-        fmt = (current.payload_tag or current.format or "").upper()
-        if fmt and fmt != "BBOX":
-            continue
-        try:
-            payload = current.tensor.copy_payload_bytes()
-        except Exception:
-            continue
-        if payload:
-            return payload
-    return None
+def bool_or(raw: dict, key: str, default: bool) -> bool:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be true or false")
+    return value
 
 
-def parse_bbox_payload(payload: bytes, img_w: int, img_h: int, max_detections: int) -> list[dict]:
-    """Decode the packed BBOX payload format used by NEAT samples."""
+def validate_config(cfg: AppConfig) -> None:
+    if not cfg.rtsp_url:
+        raise ValueError("source.rtsp_url must be set")
+    if not cfg.model_path:
+        raise ValueError("model.path must be set")
+    if not str(cfg.labels_path):
+        raise ValueError("model.labels must be set")
+    if not cfg.insight_host:
+        raise ValueError("output.insight.host must be set")
+    if cfg.latency_ms < 0:
+        raise ValueError("source.latency_ms must be >= 0")
+    if cfg.frames < 0:
+        raise ValueError("inference.frames must be >= 0")
+    if not 0.0 <= cfg.min_score <= 1.0:
+        raise ValueError("inference.min_score must be between 0 and 1")
+    if not 0.0 <= cfg.nms_iou <= 1.0:
+        raise ValueError("inference.nms_iou must be between 0 and 1")
+    if cfg.max_detections <= 0:
+        raise ValueError("inference.max_detections must be > 0")
+    if cfg.profile_interval <= 0:
+        raise ValueError("runtime.profile_interval must be > 0")
+    if cfg.video_port <= 0:
+        raise ValueError("output.insight.video_port must be > 0")
+    if cfg.metadata_port <= 0:
+        raise ValueError("output.insight.metadata_port must be > 0")
+    if cfg.save_every < 0:
+        raise ValueError("output.save_every must be >= 0")
+
+
+def load_app_config(config_path: Path) -> AppConfig:
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("config root must be a mapping")
+
+    model = section(raw, "model")
+    source = section(raw, "source")
+    inference = section(raw, "inference")
+    runtime = section(raw, "runtime")
+    output = section(raw, "output")
+    insight = section(output, "insight")
+    default_labels = Path(__file__).resolve().parents[1] / "common" / "coco_label.txt"
+
+    cfg = AppConfig(
+        model_path=string_or(model, "path"),
+        labels_path=Path(string_or(model, "labels", str(default_labels))),
+        rtsp_url=string_or(source, "rtsp_url"),
+        latency_ms=int_or(source, "latency_ms", 200),
+        tcp=bool_or(source, "tcp", True),
+        frames=int_or(inference, "frames", 0),
+        min_score=float_or(inference, "min_score", 0.55),
+        nms_iou=float_or(inference, "nms_iou", 0.60),
+        max_detections=int_or(inference, "max_detections", 50),
+        profile=bool_or(runtime, "profile", False),
+        profile_interval=int_or(runtime, "profile_interval", 100),
+        insight_host=string_or(insight, "host"),
+        video_port=int_or(insight, "video_port", 9000),
+        metadata_port=int_or(insight, "metadata_port", 9100),
+        save_dir=string_or(output, "save_dir"),
+        save_every=int_or(output, "save_every", 0),
+    )
+    validate_config(cfg)
+    return cfg
+
+
+def load_labels(labels_path: Path) -> list[str]:
+    if not labels_path.is_file():
+        raise RuntimeError(f"labels file does not exist: {labels_path}")
+    labels = [line.strip() for line in labels_path.read_text(encoding="utf-8").splitlines()]
+    labels = [label for label in labels if label]
+    if not labels:
+        raise RuntimeError(f"labels file is empty: {labels_path}")
+    return labels
+
+
+def extract_tensor_bbox_payload(sample, tensor=None) -> bytes:
+    tensor = tensor if tensor is not None else getattr(sample, "tensor", None)
+    if tensor is None:
+        raise RuntimeError("capture_missing_tensor")
+    fmt = getattr(sample, "payload_tag", "") or getattr(sample, "format", "")
+    semantic = getattr(tensor, "semantic", None)
+    tess = getattr(semantic, "tess", None)
+    if not fmt and tess is not None:
+        fmt = getattr(tess, "format", "")
+    fmt = str(fmt).upper()
+    if fmt and fmt != "BBOX":
+        raise RuntimeError(f"capture_expected_bbox format={fmt}")
+    try:
+        payload = tensor.copy_payload_bytes()
+    except Exception as exc:
+        raise RuntimeError(f"capture_payload_failed err={exc}") from exc
+    if not payload:
+        raise RuntimeError("capture_empty_payload")
+    return payload
+
+
+def extract_bbox_payload(sample) -> bytes:
+    if sample.kind == pyneat.SampleKind.Bundle:
+        for field in sample.fields:
+            try:
+                return extract_bbox_payload(field)
+            except RuntimeError:
+                continue
+        raise RuntimeError("bundle missing BBOX field")
+
+    if sample.kind == pyneat.SampleKind.TensorSet and sample.tensors:
+        return extract_tensor_bbox_payload(sample, sample.tensors[0])
+
+    if sample.kind != pyneat.SampleKind.Tensor:
+        raise RuntimeError("capture_expected_tensor")
+    return extract_tensor_bbox_payload(sample)
+
+
+def parse_boxes_strict(payload: bytes, img_w: int, img_h: int, expected_topk: int) -> list[dict]:
     if len(payload) < 4:
-        return []
-    # Payload layout:
-    #   uint32 count
-    #   repeated { int32 x, int32 y, int32 w, int32 h, float score, int32 class_id }
-    #
-    # Guard the parsed count against truncated payloads so we never read past
-    # the actual buffer contents.
-    count = min(struct.unpack_from("<I", payload, 0)[0], (len(payload) - 4) // 24, max_detections)
+        raise RuntimeError("bbox buffer too small")
+
+    header = struct.unpack_from("<I", payload, 0)[0]
+    max_boxes = (len(payload) - 4) // 24
+    if header > max_boxes:
+        raise RuntimeError("bbox header exceeds payload count")
+    if expected_topk > 0 and header > expected_topk:
+        raise RuntimeError("bbox header exceeds expected topk")
+
     boxes = []
-    off = 4
-    for _ in range(count):
-        x, y, w, h, score, cls_id = struct.unpack_from("<iiiifi", payload, off)
-        off += 24
-        # Clamp every box back into the decoded frame. This keeps Insight metadata
-        # consistent even if the payload contains slightly out-of-bounds values.
-        x1 = max(0.0, min(float(img_w), float(x)))
-        y1 = max(0.0, min(float(img_h), float(y)))
-        x2 = max(0.0, min(float(img_w), float(x + w)))
-        y2 = max(0.0, min(float(img_h), float(y + h)))
-        # Skip degenerate boxes after clamping so downstream consumers only see
-        # valid xyxy coordinates.
-        if x2 <= x1 or y2 <= y1:
-            continue
+    offset = 4
+    for _ in range(header):
+        x, y, w, h, score, class_id = struct.unpack_from("<iiiifi", payload, offset)
+        offset += 24
         boxes.append(
             {
-                "x1": x1,
-                "y1": y1,
-                "x2": x2,
-                "y2": y2,
+                "x1": max(0.0, min(float(x), float(img_w))),
+                "y1": max(0.0, min(float(y), float(img_h))),
+                "x2": max(0.0, min(float(x + w), float(img_w))),
+                "y2": max(0.0, min(float(y + h), float(img_h))),
                 "score": float(score),
-                "class_id": int(cls_id),
+                "class_id": int(class_id),
             }
         )
     return boxes
 
 
-def probe_rtsp(url: str) -> tuple[int, int, int]:
-    """Probe the stream once so the rest of the pipeline uses real dimensions.
+def build_metadata_boxes(boxes: list[dict], labels: list[str], frame_w: int, frame_h: int) -> list[dict]:
+    metadata_boxes = []
+    for index, box in enumerate(boxes, start=1):
+        x = max(0, int(box["x1"]))
+        y = max(0, int(box["y1"]))
+        w = max(0, int(box["x2"] - box["x1"]))
+        h = max(0, int(box["y2"] - box["y1"]))
+        if x + w > frame_w:
+            w = frame_w - x
+        if y + h > frame_h:
+            h = frame_h - y
+        class_id = int(box["class_id"])
+        metadata_boxes.append(
+            {
+                "id": f"obj_{index}",
+                "label": labels[class_id] if 0 <= class_id < len(labels) else "unknown",
+                "confidence": float(box["score"]),
+                "bbox": [float(x), float(y), float(max(0, w)), float(max(0, h))],
+            }
+        )
+    return metadata_boxes
 
-    The Python sample keeps this step explicit instead of hardcoding 640x480,
-    which makes the output path behave correctly for streams such as 720p.
-    """
+
+def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap = cv2.VideoCapture(url)
     if not cap.isOpened():
         raise RuntimeError(f"failed to open RTSP source for probing: {url}")
@@ -249,77 +342,58 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     if width <= 0 or height <= 0:
         raise RuntimeError("failed to probe RTSP frame size")
     if fps <= 0:
-        fps = DEFAULT_FPS
+        raise RuntimeError("failed to probe RTSP frame rate")
     return width, height, fps
 
 
-def make_source_options(cfg: AppConfig, width: int, height: int, fps: int):
-    ro = pyneat.RtspDecodedInputOptions()
-    ro.url = cfg.source.rtsp_url
-    ro.latency_ms = cfg.source.latency_ms
-    ro.tcp = cfg.source.tcp
-    ro.payload_type = 96
-    ro.insert_queue = True
-    ro.out_format = "NV12"
-    ro.decoder_name = "decoder"
-    ro.decoder_raw_output = True
-    ro.auto_caps_from_stream = True
-    ro.fallback_h264_width = width
-    ro.fallback_h264_height = height
-    ro.fallback_h264_fps = fps
-    ro.sima_allocator_type = 2
-    ro.use_videoconvert = False
-    return ro
+def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
+    opt = pyneat.RtspDecodedInputOptions()
+    opt.url = cfg.rtsp_url
+    opt.latency_ms = cfg.latency_ms
+    opt.tcp = cfg.tcp
+    opt.payload_type = 96
+    opt.insert_queue = True
+    opt.decoder_name = "decoder"
+    opt.decoder_raw_output = True
+    opt.auto_caps_from_stream = True
+    opt.fallback_h264_width = width
+    opt.fallback_h264_height = height
+    opt.fallback_h264_fps = fps
+    return opt
 
 
-def build_model(model_path: str, inference: InferenceConfig) -> pyneat.Model:
-    """Create the YOLO model for model-managed YOLO26 preprocessing and decode."""
+def make_model(cfg: AppConfig):
     opt = pyneat.ModelOptions()
     opt.preprocess.kind = pyneat.InputKind.Image
     opt.preprocess.enable = pyneat.AutoFlag.On
     opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.NV12
     opt.preprocess.preset = pyneat.NormalizePreset.COCO_YOLO
     opt.decode_type = pyneat.BoxDecodeType.YoloV26
-    opt.score_threshold = inference.min_score
-    opt.nms_iou_threshold = inference.nms_iou
-    opt.top_k = inference.max_detections
-    return pyneat.Model(model_path, opt)
+    opt.score_threshold = cfg.min_score
+    opt.nms_iou_threshold = cfg.nms_iou
+    opt.top_k = cfg.max_detections
+    return pyneat.Model(cfg.model_path, opt)
 
 
-@dataclass
-class PipelineRuntime:
-    graph: object
-    run: object
-    metadata_sender: object
-    labels: list[str]
-    frame_w: int
-    frame_h: int
-    output_fps: int
-    video_port: int
+def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
+    frame_w, frame_h, fps = probe_rtsp(cfg.rtsp_url)
+    model = make_model(cfg)
+    labels = load_labels(cfg.labels_path)
 
-
-def build_pipeline(cfg: AppConfig, model_path: str) -> PipelineRuntime:
-    frame_w, frame_h, fps = probe_rtsp(cfg.source.rtsp_url)
-    model = build_model(model_path, cfg.inference)
-    labels = load_labels(cfg.model.labels)
-
-    source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, frame_w, frame_h, fps))
-    source_outputs = ["video", "model"]
+    source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, fps, frame_w, frame_h))
+    outputs = ["video", "model"]
     if cfg.save_dir and cfg.save_every > 0:
-        source_outputs.append("frames")
-    branch = pyneat.graphs.branch("source", source_outputs)
+        outputs.append("frames")
+    branch = pyneat.graphs.branch("source", outputs)
 
-    sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, max(1, fps))
-    sender_opt.host = cfg.insight.host
-    sender_opt.channel = 0
-    sender_opt.video_port_base = cfg.insight.video_port
-    sender_opt.encoder.bitrate_kbps = 600
+    video_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, fps)
+    video_options.host = cfg.insight_host
+    video_options.channel = 0
+    video_options.video_port_base = cfg.video_port
+    video_options.encoder.bitrate_kbps = 1200
 
     video_graph = pyneat.Graph("video")
-    video_graph.connect(
-        pyneat.nodes.input("video"),
-        pyneat.groups.video_sender(sender_opt),
-    )
+    video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
 
     model_graph = pyneat.Graph("model")
     model_graph.connect(pyneat.nodes.input("model"), model)
@@ -334,106 +408,55 @@ def build_pipeline(cfg: AppConfig, model_path: str) -> PipelineRuntime:
         frames = pyneat.Graph("frames")
         frames.add(pyneat.nodes.output("frames", pyneat.OutputOptions.latest()))
         graph.connect(branch, frames)
+    if cfg.profile:
+        print(f"Backend:\n{graph.describe_backend()}")
 
-    run_opt = pyneat.RunOptions()
-    run_opt.preset = pyneat.RunPreset.Reliable
-    run_opt.queue_depth = 4
-    run_opt.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_opt.output_memory = pyneat.OutputMemory.Owned
-    run = graph.build(run_opt)
-    metadata_sender = build_metadata_sender(cfg)
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Reliable
+    run_options.queue_depth = 4
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.Owned
+    run = graph.build(run_options)
+
+    metadata_options = pyneat.MetadataSenderOptions()
+    metadata_options.host = cfg.insight_host
+    metadata_options.channel = 0
+    metadata_options.metadata_port_base = cfg.metadata_port
+    metadata_sender = pyneat.MetadataSender(metadata_options)
+
     print(
-        f"rtsp={cfg.source.rtsp_url} stream={frame_w}x{frame_h}@{fps} "
-        f"insight={cfg.insight.host} video={sender_opt.video_port} "
+        f"rtsp={cfg.rtsp_url} stream={frame_w}x{frame_h}@{fps} "
+        f"insight={cfg.insight_host} video={video_options.video_port} "
         f"metadata={metadata_sender.metadata_port()} channel=0"
     )
     return PipelineRuntime(
+        model=model,
         graph=graph,
         run=run,
         metadata_sender=metadata_sender,
         labels=labels,
         frame_w=frame_w,
         frame_h=frame_h,
-        output_fps=fps,
-        video_port=sender_opt.video_port,
+        video_port=video_options.video_port,
     )
 
 
-def build_metadata_sender(cfg: AppConfig):
-    options = pyneat.MetadataSenderOptions()
-    options.host = cfg.insight.host
-    options.channel = 0
-    options.metadata_port_base = cfg.insight.metadata_port
-    return pyneat.MetadataSender(options)
+def send_metadata(runtime: PipelineRuntime, sample, boxes: list[dict]) -> None:
+    metadata_boxes = build_metadata_boxes(boxes, runtime.labels, runtime.frame_w, runtime.frame_h)
+    frame_id = getattr(sample, "frame_id", -1)
+    if frame_id is None or frame_id < 0:
+        frame_id = 0
+    runtime.metadata_sender.send_metadata(
+        "object-detection",
+        json.dumps({"objects": metadata_boxes}, separators=(",", ":")),
+        int(time.time() * 1000),
+        str(frame_id),
+    )
 
 
-def load_labels(path: Path) -> list[str]:
-    if not path.is_file():
-        raise FileNotFoundError(f"Labels file does not exist: {path}")
-    labels = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-    if not labels:
-        raise ValueError(f"Labels file is empty: {path}")
-    return labels
-
-
-def class_name(labels: list[str], class_id: int) -> str:
-    return labels[class_id] if 0 <= class_id < len(labels) else "unknown"
-
-
-def make_object_detection_data_json(boxes: list[dict], labels: list[str]) -> str:
-    """Build the object-detection metadata data object."""
-    objects = []
-    for idx, box in enumerate(boxes, start=1):
-        cls_id = int(box["class_id"])
-        objects.append(
-            {
-                "id": f"obj_{idx}",
-                "label": class_name(labels, cls_id),
-                "confidence": float(box["score"]),
-                "bbox": [
-                    float(box["x1"]),
-                    float(box["y1"]),
-                    float(box["x2"] - box["x1"]),
-                    float(box["y2"] - box["y1"]),
-                ],
-            }
-        )
-    return json.dumps({"objects": objects}, separators=(",", ":"))
-
-
-def save_annotated_frame(
-    frame: np.ndarray,
-    boxes: list[dict],
-    labels: list[str],
-    min_score: float,
-    out_path: Path,
-) -> None:
-    """Write one BGR frame with detection boxes for e2e/debug inspection."""
-    annotated = frame.copy()
-    for box in boxes:
-        score = float(box["score"])
-        if score < min_score:
-            continue
-        cls_id = int(box["class_id"])
-        label = class_name(labels, cls_id)
-        x1 = int(round(box["x1"]))
-        y1 = int(round(box["y1"]))
-        x2 = int(round(box["x2"]))
-        y2 = int(round(box["y2"]))
-        cv2.rectangle(annotated, (x1, y1), (x2, y2), (0, 255, 0), 2)
-        cv2.putText(
-            annotated,
-            f"{label} {score:.2f}",
-            (x1, max(0, y1 - 4)),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.5,
-            (0, 255, 0),
-            1,
-            cv2.LINE_AA,
-        )
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    if not cv2.imwrite(str(out_path), annotated):
-        raise RuntimeError(f"failed to write output frame: {out_path}")
+def tensor_dim(tensor, name: str) -> int:
+    value = getattr(tensor, name)
+    return int(value() if callable(value) else value)
 
 
 def first_tensor_from_sample(sample):
@@ -450,346 +473,130 @@ def first_tensor_from_sample(sample):
     return None
 
 
-def maybe_save_debug_frame(runtime: PipelineRuntime, cfg: AppConfig, processed: int, boxes: list[dict]) -> None:
+def tensor_bgr_from_decoded(tensor):
+    if tensor.is_nv12():
+        width = tensor_dim(tensor, "width")
+        height = tensor_dim(tensor, "height")
+        payload = np.frombuffer(tensor.copy_payload_bytes(), dtype=np.uint8)
+        expected = width * height * 3 // 2
+        if payload.size < expected:
+            raise RuntimeError(f"NV12 payload too small: {payload.size} < {expected}")
+        nv12 = payload[:expected].reshape((height * 3 // 2, width))
+        return np.ascontiguousarray(cv2.cvtColor(nv12, cv2.COLOR_YUV2BGR_NV12))
+
+    if tensor.is_i420():
+        width = tensor_dim(tensor, "width")
+        height = tensor_dim(tensor, "height")
+        payload = np.frombuffer(tensor.copy_payload_bytes(), dtype=np.uint8)
+        expected = width * height * 3 // 2
+        if payload.size < expected:
+            raise RuntimeError(f"I420 payload too small: {payload.size} < {expected}")
+        i420 = payload[:expected].reshape((height * 3 // 2, width))
+        return np.ascontiguousarray(cv2.cvtColor(i420, cv2.COLOR_YUV2BGR_I420))
+
+    frame = np.asarray(tensor.to_numpy(copy=True))
+    if frame.ndim == 4 and frame.shape[0] == 1:
+        frame = frame[0]
+    if frame.ndim != 3:
+        raise RuntimeError(f"unexpected decoded tensor shape {frame.shape}")
+    if frame.dtype != np.uint8:
+        frame = np.clip(frame, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(frame)
+
+
+def draw_boxes(frame, boxes: list[dict], min_score: float) -> None:
+    for box in boxes:
+        score = float(box["score"])
+        if score < min_score:
+            continue
+        x1 = max(0, int(round(box["x1"])))
+        y1 = max(0, int(round(box["y1"])))
+        x2 = min(frame.shape[1] - 1, int(round(box["x2"])))
+        y2 = min(frame.shape[0] - 1, int(round(box["y2"])))
+        if x2 <= x1 or y2 <= y1:
+            continue
+        cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        label = f"id={int(box['class_id'])} score={score:.6f}"
+        cv2.putText(
+            frame,
+            label,
+            (x1, max(0, y1 - 4)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.4,
+            (0, 255, 0),
+            1,
+        )
+
+
+def maybe_save_debug_frame(runtime: PipelineRuntime, cfg: AppConfig, processed: int,
+                           boxes: list[dict]) -> None:
     if not cfg.save_dir or cfg.save_every <= 0 or processed % cfg.save_every != 0:
         return
+
     frame_sample = runtime.run.pull("frames", 0)
     frame_tensor = first_tensor_from_sample(frame_sample)
     if frame_tensor is None:
         return
+
     frame = tensor_bgr_from_decoded(frame_tensor)
-    save_annotated_frame(
-        frame,
-        boxes,
-        runtime.labels,
-        cfg.inference.min_score,
-        Path(cfg.save_dir) / f"frame_{processed}.jpg",
-    )
+    draw_boxes(frame, boxes, cfg.min_score)
+    out_path = Path(cfg.save_dir) / f"frame_{processed}.jpg"
+    if not cv2.imwrite(str(out_path), frame):
+        print(f"[warn] failed to write output frame: {out_path}", file=sys.stderr)
 
 
-def send_metadata(runtime: PipelineRuntime, sample, boxes: list[dict]) -> None:
-    data_json = make_object_detection_data_json(boxes, runtime.labels)
-    frame_id = getattr(sample, "frame_id", -1)
-    if frame_id is None or frame_id < 0:
-        frame_id = 0
-    runtime.metadata_sender.send_metadata(
-        "object-detection",
-        data_json,
-        int(time.time() * 1000),
-        str(frame_id),
-    )
+def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
+    profile = ProfileWindow(cfg.profile, cfg.profile_interval)
+    processed = 0
+    while cfg.frames <= 0 or processed < cfg.frames:
+        pull_start = time_ms()
+        detection_sample = runtime.run.pull("detections", 20000)
+        pull_end = time_ms()
+        if detection_sample is None:
+            print("[warn] timed out waiting for detections", file=sys.stderr)
+            continue
 
+        payload = extract_bbox_payload(detection_sample)
+        boxes = parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h, cfg.max_detections)
 
-def build_arg_parser() -> argparse.ArgumentParser:
-    """Expose only the small set of controls needed for this reference flow."""
-    parser = argparse.ArgumentParser(description="Single-camera RTSP YOLO26 Insight example")
-    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
-    parser.add_argument(
-        "--validate-config-only",
-        action="store_true",
-        help="Validate config and exit without opening the RTSP stream.",
-    )
-    return parser
+        metadata_start = time_ms()
+        send_metadata(runtime, detection_sample, boxes)
+        metadata_end = time_ms()
 
+        processed += 1
+        maybe_save_debug_frame(runtime, cfg, processed, boxes)
+        profile.add(pull_end - pull_start, metadata_end - metadata_start, len(boxes))
 
-def _mapping(value, name: str) -> dict:
-    if value is None:
-        return {}
-    if not isinstance(value, dict):
-        raise ValueError(f"{name} must be a mapping")
-    return value
-
-
-def _required_string(mapping: dict, key: str, section: str) -> str:
-    value = mapping.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{section}.{key} must be a non-empty string")
-    return value
-
-
-def _optional_int(mapping: dict, key: str, default: int) -> int:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, int):
-        raise ValueError(f"{key} must be an integer")
-    return int(value)
-
-
-def _optional_float(mapping: dict, key: str, default: float) -> float:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, (int, float)):
-        raise ValueError(f"{key} must be numeric")
-    return float(value)
-
-
-def _optional_bool(mapping: dict, key: str, default: bool) -> bool:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, bool):
-        raise ValueError(f"{key} must be true or false")
-    return bool(value)
-
-
-def _optional_string(mapping: dict, key: str, default: str) -> str:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, str):
-        raise ValueError(f"{key} must be a string")
-    return value
-
-
-def load_app_config(config_path: Path) -> AppConfig:
-    with config_path.open("r", encoding="utf-8") as handle:
-        raw = yaml.safe_load(handle) or {}
-
-    if not isinstance(raw, dict):
-        raise ValueError("config root must be a mapping")
-
-    model_cfg = _mapping(raw.get("model"), "model")
-    source_cfg = _mapping(raw.get("source"), "source")
-    inference_cfg = _mapping(raw.get("inference"), "inference")
-    runtime_cfg = _mapping(raw.get("runtime"), "runtime")
-    output_cfg = _mapping(raw.get("output"), "output")
-    insight_cfg = _mapping(output_cfg.get("insight"), "output.insight")
-    default_labels = Path(__file__).resolve().parents[1] / "common" / "coco_label.txt"
-
-    cfg = AppConfig(
-        model=ModelConfig(
-            path=_required_string(model_cfg, "path", "model"),
-            labels=Path(_optional_string(model_cfg, "labels", str(default_labels))),
-        ),
-        source=SourceConfig(
-            rtsp_url=_required_string(source_cfg, "rtsp_url", "source"),
-            latency_ms=_optional_int(source_cfg, "latency_ms", 200),
-            tcp=_optional_bool(source_cfg, "tcp", True),
-        ),
-        inference=InferenceConfig(
-            frames=_optional_int(inference_cfg, "frames", 0),
-            min_score=_optional_float(inference_cfg, "min_score", 0.55),
-            nms_iou=_optional_float(inference_cfg, "nms_iou", 0.50),
-            max_detections=_optional_int(inference_cfg, "max_detections", 100),
-        ),
-        runtime=RuntimeConfig(
-            profile=_optional_bool(runtime_cfg, "profile", False),
-            profile_interval=_optional_int(runtime_cfg, "profile_interval", 100),
-        ),
-        insight=InsightConfig(
-            host=_required_string(insight_cfg, "host", "output.insight"),
-            video_port=_optional_int(insight_cfg, "video_port", 9000),
-            metadata_port=_optional_int(insight_cfg, "metadata_port", 9100),
-        ),
-        save_dir=_optional_string(output_cfg, "save_dir", ""),
-        save_every=_optional_int(output_cfg, "save_every", 0),
-    )
-
-    if cfg.source.latency_ms < 0:
-        raise ValueError("source.latency_ms must be >= 0")
-    if cfg.inference.frames < 0:
-        raise ValueError("inference.frames must be >= 0")
-    if cfg.save_every < 0:
-        raise ValueError("output.save_every must be >= 0")
-    if not 0.0 <= cfg.inference.min_score <= 1.0:
-        raise ValueError("inference.min_score must be between 0 and 1")
-    if not 0.0 <= cfg.inference.nms_iou <= 1.0:
-        raise ValueError("inference.nms_iou must be between 0 and 1")
-    if cfg.inference.max_detections <= 0:
-        raise ValueError("inference.max_detections must be > 0")
-    if cfg.runtime.profile_interval <= 0:
-        raise ValueError("runtime.profile_interval must be > 0")
-    if cfg.insight.video_port <= 0:
-        raise ValueError("output.insight.video_port must be > 0")
-    if cfg.insight.metadata_port <= 0:
-        raise ValueError("output.insight.metadata_port must be > 0")
-
-    return cfg
-
-
-class ProfileWindow:
-    def __init__(self, enabled: bool, interval: int) -> None:
-        self.enabled = enabled
-        self.interval = interval
-        self.reset()
-
-    def reset(self) -> None:
-        self.frames = 0
-        self.boxes = 0
-        self.started = 0.0
-        self.detection_pull_ms = 0.0
-        self.metadata_send_ms = 0.0
-
-    def add(
-        self,
-        *,
-        detection_pull_ms: float,
-        metadata_send_ms: float,
-        boxes: int,
-    ) -> None:
-        if not self.enabled:
-            return
-        if self.frames == 0:
-            self.started = time.perf_counter()
-        self.frames += 1
-        self.boxes += boxes
-        self.detection_pull_ms += detection_pull_ms
-        self.metadata_send_ms += metadata_send_ms
-        if self.frames >= self.interval:
-            self.flush()
-
-    def flush(self) -> None:
-        if not self.enabled or self.frames == 0:
-            return
-        elapsed = max(time.perf_counter() - self.started, 1e-6)
-        frames = float(self.frames)
-        print(
-            f"[profile] frames={self.frames} "
-            f"output_fps={self.frames / elapsed:.2f} "
-            f"avg_detection_pull_ms={self.detection_pull_ms / frames:.2f} "
-            f"avg_metadata_send_ms={self.metadata_send_ms / frames:.2f} "
-            f"avg_boxes={self.boxes / frames:.2f}",
-            flush=True,
-        )
-        self.reset()
-
-
-def resolve_yolo26_model(root: Path) -> str:
-    """Mirror the C++ sample's local-first model lookup strategy.
-
-    Resolution order:
-
-    1. explicit environment override
-    2. local/common modelzoo directories
-    3. `sima-cli download <YOLO26 detector URL>`
-    """
-    env_path = os.environ.get("SIMA_YOLO_TAR", "")
-    if env_path and Path(env_path).exists():
-        return env_path
-
-    tmp_dir = root / "tmp"
-    tmp_dir.mkdir(parents=True, exist_ok=True)
-    model_name = "yolo26m-det-bf16-mla_tess-b1.tar.gz"
-    model_url = (
-        "https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/"
-        f"yolo26-detection/{model_name}"
-    )
-    tmp_tar = tmp_dir / model_name
-    direct_tar = root / model_name
-    if direct_tar.exists():
-        return str(direct_tar)
-    if tmp_tar.exists():
-        return str(tmp_tar)
-
-    home = Path.home()
-    search_dirs = [
-        root / "models",
-        root,
-        Path.cwd(),
-        root / "tmp",
-        home / ".simaai",
-        home / ".simaai" / "modelzoo",
-        home / ".sima" / "modelzoo",
-        Path("/data/simaai/modelzoo"),
-    ]
-    names = [
-        model_name,
-    ]
-    for directory in search_dirs:
-        for name in names:
-            candidate = directory / name
-            if candidate.exists():
-                return str(candidate)
-
-    try:
-        subprocess.run(["sima-cli", "download", model_url], cwd=str(tmp_dir), check=True)
-    except Exception:
-        return ""
-
-    if tmp_tar.exists():
-        return str(tmp_tar)
-    for directory in search_dirs:
-        for name in names:
-            candidate = directory / name
-            if candidate.exists():
-                return str(candidate)
-    return ""
+    profile.flush()
+    print(f"processed={processed} video_sender={cfg.insight_host}:{runtime.video_port}")
+    return processed
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_arg_parser().parse_args(argv)
     try:
+        args = parse_args(argv)
         cfg = load_app_config(args.config)
-    except Exception as exc:
-        print(f"Error: failed to load config {args.config}: {exc}", file=sys.stderr)
-        return 2
-    if args.validate_config_only:
-        print(f"Config validated: {args.config}")
-        return 0
+        if args.validate_config_only:
+            print(f"Config validated: {args.config}")
+            return 0
 
-    load_runtime_dependencies()
-    model_path = cfg.model.path or resolve_yolo26_model(Path.cwd())
-    if not model_path or not Path(model_path).is_file():
-        print("Failed to locate YOLO26 detector model package.", file=sys.stderr)
-        print("Set model.path or download a YOLO26 detector package with sima-cli.", file=sys.stderr)
-        return 2
+        load_runtime_dependencies()
+        if cfg.profile:
+            os.environ.setdefault("SIMA_GST_ELEMENT_TIMINGS", "1")
+            os.environ.setdefault("SIMA_GST_FLOW_DEBUG", "1")
+            os.environ.setdefault("SIMA_GST_BOUNDARY_PROBES", "1")
+        if cfg.save_dir:
+            Path(cfg.save_dir).mkdir(parents=True, exist_ok=True)
 
-    runtime = None
-    try:
-        runtime = build_pipeline(cfg, model_path)
-
-        processed = 0
-        started = time.perf_counter()
-        profile_window = ProfileWindow(cfg.runtime.profile, cfg.runtime.profile_interval)
-        save_dir = Path(cfg.save_dir) if cfg.save_dir else None
-        if save_dir is not None:
-            save_dir.mkdir(parents=True, exist_ok=True)
-        while cfg.inference.frames <= 0 or processed < cfg.inference.frames:
-            pull_start = time.perf_counter()
-            detection_sample = runtime.run.pull("detections", 20000)
-            pull_end = time.perf_counter()
-            if detection_sample is None:
-                print("[warn] timed out waiting for detections", file=sys.stderr)
-                continue
-
-            payload = extract_bbox_payload(detection_sample)
-            if not payload:
-                raise RuntimeError("model returned no BBOX payload")
-            boxes = parse_bbox_payload(
-                payload,
-                runtime.frame_w,
-                runtime.frame_h,
-                cfg.inference.max_detections,
-            )
-
-            metadata_start = time.perf_counter()
-            send_metadata(runtime, detection_sample, boxes)
-            metadata_end = time.perf_counter()
-
-            processed += 1
-            maybe_save_debug_frame(runtime, cfg, processed, boxes)
-            profile_window.add(
-                detection_pull_ms=(pull_end - pull_start) * 1000.0,
-                metadata_send_ms=(metadata_end - metadata_start) * 1000.0,
-                boxes=len(boxes),
-            )
-
-        elapsed = max(time.perf_counter() - started, 1e-6)
-        profile_window.flush()
-        print(f"processed={processed} fps={processed / elapsed:.2f} "
-              f"video_sender={cfg.insight.host}:{runtime.video_port}")
-        return 0 if processed > 0 else 3
-    except Exception as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 2
-    finally:
+        runtime = build_pipeline(cfg)
         try:
-            if runtime is not None:
-                runtime.run.close()
-        except Exception:
-            pass
+            run_pipeline(runtime, cfg)
+        finally:
+            runtime.run.close()
+        return 0
+    except Exception as exc:
+        print(f"[ERR] {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -381,9 +381,10 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     labels = load_labels(cfg.labels_path)
 
     source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, fps, frame_w, frame_h))
+    save_debug_frames = bool(cfg.save_dir and cfg.save_every > 0)
     outputs = ["video", "model"]
-    if cfg.save_dir and cfg.save_every > 0:
-        outputs.append("frames")
+    if save_debug_frames:
+        outputs.append("debug_frame")
     branch = pyneat.graphs.branch("source", outputs)
 
     video_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, fps)
@@ -397,17 +398,24 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
 
     model_graph = pyneat.Graph("model")
     model_graph.connect(pyneat.nodes.input("model"), model)
-    detections = pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4))
+
+    detections_graph = pyneat.Graph("detections")
+    detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
 
     graph = pyneat.Graph()
     graph.connect(source, branch)
     graph.connect(branch, video_graph)
     graph.connect(branch, model_graph)
-    graph.connect(model_graph, detections)
-    if cfg.save_dir and cfg.save_every > 0:
-        frames = pyneat.Graph("frames")
-        frames.add(pyneat.nodes.output("frames", pyneat.OutputOptions.latest()))
+    graph.connect(model_graph, detections_graph)
+    if save_debug_frames:
+        frames = pyneat.Graph("debug_frame")
+        frames.add(pyneat.nodes.output("debug_frame", pyneat.OutputOptions.every_frame(4)))
+        debug_join = pyneat.graphs.combine(
+            ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByPts
+        )
         graph.connect(branch, frames)
+        graph.connect(frames, debug_join)
+        graph.connect(detections_graph, debug_join)
     if cfg.profile:
         print(f"Backend:\n{graph.describe_backend()}")
 
@@ -528,13 +536,11 @@ def draw_boxes(frame, boxes: list[dict], min_score: float) -> None:
         )
 
 
-def maybe_save_debug_frame(runtime: PipelineRuntime, cfg: AppConfig, processed: int,
-                           boxes: list[dict]) -> None:
+def maybe_save_debug_frame(cfg: AppConfig, processed: int, sample, boxes: list[dict]) -> None:
     if not cfg.save_dir or cfg.save_every <= 0 or processed % cfg.save_every != 0:
         return
 
-    frame_sample = runtime.run.pull("frames", 0)
-    frame_tensor = first_tensor_from_sample(frame_sample)
+    frame_tensor = first_tensor_from_sample(sample)
     if frame_tensor is None:
         return
 
@@ -547,10 +553,11 @@ def maybe_save_debug_frame(runtime: PipelineRuntime, cfg: AppConfig, processed: 
 
 def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
     profile = ProfileWindow(cfg.profile, cfg.profile_interval)
+    output_name = "debug_output" if cfg.save_dir and cfg.save_every > 0 else "detections"
     processed = 0
     while cfg.frames <= 0 or processed < cfg.frames:
         pull_start = time_ms()
-        detection_sample = runtime.run.pull("detections", 20000)
+        detection_sample = runtime.run.pull(output_name, 20000)
         pull_end = time_ms()
         if detection_sample is None:
             print("[warn] timed out waiting for detections", file=sys.stderr)
@@ -564,7 +571,7 @@ def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
         metadata_end = time_ms()
 
         processed += 1
-        maybe_save_debug_frame(runtime, cfg, processed, boxes)
+        maybe_save_debug_frame(cfg, processed, detection_sample, boxes)
         profile.add(pull_end - pull_start, metadata_end - metadata_start, len(boxes))
 
     profile.flush()

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -390,7 +390,7 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     video_options.host = cfg.insight_host
     video_options.channel = 0
     video_options.video_port_base = cfg.video_port
-    video_options.encoder.bitrate_kbps = 1200
+    video_options.encoder.bitrate_kbps = 1000
 
     video_graph = pyneat.Graph("video")
     video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
@@ -412,10 +412,10 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
         print(f"Backend:\n{graph.describe_backend()}")
 
     run_options = pyneat.RunOptions()
-    run_options.preset = pyneat.RunPreset.Reliable
-    run_options.queue_depth = 4
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 3
     run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_options.output_memory = pyneat.OutputMemory.Owned
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
     run = graph.build(run_options)
 
     metadata_options = pyneat.MetadataSenderOptions()

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -6,12 +6,10 @@ This mirrors the intent of the C++ reference sample in the same folder:
 - run one YOLO26 detector
 - publish H.264 video plus detection metadata to Insight
 
-The implementation keeps those responsibilities loosely separated so the main
-runtime path is easy to reason about:
+The runtime path is one composed graph:
 
-1. RTSP probe/build
-2. YOLO26 inference and box extraction
-3. Insight video/metadata publishing
+RtspDecodedInput -> Branch -> VideoSender
+                         -> Model -> detections
 """
 
 from __future__ import annotations
@@ -29,34 +27,15 @@ from pathlib import Path
 import yaml
 
 DEFAULT_FPS = 30
-SOURCE_RUN_QUEUE_DEPTH = 4
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
 cv2 = None
 np = None
 pyneat = None
-DFL_BINS_16 = None
-
-# Standard COCO class order for the bundled YOLO26 detector model used by this sample.
-COCO80_NAMES = [
-    "person", "bicycle", "car", "motorcycle", "airplane", "bus",
-    "train", "truck", "boat", "traffic light", "fire hydrant", "stop sign",
-    "parking meter", "bench", "bird", "cat", "dog", "horse",
-    "sheep", "cow", "elephant", "bear", "zebra", "giraffe",
-    "backpack", "umbrella", "handbag", "tie", "suitcase", "frisbee",
-    "skis", "snowboard", "sports ball", "kite", "baseball bat", "baseball glove",
-    "skateboard", "surfboard", "tennis racket", "bottle", "wine glass", "cup",
-    "fork", "knife", "spoon", "bowl", "banana", "apple",
-    "sandwich", "orange", "broccoli", "carrot", "hot dog", "pizza",
-    "donut", "cake", "chair", "couch", "potted plant", "bed",
-    "dining table", "toilet", "tv", "laptop", "mouse", "remote",
-    "keyboard", "cell phone", "microwave", "oven", "toaster", "sink",
-    "refrigerator", "book", "clock", "vase", "scissors", "teddy bear",
-    "hair drier", "toothbrush",
-]
 
 @dataclass(frozen=True)
 class ModelConfig:
     path: str
+    labels: Path
 
 
 @dataclass(frozen=True)
@@ -100,7 +79,7 @@ class AppConfig:
 
 def load_runtime_dependencies() -> None:
     """Import runtime-only dependencies after argparse validation."""
-    global cv2, np, pyneat, DFL_BINS_16
+    global cv2, np, pyneat
     if pyneat is not None:
         return
 
@@ -116,7 +95,6 @@ def load_runtime_dependencies() -> None:
     cv2 = cv2_module
     np = np_module
     pyneat = pyneat_module
-    DFL_BINS_16 = np.arange(16, dtype=np.float32)
 
 
 def tensor_to_numpy(tensor: pyneat.Tensor) -> np.ndarray:
@@ -159,47 +137,6 @@ def tensor_bgr_from_decoded(tensor: pyneat.Tensor) -> np.ndarray:
     if arr.dtype != np.uint8:
         arr = np.clip(arr, 0, 255).astype(np.uint8)
     return np.ascontiguousarray(arr)
-
-
-def tensor_from_bgr_frame(frame: np.ndarray) -> pyneat.Tensor:
-    """Create an EV74 BGR image tensor for model-managed YOLO inference."""
-    return pyneat.Tensor.from_numpy(
-        np.ascontiguousarray(frame),
-        copy=True,
-        image_format=pyneat.PixelFormat.BGR,
-        memory=pyneat.TensorMemory.EV74,
-    )
-
-
-def blank_nv12_tensor(width: int, height: int) -> pyneat.Tensor:
-    """Create a CPU-backed blank NV12 tensor with explicit Y and UV plane metadata."""
-    if width <= 0 or height <= 0 or width % 2 != 0 or height % 2 != 0:
-        raise ValueError("NV12 requires positive even width and height")
-    payload = np.zeros((height * 3 // 2, width), dtype=np.uint8)
-    tensor = pyneat.Tensor.from_numpy(
-        payload,
-        copy=True,
-        layout=pyneat.TensorLayout.HW,
-        image_format=pyneat.PixelFormat.NV12,
-        memory=pyneat.TensorMemory.CPU,
-    )
-    tensor.shape = [height, width]
-    tensor.strides_bytes = [width, 1]
-
-    y_plane = pyneat.Plane()
-    y_plane.role = pyneat.PlaneRole.Y
-    y_plane.shape = [height, width]
-    y_plane.strides_bytes = [width, 1]
-    y_plane.byte_offset = 0
-
-    uv_plane = pyneat.Plane()
-    uv_plane.role = pyneat.PlaneRole.UV
-    uv_plane.shape = [height // 2, width]
-    uv_plane.strides_bytes = [width, 1]
-    uv_plane.byte_offset = width * height
-
-    tensor.planes = [y_plane, uv_plane]
-    return tensor
 
 
 def is_tensor_like(value) -> bool:
@@ -316,45 +253,23 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     return width, height, fps
 
 
-def build_rtsp_run(
-    url: str,
-    width: int,
-    height: int,
-    fps: int,
-    latency_ms: int,
-    tcp: bool,
-) -> tuple[pyneat.Graph, pyneat.Run]:
-    """Build a decoded RTSP input graph that yields decoded frame tensors."""
+def make_source_options(cfg: AppConfig, width: int, height: int, fps: int):
     ro = pyneat.RtspDecodedInputOptions()
-    ro.url = url
-    ro.latency_ms = latency_ms
-    ro.tcp = tcp
+    ro.url = cfg.source.rtsp_url
+    ro.latency_ms = cfg.source.latency_ms
+    ro.tcp = cfg.source.tcp
     ro.payload_type = 96
     ro.insert_queue = True
+    ro.out_format = "NV12"
+    ro.decoder_name = "decoder"
+    ro.decoder_raw_output = True
     ro.auto_caps_from_stream = True
     ro.fallback_h264_width = width
     ro.fallback_h264_height = height
     ro.fallback_h264_fps = fps
     ro.sima_allocator_type = 2
-    ro.decoder_raw_output = False
     ro.use_videoconvert = False
-    ro.use_videoscale = True
-    ro.output_caps.enable = True
-    ro.output_caps.width = width
-    ro.output_caps.height = height
-    ro.output_caps.fps = fps
-    ro.output_caps.memory = pyneat.CapsMemory.SystemMemory
-
-    graph = pyneat.Graph()
-    graph.add(pyneat.groups.rtsp_decoded_input(ro))
-    graph.add(pyneat.nodes.output(pyneat.OutputOptions.every_frame(1)))
-
-    run_opt = pyneat.RunOptions()
-    run_opt.queue_depth = SOURCE_RUN_QUEUE_DEPTH
-    run_opt.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_opt.output_memory = pyneat.OutputMemory.Owned
-    run = graph.build(run_opt)
-    return graph, run
+    return ro
 
 
 def build_model(model_path: str, inference: InferenceConfig) -> pyneat.Model:
@@ -362,7 +277,7 @@ def build_model(model_path: str, inference: InferenceConfig) -> pyneat.Model:
     opt = pyneat.ModelOptions()
     opt.preprocess.kind = pyneat.InputKind.Image
     opt.preprocess.enable = pyneat.AutoFlag.On
-    opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.BGR
+    opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.NV12
     opt.preprocess.preset = pyneat.NormalizePreset.COCO_YOLO
     opt.decode_type = pyneat.BoxDecodeType.YoloV26
     opt.score_threshold = inference.min_score
@@ -371,56 +286,77 @@ def build_model(model_path: str, inference: InferenceConfig) -> pyneat.Model:
     return pyneat.Model(model_path, opt)
 
 
-def build_detector_run(model_path: str, width: int, height: int, inference: InferenceConfig):
-    """Build the explicit YOLO26 detector graph used by the RTSP loop."""
-    model = build_model(model_path, inference)
-
-    input_opt = model.input_appsrc_options(False)
-    input_opt.payload_type = pyneat.PayloadType.Image
-    input_opt.format = "BGR"
-    input_opt.width = width
-    input_opt.height = height
-    input_opt.depth = 3
-
-    graph = pyneat.Graph()
-    graph.add(pyneat.nodes.input(input_opt))
-    graph.add(model.graph())
-    graph.add(pyneat.nodes.output())
-
-    seed = tensor_from_bgr_frame(np.zeros((height, width, 3), dtype=np.uint8))
-    run_opt = pyneat.RunOptions()
-    run_opt.queue_depth = 4
-    run_opt.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_opt.output_memory = pyneat.OutputMemory.Owned
-    return model, graph, graph.build([seed], run_opt)
+@dataclass
+class PipelineRuntime:
+    graph: object
+    run: object
+    metadata_sender: object
+    labels: list[str]
+    frame_w: int
+    frame_h: int
+    output_fps: int
+    video_port: int
 
 
-def build_video_sender_run(cfg: AppConfig, width: int, height: int, fps: int):
-    """Build the generic NEAT video sender used by this Insight-targeted example."""
-    input_opt = pyneat.InputOptions()
-    input_opt.payload_type = pyneat.PayloadType.Image
-    input_opt.format = "NV12"
-    input_opt.width = width
-    input_opt.height = height
-    input_opt.fps_n = max(1, fps)
-    input_opt.fps_d = 1
-    input_opt.caps_override = (
-        f"video/x-raw,format=NV12,width={width},height={height},framerate={max(1, fps)}/1"
-    )
-    input_opt.use_simaai_pool = False
+def build_pipeline(cfg: AppConfig, model_path: str) -> PipelineRuntime:
+    frame_w, frame_h, fps = probe_rtsp(cfg.source.rtsp_url)
+    model = build_model(model_path, cfg.inference)
+    labels = load_labels(cfg.model.labels)
 
-    sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
+    source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, frame_w, frame_h, fps))
+    source_outputs = ["video", "model"]
+    if cfg.save_dir and cfg.save_every > 0:
+        source_outputs.append("frames")
+    branch = pyneat.graphs.branch("source", source_outputs)
+
+    sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, max(1, fps))
     sender_opt.host = cfg.insight.host
     sender_opt.channel = 0
     sender_opt.video_port_base = cfg.insight.video_port
-    sender_opt.encoder.bitrate_kbps = 4000
+    sender_opt.encoder.bitrate_kbps = 600
+
+    video_graph = pyneat.Graph("video")
+    video_graph.connect(
+        pyneat.nodes.input("video"),
+        pyneat.groups.video_sender(sender_opt),
+    )
+
+    model_graph = pyneat.Graph("model")
+    model_graph.connect(pyneat.nodes.input("model"), model)
+    detections = pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4))
 
     graph = pyneat.Graph()
-    graph.add(pyneat.nodes.input(input_opt))
-    graph.add(pyneat.groups.video_sender(sender_opt))
+    graph.connect(source, branch)
+    graph.connect(branch, video_graph)
+    graph.connect(branch, model_graph)
+    graph.connect(model_graph, detections)
+    if cfg.save_dir and cfg.save_every > 0:
+        frames = pyneat.Graph("frames")
+        frames.add(pyneat.nodes.output("frames", pyneat.OutputOptions.latest()))
+        graph.connect(branch, frames)
 
-    seed = blank_nv12_tensor(width, height)
-    return graph, graph.build([seed])
+    run_opt = pyneat.RunOptions()
+    run_opt.preset = pyneat.RunPreset.Reliable
+    run_opt.queue_depth = 4
+    run_opt.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_opt.output_memory = pyneat.OutputMemory.Owned
+    run = graph.build(run_opt)
+    metadata_sender = build_metadata_sender(cfg)
+    print(
+        f"rtsp={cfg.source.rtsp_url} stream={frame_w}x{frame_h}@{fps} "
+        f"insight={cfg.insight.host} video={sender_opt.video_port} "
+        f"metadata={metadata_sender.metadata_port()} channel=0"
+    )
+    return PipelineRuntime(
+        graph=graph,
+        run=run,
+        metadata_sender=metadata_sender,
+        labels=labels,
+        frame_w=frame_w,
+        frame_h=frame_h,
+        output_fps=fps,
+        video_port=sender_opt.video_port,
+    )
 
 
 def build_metadata_sender(cfg: AppConfig):
@@ -431,16 +367,28 @@ def build_metadata_sender(cfg: AppConfig):
     return pyneat.MetadataSender(options)
 
 
-def make_object_detection_data_json(boxes: list[dict]) -> str:
+def load_labels(path: Path) -> list[str]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Labels file does not exist: {path}")
+    labels = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not labels:
+        raise ValueError(f"Labels file is empty: {path}")
+    return labels
+
+
+def class_name(labels: list[str], class_id: int) -> str:
+    return labels[class_id] if 0 <= class_id < len(labels) else "unknown"
+
+
+def make_object_detection_data_json(boxes: list[dict], labels: list[str]) -> str:
     """Build the object-detection metadata data object."""
     objects = []
     for idx, box in enumerate(boxes, start=1):
         cls_id = int(box["class_id"])
-        label = COCO80_NAMES[cls_id] if 0 <= cls_id < len(COCO80_NAMES) else "Unknown"
         objects.append(
             {
                 "id": f"obj_{idx}",
-                "label": label,
+                "label": class_name(labels, cls_id),
                 "confidence": float(box["score"]),
                 "bbox": [
                     float(box["x1"]),
@@ -453,7 +401,13 @@ def make_object_detection_data_json(boxes: list[dict]) -> str:
     return json.dumps({"objects": objects}, separators=(",", ":"))
 
 
-def save_annotated_frame(frame: np.ndarray, boxes: list[dict], min_score: float, out_path: Path) -> None:
+def save_annotated_frame(
+    frame: np.ndarray,
+    boxes: list[dict],
+    labels: list[str],
+    min_score: float,
+    out_path: Path,
+) -> None:
     """Write one BGR frame with detection boxes for e2e/debug inspection."""
     annotated = frame.copy()
     for box in boxes:
@@ -461,7 +415,7 @@ def save_annotated_frame(frame: np.ndarray, boxes: list[dict], min_score: float,
         if score < min_score:
             continue
         cls_id = int(box["class_id"])
-        label = COCO80_NAMES[cls_id] if 0 <= cls_id < len(COCO80_NAMES) else "unknown"
+        label = class_name(labels, cls_id)
         x1 = int(round(box["x1"]))
         y1 = int(round(box["y1"]))
         x2 = int(round(box["x2"]))
@@ -480,6 +434,50 @@ def save_annotated_frame(frame: np.ndarray, boxes: list[dict], min_score: float,
     out_path.parent.mkdir(parents=True, exist_ok=True)
     if not cv2.imwrite(str(out_path), annotated):
         raise RuntimeError(f"failed to write output frame: {out_path}")
+
+
+def first_tensor_from_sample(sample):
+    if sample is None:
+        return None
+    if sample.kind == pyneat.SampleKind.Tensor and sample.tensor is not None:
+        return sample.tensor
+    if sample.kind == pyneat.SampleKind.TensorSet and sample.tensors:
+        return sample.tensors[0]
+    for field in sample.fields:
+        tensor = first_tensor_from_sample(field)
+        if tensor is not None:
+            return tensor
+    return None
+
+
+def maybe_save_debug_frame(runtime: PipelineRuntime, cfg: AppConfig, processed: int, boxes: list[dict]) -> None:
+    if not cfg.save_dir or cfg.save_every <= 0 or processed % cfg.save_every != 0:
+        return
+    frame_sample = runtime.run.pull("frames", 0)
+    frame_tensor = first_tensor_from_sample(frame_sample)
+    if frame_tensor is None:
+        return
+    frame = tensor_bgr_from_decoded(frame_tensor)
+    save_annotated_frame(
+        frame,
+        boxes,
+        runtime.labels,
+        cfg.inference.min_score,
+        Path(cfg.save_dir) / f"frame_{processed}.jpg",
+    )
+
+
+def send_metadata(runtime: PipelineRuntime, sample, boxes: list[dict]) -> None:
+    data_json = make_object_detection_data_json(boxes, runtime.labels)
+    frame_id = getattr(sample, "frame_id", -1)
+    if frame_id is None or frame_id < 0:
+        frame_id = 0
+    runtime.metadata_sender.send_metadata(
+        "object-detection",
+        data_json,
+        int(time.time() * 1000),
+        str(frame_id),
+    )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -558,9 +556,13 @@ def load_app_config(config_path: Path) -> AppConfig:
     runtime_cfg = _mapping(raw.get("runtime"), "runtime")
     output_cfg = _mapping(raw.get("output"), "output")
     insight_cfg = _mapping(output_cfg.get("insight"), "output.insight")
+    default_labels = Path(__file__).resolve().parents[1] / "common" / "coco_label.txt"
 
     cfg = AppConfig(
-        model=ModelConfig(path=_required_string(model_cfg, "path", "model")),
+        model=ModelConfig(
+            path=_required_string(model_cfg, "path", "model"),
+            labels=Path(_optional_string(model_cfg, "labels", str(default_labels))),
+        ),
         source=SourceConfig(
             rtsp_url=_required_string(source_cfg, "rtsp_url", "source"),
             latency_ms=_optional_int(source_cfg, "latency_ms", 200),
@@ -617,23 +619,15 @@ class ProfileWindow:
         self.frames = 0
         self.boxes = 0
         self.started = 0.0
-        self.rtsp_pull_ms = 0.0
-        self.infer_ms = 0.0
-        self.bbox_ms = 0.0
-        self.video_push_ms = 0.0
-        self.e2e_ms = 0.0
-        self.max_e2e_ms = 0.0
+        self.detection_pull_ms = 0.0
+        self.metadata_send_ms = 0.0
 
     def add(
         self,
         *,
-        rtsp_pull_ms: float,
-        infer_ms: float,
-        bbox_ms: float,
-        video_push_ms: float,
-        e2e_ms: float,
+        detection_pull_ms: float,
+        metadata_send_ms: float,
         boxes: int,
-        published_total: int,
     ) -> None:
         if not self.enabled:
             return
@@ -641,30 +635,22 @@ class ProfileWindow:
             self.started = time.perf_counter()
         self.frames += 1
         self.boxes += boxes
-        self.rtsp_pull_ms += rtsp_pull_ms
-        self.infer_ms += infer_ms
-        self.bbox_ms += bbox_ms
-        self.video_push_ms += video_push_ms
-        self.e2e_ms += e2e_ms
-        self.max_e2e_ms = max(self.max_e2e_ms, e2e_ms)
+        self.detection_pull_ms += detection_pull_ms
+        self.metadata_send_ms += metadata_send_ms
         if self.frames >= self.interval:
-            self.flush(published_total)
+            self.flush()
 
-    def flush(self, published_total: int) -> None:
+    def flush(self) -> None:
         if not self.enabled or self.frames == 0:
             return
         elapsed = max(time.perf_counter() - self.started, 1e-6)
         frames = float(self.frames)
         print(
-            f"[profile] frames={self.frames} published={published_total} "
-            f"fps={self.frames / elapsed:.2f} "
-            f"avg_rtsp_pull_ms={self.rtsp_pull_ms / frames:.2f} "
-            f"avg_infer_ms={self.infer_ms / frames:.2f} "
-            f"avg_bbox_ms={self.bbox_ms / frames:.2f} "
-            f"avg_video_push_ms={self.video_push_ms / frames:.2f} "
-            f"avg_e2e_ms={self.e2e_ms / frames:.2f} "
-            f"avg_boxes={self.boxes / frames:.2f} "
-            f"max_e2e_ms={self.max_e2e_ms:.2f}",
+            f"[profile] frames={self.frames} "
+            f"output_fps={self.frames / elapsed:.2f} "
+            f"avg_detection_pull_ms={self.detection_pull_ms / frames:.2f} "
+            f"avg_metadata_send_ms={self.metadata_send_ms / frames:.2f} "
+            f"avg_boxes={self.boxes / frames:.2f}",
             flush=True,
         )
         self.reset()
@@ -750,41 +736,9 @@ def main(argv: list[str] | None = None) -> int:
         print("Set model.path or download a YOLO26 detector package with sima-cli.", file=sys.stderr)
         return 2
 
-    rtsp_graph = None
-    rtsp_run = None
-    detector_graph = None
-    detector_run = None
-    video_graph = None
-    video_run = None
-    metadata_sender = None
+    runtime = None
     try:
-        # Probe first so decode, inference, and VideoSender all agree on the
-        # same live frame dimensions.
-        frame_w, frame_h, fps = probe_rtsp(cfg.source.rtsp_url)
-        print(f"[init] probed RTSP decode dims {frame_w}x{frame_h}")
-
-        # NEAT boundary: build YOLO detector graph from the resolved compiled model package.
-        model, detector_graph, detector_run = build_detector_run(
-            model_path,
-            frame_w,
-            frame_h,
-            cfg.inference,
-        )
-        # NEAT boundary: build RTSP decode runtime used by pull_tensors().
-        rtsp_graph, rtsp_run = build_rtsp_run(
-            cfg.source.rtsp_url,
-            frame_w,
-            frame_h,
-            fps,
-            cfg.source.latency_ms,
-            tcp=cfg.source.tcp,
-        )
-        # NEAT boundary: build VideoSender and MetadataSender.
-        video_graph, video_run = build_video_sender_run(cfg, frame_w, frame_h, fps)
-        metadata_sender = build_metadata_sender(cfg)
-
-        print(f"insight host={cfg.insight.host} video_port={cfg.insight.video_port} "
-              f"metadata_port={metadata_sender.metadata_port()} channel=0")
+        runtime = build_pipeline(cfg, model_path)
 
         processed = 0
         started = time.perf_counter()
@@ -792,102 +746,48 @@ def main(argv: list[str] | None = None) -> int:
         save_dir = Path(cfg.save_dir) if cfg.save_dir else None
         if save_dir is not None:
             save_dir.mkdir(parents=True, exist_ok=True)
-        # Contract: single-threaded frame order is pull -> infer -> publish video -> publish metadata.
         while cfg.inference.frames <= 0 or processed < cfg.inference.frames:
-            # Push/pull integration point: pull one decoded frame from RTSP run.
-            t_pull0 = time.perf_counter()
-            tensors = rtsp_run.pull_tensors(timeout_ms=20000)
-            t_pull1 = time.perf_counter()
-            if not tensors:
-                print("RTSP pull timed out / stream closed", file=sys.stderr)
-                break
+            pull_start = time.perf_counter()
+            detection_sample = runtime.run.pull("detections", 20000)
+            pull_end = time.perf_counter()
+            if detection_sample is None:
+                print("[warn] timed out waiting for detections", file=sys.stderr)
+                continue
 
-            decoded_frame = tensors[0]
-            frame = tensor_bgr_from_decoded(decoded_frame)
-            infer_input = tensor_from_bgr_frame(frame)
-
-            # Push/pull integration point: run model and parse the BBOX payload.
-            t_inf0 = time.perf_counter()
-            result = detector_run.run([infer_input], timeout_ms=20000)
-            t_inf1 = time.perf_counter()
-
-            payload = extract_bbox_payload(result)
+            payload = extract_bbox_payload(detection_sample)
             if not payload:
                 raise RuntimeError("model returned no BBOX payload")
-            t_bbox0 = time.perf_counter()
             boxes = parse_bbox_payload(
                 payload,
-                frame.shape[1],
-                frame.shape[0],
+                runtime.frame_w,
+                runtime.frame_h,
                 cfg.inference.max_detections,
             )
-            t_bbox1 = time.perf_counter()
 
-            # Contract: publish video first, then publish matching metadata.
-            t_video0 = time.perf_counter()
-            video_ok = video_run.push([decoded_frame])
-            if not video_ok:
-                raise RuntimeError("Insight video push failed")
-            t_video1 = time.perf_counter()
-            fid = str(processed)
-            data_json = make_object_detection_data_json(boxes)
-            metadata_sender.send_metadata(
-                "object-detection",
-                data_json,
-                int(time.time() * 1000),
-                fid,
-            )
-            should_save = (
-                save_dir is not None
-                and cfg.save_every > 0
-                and (processed + 1) % cfg.save_every == 0
-            )
-            if should_save:
-                save_annotated_frame(
-                    frame,
-                    boxes,
-                    cfg.inference.min_score,
-                    save_dir / f"frame_{processed:06d}.jpg",
-                )
+            metadata_start = time.perf_counter()
+            send_metadata(runtime, detection_sample, boxes)
+            metadata_end = time.perf_counter()
 
             processed += 1
+            maybe_save_debug_frame(runtime, cfg, processed, boxes)
             profile_window.add(
-                rtsp_pull_ms=(t_pull1 - t_pull0) * 1000.0,
-                infer_ms=(t_inf1 - t_inf0) * 1000.0,
-                bbox_ms=(t_bbox1 - t_bbox0) * 1000.0,
-                video_push_ms=(t_video1 - t_video0) * 1000.0,
-                e2e_ms=(t_video1 - t_pull1) * 1000.0,
+                detection_pull_ms=(pull_end - pull_start) * 1000.0,
+                metadata_send_ms=(metadata_end - metadata_start) * 1000.0,
                 boxes=len(boxes),
-                published_total=processed,
             )
 
         elapsed = max(time.perf_counter() - started, 1e-6)
-        profile_window.flush(processed)
+        profile_window.flush()
         print(f"processed={processed} fps={processed / elapsed:.2f} "
-              f"video_sender={cfg.insight.host}:{cfg.insight.video_port}")
+              f"video_sender={cfg.insight.host}:{runtime.video_port}")
         return 0 if processed > 0 else 3
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
     finally:
-        # Contract: close output run, then close RTSP run.
         try:
-            if video_run is not None:
-                video_run.close()
-        except Exception:
-            pass
-        try:
-            if detector_run is not None:
-                detector_run.close()
-        except Exception:
-            pass
-        try:
-            if rtsp_run is not None:
-                rtsp_run.close()
-        except Exception:
-            pass
-        try:
-            metadata_sender = None
+            if runtime is not None:
+                runtime.run.close()
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

This PR optimizes `single-stream-object-detector` while keeping the user-facing behavior unchanged.

The main goal is to make the C++ and Python implementations use the same graph shape, reduce app-side frame handling, and keep the live Insight path efficient and readable.

## Architecture

Both C++ and Python now use the same high-level graph topology:

```text
RtspDecodedInput
  -> Branch("source")
      -> "video" -> VideoSender
      -> "model" -> Model(YOLO26 preprocess + inference + decode)
                  -> Output("detections")
```

When saved debug output is enabled through config, the graph adds a save-only branch:

```text
RtspDecodedInput
  -> Branch("source")
      -> "debug_frame" -> Output("debug_frame")

Model output
  -> Output("detections")

"debug_frame" + "detections"
  -> Combine(ByPts)
  -> Output("debug_output")
```

The live Insight path is unchanged. Video continues through `VideoSender`, and metadata continues to be sent from the detection output. The extra `debug_output` path only exists when `output.save_dir` and `output.save_every` are configured.

## Runtime Behavior

- Uses `RtspDecodedInput` as the source for the live RTSP stream.
- Uses `graphs::Branch` / `pyneat.graphs.branch` to make source fanout explicit.
- Uses `Model` with YOLO26 options instead of manually wiring preproc, MLA, and box decode in the app.
- Keeps YOLO26 preprocessing options explicit:
  - `preprocess.enable = On`
  - `preprocess.input_format = NV12`
  - `preprocess.preset = COCO_YOLO`
  - `decode_type = YoloV26`
- Uses the RTSP probe result for stream width, height, and FPS instead of hardcoding stream geometry.
- Uses `RunPreset::Realtime` / `pyneat.RunPreset.Realtime` for live RTSP behavior.
- Sets queue depth to `3` and overflow policy to `KeepLatest`.
- Uses `OutputMemory::ZeroCopy` / `pyneat.OutputMemory.ZeroCopy` for terminal outputs.
- Keeps live video on the graph path and avoids CPU frame conversion unless saved debug output is requested.
- Reads COCO labels from `src/common/coco_label.txt` instead of hardcoding them in Python.

## Saved Output Fix

The previous saved-image path could drift over time because it pulled detections first and then separately pulled a latest frame sample:

```text
pull("detections")
pull("frames", 0)
```

That could save a frame that did not match the boxes, especially later in longer runs.

This PR changes saved-output mode to pull one joined sample:

```text
pull("debug_output")
```

`debug_output` is produced by `Combine(ByPts)` from `debug_frame` and `detections`, so the saved frame and boxes are timestamp-matched. This keeps e2e/debug output aligned without changing the live Insight path.

## Code Cleanup

- Aligns C++ and Python around the same functions and runtime structure.
- Removes redundant Python-side model search and hardcoded label data.
- Keeps debug image saving local to the example.
- Keeps config keys unchanged.
- Keeps normal runtime cheap: if `output.save_dir` or `output.save_every` is not set, no debug frame output, CPU frame conversion, OpenCV drawing, or image writing is added.

## Testing

Checked locally before push:

```bash
clang-format -i examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
python3 -m py_compile examples/object-detection/single-stream-object-detector/src/python/main.py
git diff --check -- examples/object-detection/single-stream-object-detector/src/cpp/main.cpp examples/object-detection/single-stream-object-detector/src/python/main.py
```

Manual board validation was performed for saved output generation in both implementations using the sandbox-test configs. Output images were generated under:

```text
/workspace/sima-neat/apps/sandbox-test/cpp/single-stream-object-detector/test_full_pipeline/out
/workspace/sima-neat/apps/sandbox-test/python/single-stream-object-detector/test_full_pipeline/out
```

Validation result: saved frames and boxes are aligned after switching to the `Combine(ByPts)` debug output path.

## Notes

- This PR does not change model thresholds or detector output semantics.
- This PR does not change the live Insight metadata format.
- This PR does not change the example config schema.
- Full CI remains the merge gate.

Refs #220
