### PR TITLE
Optimize single-stream instance segmenter RTSP path

### DIFF
--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "support/runtime/example_utils.h"
-#include "support/runtime/config_utils.h"
 #include "neat.h"
 #include "neat/models.h"
-#include "neat/nodes.h"
 #include "neat/node_groups.h"
+#include "neat/nodes.h"
+#include "support/runtime/config_utils.h"
+#include "support/runtime/example_utils.h"
 #include <nodes/groups/VideoSender.h>
 #include <nodes/io/MetadataSender.h>
 
@@ -25,23 +25,16 @@
 #include <opencv2/imgproc.hpp>
 
 #include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <cmath>
-#include <condition_variable>
-#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <mutex>
-#include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -50,42 +43,21 @@ using sima_examples::time_ms;
 
 namespace {
 
-// single-stream-instance-segmenter is a reference pipeline for the common deployment:
-// one RTSP source, one YOLO26 segmentation model, and Insight video/metadata output.
-//
-// The code keeps ingest, inference, and output transport separate so each
-// stage can be reasoned about and debugged independently.
-
-struct ModelConfig {
-  std::string path;
-  fs::path labels;
-};
-
-struct SourceConfig {
+struct AppConfig {
+  std::string model_path;
+  fs::path labels_path;
   std::string rtsp_url;
   int latency_ms = 200;
   bool tcp = true;
-};
-
-struct InferenceConfig {
   int frames = 0;
   double min_score = 0.55;
   double nms_iou = 0.60;
   int max_detections = 50;
-};
-
-struct RuntimeConfig {
   bool profile = false;
   int profile_interval = 100;
-};
-
-struct InsightConfig {
-  std::string host = "127.0.0.1";
+  std::string insight_host = "127.0.0.1";
   int video_port = 9000;
   int metadata_port = 9100;
-};
-
-struct OutputConfig {
   fs::path save_dir;
   int save_every = 0;
   double mask_alpha = 0.55;
@@ -93,18 +65,92 @@ struct OutputConfig {
   bool draw_boxes = true;
 };
 
-struct AppConfig {
-  ModelConfig model;
-  SourceConfig source;
-  InferenceConfig inference;
-  RuntimeConfig runtime;
-  InsightConfig insight;
-  OutputConfig output;
-};
-
 struct CliOptions {
   fs::path config_path;
   bool validate_config_only = false;
+};
+
+struct SegmentationDetection {
+  float x1 = 0.0f;
+  float y1 = 0.0f;
+  float x2 = 0.0f;
+  float y2 = 0.0f;
+  float score = 0.0f;
+  int class_id = -1;
+  cv::Mat mask;
+};
+
+struct ProfileWindow {
+  bool enabled = false;
+  int interval = 100;
+  int frames = 0;
+  int boxes = 0;
+  double start_ms = 0.0;
+  double pull_ms = 0.0;
+  double decode_ms = 0.0;
+  double overlay_ms = 0.0;
+  double video_push_ms = 0.0;
+  double metadata_ms = 0.0;
+
+  void add(double pull, double decode, double overlay, double video_push, double metadata,
+           int box_count) {
+    if (!enabled) {
+      return;
+    }
+    if (frames == 0) {
+      start_ms = time_ms();
+    }
+    frames += 1;
+    boxes += box_count;
+    pull_ms += pull;
+    decode_ms += decode;
+    overlay_ms += overlay;
+    video_push_ms += video_push;
+    metadata_ms += metadata;
+    if (frames >= interval) {
+      flush();
+    }
+  }
+
+  void flush() {
+    if (!enabled || frames <= 0) {
+      return;
+    }
+    const double elapsed_ms = std::max(time_ms() - start_ms, 1e-6);
+    const double n = static_cast<double>(frames);
+    const double fps = static_cast<double>(frames) * 1000.0 / elapsed_ms;
+    std::cout << "[profile] frames=" << frames << " output_fps=" << fps
+              << " avg_pull_ms=" << pull_ms / n << " avg_decode_ms=" << decode_ms / n
+              << " avg_overlay_ms=" << overlay_ms / n << " avg_video_push_ms=" << video_push_ms / n
+              << " avg_metadata_ms=" << metadata_ms / n
+              << " avg_instances=" << static_cast<double>(boxes) / n << "\n";
+    reset();
+  }
+
+  void reset() {
+    frames = 0;
+    boxes = 0;
+    start_ms = 0.0;
+    pull_ms = 0.0;
+    decode_ms = 0.0;
+    overlay_ms = 0.0;
+    video_push_ms = 0.0;
+    metadata_ms = 0.0;
+  }
+};
+
+struct PipelineRuntime {
+  std::unique_ptr<simaai::neat::Model> model;
+  simaai::neat::Graph graph;
+  simaai::neat::Run run;
+  simaai::neat::Graph video_graph;
+  simaai::neat::Run video_run;
+  std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
+  std::vector<std::string> labels;
+  int frame_w = 0;
+  int frame_h = 0;
+  int output_fps = 30;
+  int video_port = 0;
 };
 
 CliOptions parse_args(int argc, char** argv) {
@@ -130,57 +176,56 @@ CliOptions parse_args(int argc, char** argv) {
 }
 
 void validate_config(const AppConfig& cfg) {
-  sima_examples::require(!cfg.source.rtsp_url.empty(), "source.rtsp_url must be set");
-  sima_examples::require(!cfg.model.path.empty(), "model.path must be set");
-  sima_examples::require(!cfg.model.labels.empty(), "model.labels must be set");
-  sima_examples::require(!cfg.insight.host.empty(), "output.insight.host must be set");
-  sima_examples::require(cfg.source.latency_ms >= 0, "source.latency_ms must be >= 0");
-  sima_examples::require(cfg.inference.frames >= 0, "inference.frames must be >= 0");
-  sima_examples::require(cfg.inference.min_score >= 0.0 && cfg.inference.min_score <= 1.0,
+  sima_examples::require(!cfg.rtsp_url.empty(), "source.rtsp_url must be set");
+  sima_examples::require(!cfg.model_path.empty(), "model.path must be set");
+  sima_examples::require(!cfg.labels_path.empty(), "model.labels must be set");
+  sima_examples::require(!cfg.insight_host.empty(), "output.insight.host must be set");
+  sima_examples::require(cfg.latency_ms >= 0, "source.latency_ms must be >= 0");
+  sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
+  sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
-  sima_examples::require(cfg.inference.nms_iou >= 0.0 && cfg.inference.nms_iou <= 1.0,
+  sima_examples::require(cfg.nms_iou >= 0.0 && cfg.nms_iou <= 1.0,
                          "inference.nms_iou must be between 0 and 1");
-  sima_examples::require(cfg.inference.max_detections > 0, "inference.max_detections must be > 0");
-  sima_examples::require(cfg.runtime.profile_interval > 0, "runtime.profile_interval must be > 0");
-  sima_examples::require(cfg.insight.video_port > 0, "output.insight.video_port must be > 0");
-  sima_examples::require(cfg.insight.metadata_port > 0, "output.insight.metadata_port must be > 0");
-  sima_examples::require(cfg.output.save_every >= 0, "output.save_every must be >= 0");
-  sima_examples::require(cfg.output.mask_alpha >= 0.0 && cfg.output.mask_alpha <= 1.0,
+  sima_examples::require(cfg.max_detections > 0, "inference.max_detections must be > 0");
+  sima_examples::require(cfg.profile_interval > 0, "runtime.profile_interval must be > 0");
+  sima_examples::require(cfg.video_port > 0, "output.insight.video_port must be > 0");
+  sima_examples::require(cfg.metadata_port > 0, "output.insight.metadata_port must be > 0");
+  sima_examples::require(cfg.save_every >= 0, "output.save_every must be >= 0");
+  sima_examples::require(cfg.mask_alpha >= 0.0 && cfg.mask_alpha <= 1.0,
                          "output.mask_alpha must be between 0 and 1");
-  sima_examples::require(cfg.output.mask_threshold >= 0.0 && cfg.output.mask_threshold <= 1.0,
+  sima_examples::require(cfg.mask_threshold >= 0.0 && cfg.mask_threshold <= 1.0,
                          "output.mask_threshold must be between 0 and 1");
 }
 
 AppConfig load_app_config(const fs::path& config_path) {
   const auto raw = sima_examples::ScalarConfig::load(config_path);
-  AppConfig cfg;
   const fs::path default_labels =
       sima_examples::default_config_path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR).parent_path() /
       "coco_label.txt";
-  cfg.model.path = raw.string_or("model.path", "");
-  cfg.model.labels = raw.string_or("model.labels", default_labels.string());
-  cfg.source.rtsp_url = raw.string_or("source.rtsp_url", "");
-  cfg.source.latency_ms = raw.int_or("source.latency_ms", 200);
-  cfg.source.tcp = raw.bool_or("source.tcp", true);
-  cfg.inference.frames = raw.int_or("inference.frames", 0);
-  cfg.inference.min_score = raw.double_or("inference.min_score", 0.55);
-  cfg.inference.nms_iou = raw.double_or("inference.nms_iou", 0.60);
-  cfg.inference.max_detections = raw.int_or("inference.max_detections", 50);
-  cfg.runtime.profile = raw.bool_or("runtime.profile", false);
-  cfg.runtime.profile_interval = raw.int_or("runtime.profile_interval", 100);
-  cfg.insight.host = raw.string_or("output.insight.host", "");
-  cfg.insight.video_port = raw.int_or("output.insight.video_port", 9000);
-  cfg.insight.metadata_port = raw.int_or("output.insight.metadata_port", 9100);
-  cfg.output.save_dir = raw.string_or("output.save_dir", "");
-  cfg.output.save_every = raw.int_or("output.save_every", 0);
-  cfg.output.mask_alpha = raw.double_or("output.mask_alpha", 0.55);
-  cfg.output.mask_threshold = raw.double_or("output.mask_threshold", 0.50);
-  cfg.output.draw_boxes = raw.bool_or("output.draw_boxes", true);
+
+  AppConfig cfg;
+  cfg.model_path = raw.string_or("model.path", "");
+  cfg.labels_path = raw.string_or("model.labels", default_labels.string());
+  cfg.rtsp_url = raw.string_or("source.rtsp_url", "");
+  cfg.latency_ms = raw.int_or("source.latency_ms", 200);
+  cfg.tcp = raw.bool_or("source.tcp", true);
+  cfg.frames = raw.int_or("inference.frames", 0);
+  cfg.min_score = raw.double_or("inference.min_score", 0.55);
+  cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
+  cfg.max_detections = raw.int_or("inference.max_detections", 50);
+  cfg.profile = raw.bool_or("runtime.profile", false);
+  cfg.profile_interval = raw.int_or("runtime.profile_interval", 100);
+  cfg.insight_host = raw.string_or("output.insight.host", "");
+  cfg.video_port = raw.int_or("output.insight.video_port", 9000);
+  cfg.metadata_port = raw.int_or("output.insight.metadata_port", 9100);
+  cfg.save_dir = raw.string_or("output.save_dir", "");
+  cfg.save_every = raw.int_or("output.save_every", 0);
+  cfg.mask_alpha = raw.double_or("output.mask_alpha", 0.55);
+  cfg.mask_threshold = raw.double_or("output.mask_threshold", 0.50);
+  cfg.draw_boxes = raw.bool_or("output.draw_boxes", true);
   validate_config(cfg);
   return cfg;
 }
-
-using sima_examples::infer_dims;
 
 std::vector<std::string> load_labels(const fs::path& labels_path) {
   std::ifstream in(labels_path);
@@ -201,38 +246,7 @@ std::vector<std::string> load_labels(const fs::path& labels_path) {
   return labels;
 }
 
-struct SegmentationDetection {
-  float x1 = 0.0f;
-  float y1 = 0.0f;
-  float x2 = 0.0f;
-  float y2 = 0.0f;
-  float score = 0.0f;
-  int class_id = -1;
-  cv::Mat mask;
-};
-
-std::vector<simaai::neat::Tensor> collect_tensors(const simaai::neat::Sample& sample) {
-  if (sample.kind == simaai::neat::SampleKind::Tensor) {
-    if (!sample.tensor.has_value()) {
-      return {};
-    }
-    return {*sample.tensor};
-  }
-  if (sample.kind == simaai::neat::SampleKind::TensorSet) {
-    return sample.tensors;
-  }
-  if (sample.kind == simaai::neat::SampleKind::Bundle) {
-    std::vector<simaai::neat::Tensor> out;
-    for (const auto& field : sample.fields) {
-      auto part = collect_tensors(field);
-      out.insert(out.end(), part.begin(), part.end());
-    }
-    return out;
-  }
-  return {};
-}
-
-std::vector<float> tensor_to_floats_local(const simaai::neat::Tensor& tensor) {
+std::vector<float> tensor_to_floats(const simaai::neat::Tensor& tensor) {
   if (tensor.dtype != simaai::neat::TensorDType::Float32) {
     throw std::runtime_error("expected Float32 tensor");
   }
@@ -247,7 +261,7 @@ std::vector<float> tensor_to_floats_local(const simaai::neat::Tensor& tensor) {
   return values;
 }
 
-std::vector<std::uint8_t> tensor_to_u8_local(const simaai::neat::Tensor& tensor) {
+std::vector<std::uint8_t> tensor_to_u8(const simaai::neat::Tensor& tensor) {
   if (tensor.dtype != simaai::neat::TensorDType::UInt8) {
     throw std::runtime_error("expected UInt8 tensor");
   }
@@ -261,14 +275,14 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
     throw std::runtime_error("model returned no segmentation tensors");
   }
 
-  auto decoded =
+  const auto decoded =
       simaai::neat::decode_segmentation(tensors, frame_w, frame_h, max_detections, false);
   std::vector<SegmentationDetection> detections;
+  const size_t mask_bytes = 160U * 160U;
   for (const auto& item : decoded) {
-    const auto boxes = tensor_to_floats_local(item.boxes);
-    const auto masks = tensor_to_u8_local(item.masks);
+    const auto boxes = tensor_to_floats(item.boxes);
+    const auto masks = tensor_to_u8(item.masks);
     const int count = static_cast<int>(boxes.size() / 6U);
-    const size_t mask_bytes = 160U * 160U;
     for (int i = 0; i < count; ++i) {
       const float* row = boxes.data() + static_cast<size_t>(i) * 6U;
       if (row[2] <= row[0] || row[3] <= row[1]) {
@@ -295,430 +309,96 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
   return detections;
 }
 
-double fps_from_count(int count, double elapsed_ms) {
-  if (elapsed_ms <= 0.0)
-    return 0.0;
-  return static_cast<double>(count) * 1000.0 / elapsed_ms;
+simaai::neat::nodes::groups::RtspDecodedInputOptions
+make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& height_out) {
+  sima_examples::RtspStreamInfo probe;
+  sima_examples::RtspProbeOptions probe_options;
+  probe_options.payload_type = 96;
+  probe_options.latency_ms = cfg.latency_ms;
+  probe_options.rtsp_tcp = cfg.tcp;
+  probe_options.debug = cfg.profile;
+  (void)sima_examples::probe_rtsp_stream_info(cfg.rtsp_url, probe_options, probe);
+
+  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
+  opt.url = cfg.rtsp_url;
+  opt.latency_ms = cfg.latency_ms;
+  opt.tcp = cfg.tcp;
+  opt.payload_type = 96;
+  opt.insert_queue = true;
+  opt.out_format = "NV12";
+  opt.decoder_name = "decoder";
+  opt.decoder_raw_output = true;
+  opt.auto_caps_from_stream = true;
+  if (probe.width > 0 && probe.height > 0) {
+    opt.fallback_h264_width = probe.width;
+    opt.fallback_h264_height = probe.height;
+    width_out = probe.width;
+    height_out = probe.height;
+  }
+  if (probe.fps > 0) {
+    opt.fallback_h264_fps = probe.fps;
+    fps_out = probe.fps;
+  }
+  return opt;
 }
 
-void print_throughput_summary(int produced, int det_outputs, int published,
-                              double producer_start_ms, double producer_end_ms,
-                              double consumer_start_ms, double consumer_end_ms) {
-  const double producer_elapsed_ms =
-      (producer_end_ms > producer_start_ms) ? (producer_end_ms - producer_start_ms) : 0.0;
-  const double consumer_elapsed_ms =
-      (consumer_end_ms > consumer_start_ms) ? (consumer_end_ms - consumer_start_ms) : 0.0;
-  std::cout << "[THROUGHPUT] produced=" << produced
-            << " fps=" << fps_from_count(produced, producer_elapsed_ms)
-            << " yolo_out=" << det_outputs
-            << " fps=" << fps_from_count(det_outputs, consumer_elapsed_ms)
-            << " published=" << published
-            << " fps=" << fps_from_count(published, consumer_elapsed_ms)
-            << " producer_ms=" << producer_elapsed_ms << " consumer_ms=" << consumer_elapsed_ms
-            << "\n";
+std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg) {
+  simaai::neat::Model::Options opt;
+  opt.preprocess.kind = simaai::neat::InputKind::Image;
+  opt.preprocess.enable = simaai::neat::AutoFlag::On;
+  opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::NV12;
+  opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
+  opt.decode_type = simaai::neat::BoxDecodeType::YoloV26Seg;
+  opt.score_threshold = cfg.min_score;
+  opt.nms_iou_threshold = cfg.nms_iou;
+  opt.top_k = cfg.max_detections;
+  return std::make_unique<simaai::neat::Model>(cfg.model_path, opt);
 }
 
-struct FrameItem {
-  int index = 0;
-  simaai::neat::Tensor frame;
-  double pull_ts_ms = 0.0;
-  double rtsp_pull_ms = 0.0;
-};
-
-struct PendingFrame {
-  int index = 0;
-  double pull_ts_ms = 0.0;
-  simaai::neat::Tensor frame;
-};
-
-struct FrameQueue {
-  explicit FrameQueue(size_t max_size_in) : max_size(max_size_in) {}
-
-  bool push(FrameItem item) {
-    std::unique_lock<std::mutex> lock(mu);
-    cond.wait(lock, [&]() { return closed || items.size() < max_size; });
-    if (closed)
-      return false;
-    items.push_back(std::move(item));
-    lock.unlock();
-    cond.notify_all();
-    return true;
+cv::Mat tensor_bgr_from_decoded(const simaai::neat::Tensor& tensor) {
+  cv::Mat bgr;
+  std::string err;
+  if (sima_examples::nv12_to_bgr(tensor, bgr, err)) {
+    return bgr;
   }
+  return tensor.to_cv_mat_copy(simaai::neat::ImageSpec::PixelFormat::BGR);
+}
 
-  bool pop(FrameItem& out) {
-    std::unique_lock<std::mutex> lock(mu);
-    cond.wait(lock, [&]() { return closed || !items.empty(); });
-    if (items.empty())
-      return false;
-    out = std::move(items.front());
-    items.pop_front();
-    lock.unlock();
-    cond.notify_all();
-    return true;
+const simaai::neat::Sample* find_field(const simaai::neat::Sample& sample,
+                                       const std::string& label) {
+  if (sample.stream_label == label) {
+    return &sample;
   }
-
-  void close() {
-    std::lock_guard<std::mutex> lock(mu);
-    closed = true;
-    cond.notify_all();
-  }
-
-private:
-  size_t max_size = 0;
-  std::mutex mu;
-  std::condition_variable cond;
-  std::deque<FrameItem> items;
-  bool closed = false;
-};
-
-struct ProducerStats {
-  int count = 0;
-};
-
-struct TimingAccumulator {
-  int count = 0;
-  double sum_ms = 0.0;
-  double max_ms = 0.0;
-
-  void add(double ms) {
-    sum_ms += ms;
-    if (ms > max_ms)
-      max_ms = ms;
-    count += 1;
-  }
-
-  double avg() const {
-    return count > 0 ? sum_ms / static_cast<double>(count) : 0.0;
-  }
-
-  void reset() {
-    count = 0;
-    sum_ms = 0.0;
-    max_ms = 0.0;
-  }
-};
-
-struct FrameProfile {
-  double rtsp_pull_ms = 0.0;
-  double queue_pop_ms = 0.0;
-  double yolo_push_ms = 0.0;
-  double yolo_pull_ms = 0.0;
-  double decode_ms = 0.0;
-  double video_input_ms = 0.0;
-  double video_push_ms = 0.0;
-  double metadata_ms = 0.0;
-  double e2e_ms = 0.0;
-  int boxes = 0;
-};
-
-struct ProfileWindow {
-  bool enabled = false;
-  int interval = 100;
-  int frames = 0;
-  int boxes = 0;
-  double start_ms = 0.0;
-  TimingAccumulator rtsp_pull;
-  TimingAccumulator queue_pop;
-  TimingAccumulator yolo_push;
-  TimingAccumulator yolo_pull;
-  TimingAccumulator decode;
-  TimingAccumulator video_input;
-  TimingAccumulator video_push;
-  TimingAccumulator metadata;
-  TimingAccumulator e2e;
-
-  void add(const FrameProfile& profile, int published_total) {
-    if (!enabled)
-      return;
-    if (frames == 0)
-      start_ms = time_ms();
-    frames += 1;
-    boxes += profile.boxes;
-    rtsp_pull.add(profile.rtsp_pull_ms);
-    queue_pop.add(profile.queue_pop_ms);
-    yolo_push.add(profile.yolo_push_ms);
-    yolo_pull.add(profile.yolo_pull_ms);
-    decode.add(profile.decode_ms);
-    video_input.add(profile.video_input_ms);
-    video_push.add(profile.video_push_ms);
-    metadata.add(profile.metadata_ms);
-    e2e.add(profile.e2e_ms);
-    if (frames >= interval)
-      flush(published_total);
-  }
-
-  void flush(int published_total) {
-    if (!enabled || frames <= 0)
-      return;
-    const double elapsed_ms = time_ms() - start_ms;
-    std::cout << "[profile] frames=" << frames << " published=" << published_total
-              << " fps=" << fps_from_count(frames, elapsed_ms)
-              << " avg_rtsp_pull_ms=" << rtsp_pull.avg() << " avg_queue_pop_ms=" << queue_pop.avg()
-              << " avg_yolo_ms=" << (yolo_push.avg() + yolo_pull.avg())
-              << " avg_decode_ms=" << decode.avg() << " avg_video_input_ms=" << video_input.avg()
-              << " avg_video_push_ms=" << video_push.avg() << " avg_metadata_ms=" << metadata.avg()
-              << " avg_e2e_ms=" << e2e.avg()
-              << " avg_boxes=" << (static_cast<double>(boxes) / static_cast<double>(frames))
-              << " max_e2e_ms=" << e2e.max_ms << "\n";
-    reset();
-  }
-
-  void reset() {
-    frames = 0;
-    boxes = 0;
-    start_ms = 0.0;
-    rtsp_pull.reset();
-    queue_pop.reset();
-    yolo_push.reset();
-    yolo_pull.reset();
-    decode.reset();
-    video_input.reset();
-    video_push.reset();
-    metadata.reset();
-    e2e.reset();
-  }
-};
-
-struct RtspRuntime {
-  simaai::neat::Graph source_graph;
-  simaai::neat::Run source_run;
-  simaai::neat::Tensor first_frame;
-  double first_pull_ms = 0.0;
-  double first_pull_ts = 0.0;
-  int frame_w = 0;
-  int frame_h = 0;
-  int output_fps = 30;
-};
-
-struct InsightRuntime {
-  std::string host;
-  int video_port = 0;
-  simaai::neat::Graph video_graph;
-  simaai::neat::Run video_run;
-  std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
-  std::vector<std::string> labels;
-};
-
-struct DetectorRuntime {
-  std::unique_ptr<simaai::neat::Model> model;
-  simaai::neat::Graph detector_graph;
-  simaai::neat::Run detector_run;
-};
-
-struct WorkerSharedState {
-  std::optional<int> frame_limit;
-  FrameQueue& queue;
-  ProducerStats& producer_stats;
-  ProfileWindow& profile_window;
-  std::atomic<bool>& stop;
-  std::atomic<int>& published;
-  std::atomic<int>& det_outputs;
-  double& producer_start_ms;
-  double& producer_end_ms;
-  double& consumer_start_ms;
-  double& consumer_end_ms;
-};
-
-RtspRuntime build_rtsp_runtime(const AppConfig& cfg) {
-  RtspRuntime runtime;
-
-  sima_examples::RtspStreamInfo rtsp_probe;
-  sima_examples::RtspProbeOptions rtsp_probe_opt;
-  rtsp_probe_opt.payload_type = 96;
-  rtsp_probe_opt.latency_ms = cfg.source.latency_ms;
-  rtsp_probe_opt.rtsp_tcp = cfg.source.tcp;
-  rtsp_probe_opt.debug = cfg.runtime.profile;
-  (void)sima_examples::probe_rtsp_stream_info(cfg.source.rtsp_url, rtsp_probe_opt, rtsp_probe);
-
-  simaai::neat::nodes::groups::RtspDecodedInputOptions source_options;
-  source_options.url = cfg.source.rtsp_url;
-  source_options.latency_ms = cfg.source.latency_ms;
-  source_options.tcp = cfg.source.tcp;
-  source_options.payload_type = 96;
-  source_options.insert_queue = true;
-  source_options.out_format = "NV12";
-  source_options.decoder_name = "decoder";
-  source_options.decoder_raw_output = true;
-  source_options.auto_caps_from_stream = true;
-  if (rtsp_probe.width > 0 && rtsp_probe.height > 0) {
-    source_options.fallback_h264_width = rtsp_probe.width;
-    source_options.fallback_h264_height = rtsp_probe.height;
-    std::cout << "[init] probed RTSP decode dims " << rtsp_probe.width << "x" << rtsp_probe.height;
-    if (rtsp_probe.fps > 0)
-      std::cout << " @" << rtsp_probe.fps << " fps";
-    std::cout << "\n";
-  }
-  if (rtsp_probe.fps > 0)
-    source_options.fallback_h264_fps = rtsp_probe.fps;
-  runtime.output_fps = (rtsp_probe.fps > 0) ? rtsp_probe.fps : 30;
-
-  runtime.source_graph.add(simaai::neat::nodes::groups::RtspDecodedInput(source_options));
-  runtime.source_graph.add(simaai::neat::nodes::Output());
-  simaai::neat::RunOptions source_run_options;
-  source_run_options.queue_depth = 4;
-  source_run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  runtime.source_run = runtime.source_graph.build(source_run_options);
-
-  const double first_pull_start = time_ms();
-  simaai::neat::Sample first_sample;
-  simaai::neat::PullError first_pull_error;
-  const auto first_pull_status = runtime.source_run.pull(20000, first_sample, &first_pull_error);
-  if (first_pull_status != simaai::neat::PullStatus::Ok) {
-    if (first_pull_status == simaai::neat::PullStatus::Timeout) {
-      throw std::runtime_error(
-          "Timed out waiting for first RTSP frame. This is usually upstream connectivity or stream "
-          "delivery, not framerate derivation. If diagnostics show zero buffers at rtspsrc/depay/"
-          "decoder, the device is not receiving RTP from the source.");
+  for (const auto& field : sample.fields) {
+    if (const auto* found = find_field(field, label)) {
+      return found;
     }
-    throw std::runtime_error("Failed waiting for first RTSP frame: " + first_pull_error.message);
   }
-  auto first_tensors = simaai::neat::tensors_from_sample(first_sample);
-  runtime.first_frame = std::move(first_tensors.front());
-  const double first_pull_end = time_ms();
-  runtime.first_pull_ms = first_pull_end - first_pull_start;
-  runtime.first_pull_ts = first_pull_end;
-  sima_examples::require(infer_dims(runtime.first_frame, runtime.frame_w, runtime.frame_h),
-                         "first frame missing dimensions");
-  if (runtime.frame_w == 1280 && runtime.frame_h == 720 && source_options.h264_width <= 0 &&
-      source_options.h264_height <= 0 && source_options.fallback_h264_width <= 0 &&
-      source_options.fallback_h264_height <= 0) {
-    std::fprintf(stderr, "[WARN] deriving width=1280 and height=720 from SDP or timestamp\n");
-  }
-  return runtime;
+  return nullptr;
 }
 
-InsightRuntime build_insight_runtime(const AppConfig& cfg, int frame_w, int frame_h,
-                                     int output_fps) {
-  InsightRuntime runtime;
-  runtime.host = cfg.insight.host;
-  runtime.video_port = cfg.insight.video_port;
-
-  simaai::neat::InputOptions video_input_options;
-  video_input_options.payload_type = simaai::neat::PayloadType::Image;
-  video_input_options.format = "RGB";
-  video_input_options.width = frame_w;
-  video_input_options.height = frame_h;
-  video_input_options.depth = 3;
-  video_input_options.use_simaai_pool = false;
-  runtime.video_graph.add(simaai::neat::nodes::Input(video_input_options));
-  auto video_sender_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
-      frame_w, frame_h, output_fps);
-  video_sender_options.host = runtime.host;
-  video_sender_options.channel = 0;
-  video_sender_options.video_port_base = cfg.insight.video_port;
-  runtime.video_port = video_sender_options.video_port();
-  video_sender_options.encoder.bitrate_kbps = 4000;
-  runtime.video_graph.add(simaai::neat::nodes::groups::VideoSender(video_sender_options));
-
-  cv::Mat video_seed(frame_h, frame_w, CV_8UC3, cv::Scalar(0, 0, 0));
-  simaai::neat::RunOptions video_run_options;
-  runtime.video_run =
-      runtime.video_graph.build(std::vector<cv::Mat>{video_seed}, video_run_options);
-  std::cout << "video_sender=" << runtime.host << ":" << runtime.video_port << "\n";
-
-  simaai::neat::MetadataSenderOptions metadata_options;
-  metadata_options.host = cfg.insight.host;
-  metadata_options.channel = 0;
-  metadata_options.metadata_port_base = cfg.insight.metadata_port;
-  std::string metadata_err;
-  runtime.metadata_sender =
-      std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
-  sima_examples::require(runtime.metadata_sender->ok(), metadata_err);
-  runtime.labels = load_labels(cfg.model.labels);
-  std::cout << "insight host=" << runtime.metadata_sender->host()
-            << " video_port=" << runtime.video_port
-            << " metadata_port=" << runtime.metadata_sender->metadata_port() << " channel=0\n";
-  return runtime;
-}
-
-DetectorRuntime build_detector_runtime(const AppConfig& cfg, int frame_w, int frame_h) {
-  DetectorRuntime runtime;
-
-  simaai::neat::Model::Options model_opt;
-  model_opt.preprocess.kind = simaai::neat::InputKind::Image;
-  model_opt.preprocess.enable = simaai::neat::AutoFlag::On;
-  model_opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::BGR;
-  model_opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
-  model_opt.decode_type = simaai::neat::BoxDecodeType::YoloV26Seg;
-  model_opt.score_threshold = cfg.inference.min_score;
-  model_opt.nms_iou_threshold = cfg.inference.nms_iou;
-  model_opt.top_k = cfg.inference.max_detections;
-  std::cout << "[init] loading model " << cfg.model.path << "\n";
-  runtime.model = std::make_unique<simaai::neat::Model>(cfg.model.path, model_opt);
-  std::cout << "[init] model configured for " << frame_w << "x" << frame_h << " BGR\n";
-
-  simaai::neat::InputOptions appsrc_options = runtime.model->input_appsrc_options(false);
-  appsrc_options.payload_type = simaai::neat::PayloadType::Image;
-  appsrc_options.format = "BGR";
-  appsrc_options.width = frame_w;
-  appsrc_options.height = frame_h;
-  appsrc_options.depth = 3;
-
-  runtime.detector_graph.add(simaai::neat::nodes::Input(appsrc_options));
-  runtime.detector_graph.add(runtime.model->graph());
-  runtime.detector_graph.add(simaai::neat::nodes::Output());
-
-  simaai::neat::RunOptions detector_run_options;
-  detector_run_options.preset = simaai::neat::RunPreset::Reliable;
-  detector_run_options.queue_depth = 4;
-  detector_run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  detector_run_options.output_memory = simaai::neat::OutputMemory::Owned;
-  cv::Mat detector_seed(frame_h, frame_w, CV_8UC3, cv::Scalar(0, 0, 0));
-  std::cout << "[init] building YOLO26 segmentation pipeline\n";
-  runtime.detector_run =
-      runtime.detector_graph.build(std::vector<cv::Mat>{detector_seed}, detector_run_options);
-  std::cout << "[init] YOLO26 segmentation pipeline ready\n";
-  return runtime;
-}
-
-std::optional<int> frame_limit_from_config(const AppConfig& cfg) {
-  if (cfg.inference.frames > 0) {
-    return cfg.inference.frames;
+const simaai::neat::Sample& joined_field(const simaai::neat::Sample& sample,
+                                         const std::string& label, size_t bundle_index) {
+  if (const auto* field = find_field(sample, label)) {
+    return *field;
   }
-  return std::nullopt;
+  if (sample.kind == simaai::neat::SampleKind::Bundle && sample.fields.size() > bundle_index) {
+    return sample.fields[bundle_index];
+  }
+  throw std::runtime_error("joined output missing " + label + " field");
 }
 
-std::vector<sima_examples::MetadataBox>
-build_segmentation_metadata_boxes(const std::vector<SegmentationDetection>& detections,
-                                  const std::vector<std::string>& labels, int frame_w,
-                                  int frame_h) {
-  std::vector<sima_examples::MetadataBox> metadata_boxes;
-  metadata_boxes.reserve(detections.size());
-  int object_index = 1;
-  for (const auto& det : detections) {
-    int x1 = static_cast<int>(det.x1);
-    int y1 = static_cast<int>(det.y1);
-    int w = static_cast<int>(det.x2 - det.x1);
-    int h = static_cast<int>(det.y2 - det.y1);
-    if (x1 < 0)
-      x1 = 0;
-    if (y1 < 0)
-      y1 = 0;
-    if (w < 0)
-      w = 0;
-    if (h < 0)
-      h = 0;
-    if (x1 + w > frame_w)
-      w = frame_w - x1;
-    if (y1 + h > frame_h)
-      h = frame_h - y1;
-    if (w < 0)
-      w = 0;
-    if (h < 0)
-      h = 0;
-    sima_examples::MetadataBox obj;
-    obj.id = "obj_" + std::to_string(object_index++);
-    obj.label = (det.class_id >= 0 && det.class_id < static_cast<int>(labels.size()))
-                    ? labels[det.class_id]
-                    : "unknown";
-    obj.confidence = det.score;
-    obj.x = static_cast<float>(x1);
-    obj.y = static_cast<float>(y1);
-    obj.w = static_cast<float>(w);
-    obj.h = static_cast<float>(h);
-    metadata_boxes.push_back(obj);
-  }
-  return metadata_boxes;
+simaai::neat::Tensor frame_tensor_from_sample(const simaai::neat::Sample& sample) {
+  const auto tensors = simaai::neat::tensors_from_sample(joined_field(sample, "frame", 0U), true);
+  return tensors.front();
+}
+
+simaai::neat::TensorList segment_tensors_from_sample(const simaai::neat::Sample& sample) {
+  return simaai::neat::tensors_from_sample(joined_field(sample, "segments", 1U), true);
+}
+
+std::string class_name(const std::vector<std::string>& labels, int class_id) {
+  return class_id >= 0 && class_id < static_cast<int>(labels.size()) ? labels[class_id] : "unknown";
 }
 
 cv::Scalar class_color(int class_id) {
@@ -729,25 +409,6 @@ cv::Scalar class_color(int class_id) {
       cv::Scalar(187, 212, 0),  cv::Scalar(255, 194, 0),   cv::Scalar(168, 153, 44),
   };
   return palette[static_cast<size_t>(std::max(class_id, 0)) % palette.size()];
-}
-
-void draw_box(cv::Mat& frame, const SegmentationDetection& det,
-              const std::vector<std::string>& labels) {
-  const int x1 = std::clamp(static_cast<int>(std::round(det.x1)), 0, frame.cols - 1);
-  const int y1 = std::clamp(static_cast<int>(std::round(det.y1)), 0, frame.rows - 1);
-  const int x2 = std::clamp(static_cast<int>(std::round(det.x2)), 0, frame.cols - 1);
-  const int y2 = std::clamp(static_cast<int>(std::round(det.y2)), 0, frame.rows - 1);
-  if (x2 <= x1 || y2 <= y1) {
-    return;
-  }
-  const cv::Scalar color = class_color(det.class_id);
-  cv::rectangle(frame, cv::Point(x1, y1), cv::Point(x2, y2), color, 2);
-  const std::string label = (det.class_id >= 0 && det.class_id < static_cast<int>(labels.size()))
-                                ? labels[det.class_id]
-                                : "unknown";
-  cv::putText(frame, label + " " + std::to_string(det.score).substr(0, 4),
-              cv::Point(x1, std::max(0, y1 - 4)), cv::FONT_HERSHEY_SIMPLEX, 0.5, color, 1,
-              cv::LINE_AA);
 }
 
 cv::Rect frame_rect_for_detection(const SegmentationDetection& det, const cv::Size& frame_size) {
@@ -765,11 +426,10 @@ cv::Rect mask_rect_for_frame_rect(const cv::Rect& frame_rect, const cv::Size& fr
   const double scale =
       std::min(static_cast<double>(model_w) / static_cast<double>(frame_size.width),
                static_cast<double>(model_h) / static_cast<double>(frame_size.height));
-  const double resized_w = static_cast<double>(frame_size.width) * scale;
-  const double resized_h = static_cast<double>(frame_size.height) * scale;
-  const double pad_x = (static_cast<double>(model_w) - resized_w) * 0.5;
-  const double pad_y = (static_cast<double>(model_h) - resized_h) * 0.5;
-
+  const double pad_x =
+      (static_cast<double>(model_w) - static_cast<double>(frame_size.width) * scale) * 0.5;
+  const double pad_y =
+      (static_cast<double>(model_h) - static_cast<double>(frame_size.height) * scale) * 0.5;
   const auto to_mask_x = [&](double frame_x) {
     return (frame_x * scale + pad_x) * static_cast<double>(mask_size.width) /
            static_cast<double>(model_w);
@@ -800,181 +460,236 @@ cv::Mat project_letterbox_mask_roi(const cv::Mat& mask, const cv::Rect& frame_re
   return projected;
 }
 
+void draw_box(cv::Mat& frame, const SegmentationDetection& det,
+              const std::vector<std::string>& labels) {
+  const cv::Rect rect = frame_rect_for_detection(det, frame.size());
+  const cv::Scalar color = class_color(det.class_id);
+  cv::rectangle(frame, rect, color, 2);
+  cv::putText(frame,
+              class_name(labels, det.class_id) + " " + std::to_string(det.score).substr(0, 4),
+              cv::Point(rect.x, std::max(0, rect.y - 4)), cv::FONT_HERSHEY_SIMPLEX, 0.5, color, 1,
+              cv::LINE_AA);
+}
+
 cv::Mat overlay_segmentation(const cv::Mat& frame,
                              const std::vector<SegmentationDetection>& detections,
                              const std::vector<std::string>& labels, const AppConfig& cfg) {
   cv::Mat annotated = frame.clone();
   for (const auto& det : detections) {
-    if (det.score < cfg.inference.min_score || det.mask.empty()) {
+    if (det.score < cfg.min_score || det.mask.empty()) {
       continue;
     }
     const cv::Rect frame_rect = frame_rect_for_detection(det, annotated.size());
     cv::Mat resized_mask = project_letterbox_mask_roi(det.mask, frame_rect, annotated.size());
     cv::Mat binary_mask;
-    cv::threshold(resized_mask, binary_mask, cfg.output.mask_threshold * 255.0, 255,
-                  cv::THRESH_BINARY);
+    cv::threshold(resized_mask, binary_mask, cfg.mask_threshold * 255.0, 255, cv::THRESH_BINARY);
     if (cv::countNonZero(binary_mask) > 0) {
       cv::Mat annotated_roi = annotated(frame_rect);
       cv::Mat mask_color(frame_rect.size(), annotated.type(), class_color(det.class_id));
       cv::Mat blended;
-      cv::addWeighted(annotated_roi, 1.0 - cfg.output.mask_alpha, mask_color, cfg.output.mask_alpha,
-                      0.0, blended);
+      cv::addWeighted(annotated_roi, 1.0 - cfg.mask_alpha, mask_color, cfg.mask_alpha, 0.0,
+                      blended);
       blended.copyTo(annotated_roi, binary_mask);
 
       std::vector<std::vector<cv::Point>> contours;
       cv::findContours(binary_mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
       cv::drawContours(annotated_roi, contours, -1, class_color(det.class_id), 2);
     }
-    if (cfg.output.draw_boxes) {
+    if (cfg.draw_boxes) {
       draw_box(annotated, det, labels);
     }
   }
   return annotated;
 }
 
-void producer_worker(simaai::neat::Run& source_run, simaai::neat::Tensor first_frame,
-                     double first_pull_ms, double first_pull_ts, WorkerSharedState& state) {
-  state.producer_start_ms = time_ms();
-  int produced = 0;
-  bool use_first = true;
-  while (!state.stop.load() && (!state.frame_limit || produced < *state.frame_limit)) {
-    simaai::neat::Tensor frame;
-    double pull_ms = 0.0;
-    double pull_ts = 0.0;
-    if (use_first) {
-      frame = std::move(first_frame);
-      use_first = false;
-      pull_ms = first_pull_ms;
-      pull_ts = first_pull_ts;
-    } else {
-      const double t0 = time_ms();
-      auto frame_opt = source_run.pull();
-      if (!frame_opt.has_value())
-        continue;
-      const double t1 = time_ms();
-      auto tensors = simaai::neat::tensors_from_sample(*frame_opt);
-      frame = std::move(tensors.front());
-      pull_ms = t1 - t0;
-      pull_ts = t1;
-    }
-    FrameItem item;
-    item.index = produced;
-    item.frame = std::move(frame);
-    item.pull_ts_ms = pull_ts;
-    item.rtsp_pull_ms = pull_ms;
-
-    if (!state.queue.push(std::move(item)))
-      break;
-
-    produced += 1;
-    state.producer_stats.count = produced;
+std::vector<sima_examples::MetadataBox>
+build_metadata_boxes(const std::vector<SegmentationDetection>& detections,
+                     const std::vector<std::string>& labels, int frame_w, int frame_h) {
+  std::vector<sima_examples::MetadataBox> boxes;
+  boxes.reserve(detections.size());
+  int object_index = 1;
+  for (const auto& det : detections) {
+    const cv::Rect rect = frame_rect_for_detection(det, cv::Size(frame_w, frame_h));
+    sima_examples::MetadataBox obj;
+    obj.id = "obj_" + std::to_string(object_index++);
+    obj.label = class_name(labels, det.class_id);
+    obj.confidence = det.score;
+    obj.x = static_cast<float>(rect.x);
+    obj.y = static_cast<float>(rect.y);
+    obj.w = static_cast<float>(rect.width);
+    obj.h = static_cast<float>(rect.height);
+    boxes.push_back(obj);
   }
-  state.queue.close();
-  state.producer_end_ms = time_ms();
+  return boxes;
 }
 
-void consumer_worker(simaai::neat::Run& detector_run, simaai::neat::Run& video_run,
-                     simaai::neat::MetadataSender& metadata_sender,
-                     const std::vector<std::string>& insight_labels, int frame_w, int frame_h,
-                     const AppConfig& cfg, WorkerSharedState& state) {
-  state.consumer_start_ms = time_ms();
-  int out_pulls = 0;
-  while (!state.stop.load() &&
-         (!state.frame_limit || state.published.load() < *state.frame_limit)) {
-    FrameProfile frame_profile;
-    FrameItem item;
-    const double q0 = time_ms();
-    if (!state.queue.pop(item))
-      break;
-    const double q1 = time_ms();
-    frame_profile.rtsp_pull_ms = item.rtsp_pull_ms;
-    frame_profile.queue_pop_ms = q1 - q0;
+PipelineRuntime build_pipeline(const AppConfig& cfg) {
+  PipelineRuntime runtime;
+  const auto source_options =
+      make_source_options(cfg, runtime.output_fps, runtime.frame_w, runtime.frame_h);
+  sima_examples::require(runtime.frame_w > 0 && runtime.frame_h > 0,
+                         "failed to probe RTSP frame dimensions");
+  sima_examples::require(runtime.output_fps > 0, "failed to probe RTSP frame rate");
 
-    PendingFrame decoded_frame;
-    decoded_frame.index = item.index;
-    decoded_frame.pull_ts_ms = item.pull_ts_ms;
-    decoded_frame.frame = std::move(item.frame);
+  runtime.model = make_model(cfg);
+  runtime.labels = load_labels(cfg.labels_path);
 
-    const double t_yolo0 = time_ms();
-    const cv::Mat detector_input =
-        decoded_frame.frame.to_cv_mat_copy(simaai::neat::ImageSpec::PixelFormat::BGR);
-    simaai::neat::Tensor detector_tensor =
-        simaai::neat::Tensor::from_cv_mat(detector_input, simaai::neat::ImageSpec::PixelFormat::BGR,
-                                          simaai::neat::TensorMemory::EV74);
-    auto detection_tensors = detector_run.run(simaai::neat::TensorList{detector_tensor}, 50000);
-    const double t_yolo1 = time_ms();
-    frame_profile.yolo_pull_ms = t_yolo1 - t_yolo0;
-    out_pulls += 1;
-    state.det_outputs.store(out_pulls);
+  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
+  auto branch = simaai::neat::graphs::Branch("source", {"frame", "model"});
 
-    PendingFrame pending = std::move(decoded_frame);
+  simaai::neat::Graph frame_graph("frame");
+  frame_graph.add(simaai::neat::nodes::Output("frame", simaai::neat::OutputOptions::EveryFrame(4)));
 
-    const double t_decode0 = time_ms();
-    std::vector<SegmentationDetection> detections;
-    try {
-      detections = decode_segmentation_output(detection_tensors, frame_w, frame_h,
-                                              cfg.inference.max_detections);
-    } catch (const std::exception& ex) {
-      std::cerr << "[warn] segmentation decode failed: " << ex.what() << "\n";
-      continue;
-    }
-    const double t_decode1 = time_ms();
-    frame_profile.decode_ms = t_decode1 - t_decode0;
-    frame_profile.boxes = static_cast<int>(detections.size());
+  simaai::neat::Graph model_graph("model");
+  model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
 
-    std::vector<sima_examples::MetadataBox> metadata_boxes =
-        build_segmentation_metadata_boxes(detections, insight_labels, frame_w, frame_h);
+  simaai::neat::Graph segments_graph("segments");
+  segments_graph.add(
+      simaai::neat::nodes::Output("segments", simaai::neat::OutputOptions::EveryFrame(4)));
 
-    // Contract: publish video first, then publish the matching metadata side-channel payload.
-    double output_ts = 0.0;
-    const double t_video_input0 = time_ms();
-    cv::Mat annotated = overlay_segmentation(detector_input, detections, insight_labels, cfg);
-    cv::Mat video_rgb;
-    cv::cvtColor(annotated, video_rgb, cv::COLOR_BGR2RGB);
-    const double t_video_input1 = time_ms();
-    frame_profile.video_input_ms = t_video_input1 - t_video_input0;
+  auto joined = simaai::neat::graphs::Combine({"frame", "segments"}, "segmentation_output",
+                                              simaai::neat::CombinePolicy::ByFrame);
 
-    const double t_video_sender_push0 = time_ms();
-    simaai::neat::Tensor video_tensor = simaai::neat::Tensor::from_cv_mat(
-        video_rgb, simaai::neat::ImageSpec::PixelFormat::RGB, simaai::neat::TensorMemory::EV74);
-    if (!video_run.push(simaai::neat::TensorList{video_tensor})) {
-      std::cerr << "[warn] VideoSender push failed\n";
-      continue;
-    }
-    const double t_video_sender_push1 = time_ms();
-    frame_profile.video_push_ms = t_video_sender_push1 - t_video_sender_push0;
-    output_ts = t_video_sender_push1;
-    const int64_t fid = static_cast<int64_t>(pending.index);
-    const auto now = std::chrono::system_clock::now().time_since_epoch();
-    const int64_t ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-    const std::string data_json =
-        sima_examples::metadata_boxes_data_json("objects", metadata_boxes);
-    std::string metadata_err;
-    const double t_metadata0 = time_ms();
-    const bool metadata_ok = metadata_sender.send_metadata(
-        "instance-segmentation", data_json, ts_ms, std::to_string(fid), &metadata_err);
-    const double t_metadata1 = time_ms();
-    frame_profile.metadata_ms = t_metadata1 - t_metadata0;
-    if (!metadata_ok) {
-      std::cerr << "[warn] insight metadata send failed: " << metadata_err << "\n";
-    }
-    if (!cfg.output.save_dir.empty() && cfg.output.save_every > 0 &&
-        (state.published.load() + 1) % cfg.output.save_every == 0) {
-      const fs::path out_path =
-          cfg.output.save_dir / ("frame_" + std::to_string(pending.index) + ".jpg");
-      if (!cv::imwrite(out_path.string(), annotated)) {
-        std::cerr << "[warn] failed to write output frame: " << out_path.string() << "\n";
-      }
-    }
-
-    frame_profile.e2e_ms = output_ts - pending.pull_ts_ms;
-
-    const int published_now = state.published.fetch_add(1) + 1;
-    state.profile_window.add(frame_profile, published_now);
+  runtime.graph.connect(source, branch);
+  runtime.graph.connect(branch, frame_graph);
+  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(model_graph, segments_graph);
+  runtime.graph.connect(frame_graph, joined);
+  runtime.graph.connect(segments_graph, joined);
+  if (cfg.profile) {
+    std::cout << "Backend:\n" << runtime.graph.describe_backend() << "\n";
   }
-  state.stop.store(true);
-  state.queue.close();
-  state.consumer_end_ms = time_ms();
+
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 3;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
+  runtime.run = runtime.graph.build(run_options);
+
+  simaai::neat::InputOptions video_input;
+  video_input.payload_type = simaai::neat::PayloadType::Image;
+  video_input.format = "RGB";
+  video_input.width = runtime.frame_w;
+  video_input.height = runtime.frame_h;
+  video_input.depth = 3;
+  video_input.use_simaai_pool = false;
+
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
+      runtime.frame_w, runtime.frame_h, runtime.output_fps);
+  video_options.host = cfg.insight_host;
+  video_options.channel = 0;
+  video_options.video_port_base = cfg.video_port;
+  video_options.encoder.bitrate_kbps = 1000;
+  runtime.video_port = video_options.video_port();
+
+  runtime.video_graph.add(simaai::neat::nodes::Input(video_input));
+  runtime.video_graph.add(simaai::neat::nodes::groups::VideoSender(video_options));
+  cv::Mat seed(runtime.frame_h, runtime.frame_w, CV_8UC3, cv::Scalar(0, 0, 0));
+  runtime.video_run = runtime.video_graph.build(std::vector<cv::Mat>{seed});
+
+  simaai::neat::MetadataSenderOptions metadata_options;
+  metadata_options.host = cfg.insight_host;
+  metadata_options.channel = 0;
+  metadata_options.metadata_port_base = cfg.metadata_port;
+  std::string metadata_err;
+  runtime.metadata_sender =
+      std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
+  sima_examples::require(runtime.metadata_sender->ok(), metadata_err);
+
+  std::cout << "rtsp=" << cfg.rtsp_url << " stream=" << runtime.frame_w << "x" << runtime.frame_h
+            << "@" << runtime.output_fps << " insight=" << cfg.insight_host
+            << " video=" << runtime.video_port
+            << " metadata=" << runtime.metadata_sender->metadata_port() << " channel=0\n";
+  return runtime;
+}
+
+void send_metadata(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
+                   const std::vector<SegmentationDetection>& detections) {
+  const auto boxes =
+      build_metadata_boxes(detections, runtime.labels, runtime.frame_w, runtime.frame_h);
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  const int64_t ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+  const int64_t frame_id = sample.frame_id >= 0 ? sample.frame_id : 0;
+  std::string err;
+  if (!runtime.metadata_sender->send_metadata(
+          "instance-segmentation", sima_examples::metadata_boxes_data_json("objects", boxes), ts_ms,
+          std::to_string(frame_id), &err)) {
+    std::cerr << "[warn] insight metadata send failed: " << err << "\n";
+  }
+}
+
+void push_annotated_video(PipelineRuntime& runtime, const cv::Mat& annotated_bgr) {
+  cv::Mat rgb;
+  cv::cvtColor(annotated_bgr, rgb, cv::COLOR_BGR2RGB);
+  const auto tensor = simaai::neat::Tensor::from_cv_mat(
+      rgb, simaai::neat::ImageSpec::PixelFormat::RGB, simaai::neat::TensorMemory::EV74);
+  if (!runtime.video_run.push(simaai::neat::TensorList{tensor})) {
+    throw std::runtime_error("Insight video push failed");
+  }
+}
+
+void maybe_save_frame(const AppConfig& cfg, int processed, const cv::Mat& annotated_bgr) {
+  if (cfg.save_dir.empty() || cfg.save_every <= 0 || processed % cfg.save_every != 0) {
+    return;
+  }
+  const auto out_path = cfg.save_dir / ("frame_" + std::to_string(processed) + ".jpg");
+  if (!cv::imwrite(out_path.string(), annotated_bgr)) {
+    std::cerr << "[warn] failed to write output frame: " << out_path.string() << "\n";
+  }
+}
+
+void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
+  ProfileWindow profile;
+  profile.enabled = cfg.profile;
+  profile.interval = cfg.profile_interval;
+
+  int processed = 0;
+  while (cfg.frames <= 0 || processed < cfg.frames) {
+    simaai::neat::Sample sample;
+    simaai::neat::PullError pull_error;
+    const double pull_start = time_ms();
+    const auto status = runtime.run.pull("segmentation_output", 20000, sample, &pull_error);
+    const double pull_end = time_ms();
+    if (status == simaai::neat::PullStatus::Timeout) {
+      std::cerr << "[warn] timed out waiting for segmentation output\n";
+      continue;
+    }
+    if (status == simaai::neat::PullStatus::Closed) {
+      break;
+    }
+    if (status != simaai::neat::PullStatus::Ok) {
+      throw std::runtime_error("failed to pull segmentation output: " + pull_error.message);
+    }
+
+    const double decode_start = time_ms();
+    const cv::Mat frame = tensor_bgr_from_decoded(frame_tensor_from_sample(sample));
+    const auto detections = decode_segmentation_output(
+        segment_tensors_from_sample(sample), runtime.frame_w, runtime.frame_h, cfg.max_detections);
+    const double decode_end = time_ms();
+
+    const double overlay_start = time_ms();
+    const cv::Mat annotated = overlay_segmentation(frame, detections, runtime.labels, cfg);
+    const double overlay_end = time_ms();
+
+    const double video_start = time_ms();
+    push_annotated_video(runtime, annotated);
+    const double video_end = time_ms();
+
+    const double metadata_start = time_ms();
+    send_metadata(runtime, sample, detections);
+    const double metadata_end = time_ms();
+
+    ++processed;
+    maybe_save_frame(cfg, processed, annotated);
+    profile.add(pull_end - pull_start, decode_end - decode_start, overlay_end - overlay_start,
+                video_end - video_start, metadata_end - metadata_start,
+                static_cast<int>(detections.size()));
+  }
+
+  profile.flush();
+  std::cout << "processed=" << processed << " video_sender=" << cfg.insight_host << ":"
+            << runtime.video_port << "\n";
 }
 
 } // namespace
@@ -990,73 +705,22 @@ int main(int argc, char** argv) {
       std::cout << "Config validated: " << cli.config_path << "\n";
       return 0;
     }
-    if (!cfg.output.save_dir.empty()) {
-      fs::create_directories(cfg.output.save_dir);
+    if (!cfg.save_dir.empty()) {
+      fs::create_directories(cfg.save_dir);
+    }
+    if (cfg.profile) {
+      setenv("SIMA_GST_ELEMENT_TIMINGS", "1", 0);
+      setenv("SIMA_GST_FLOW_DEBUG", "1", 0);
+      setenv("SIMA_GST_BOUNDARY_PROBES", "1", 0);
     }
 
-    RtspRuntime rtsp_runtime = build_rtsp_runtime(cfg);
-    InsightRuntime insight_runtime = build_insight_runtime(
-        cfg, rtsp_runtime.frame_w, rtsp_runtime.frame_h, rtsp_runtime.output_fps);
-    DetectorRuntime detector_runtime =
-        build_detector_runtime(cfg, rtsp_runtime.frame_w, rtsp_runtime.frame_h);
-
-    std::optional<int> frame_limit = frame_limit_from_config(cfg);
-    std::cout << "mode=insight"
-              << " frame_limit=" << (frame_limit ? std::to_string(*frame_limit) : "inf")
-              << " profile=" << (cfg.runtime.profile ? "1" : "0") << "\n";
-
-    // Contract: bounded queue preserves backpressure and producer closes it on exit.
-    FrameQueue queue(300);
-    ProducerStats producer_stats;
-    ProfileWindow profile_window;
-    profile_window.enabled = cfg.runtime.profile;
-    profile_window.interval = cfg.runtime.profile_interval;
-    std::atomic<bool> stop{false};
-    std::atomic<int> published{0};
-    std::atomic<int> det_outputs{0};
-    double producer_start_ms = 0.0;
-    double producer_end_ms = 0.0;
-    double consumer_start_ms = 0.0;
-    double consumer_end_ms = 0.0;
-
-    WorkerSharedState worker_state{
-        frame_limit,     queue,       producer_stats,    profile_window,  stop,
-        published,       det_outputs, producer_start_ms, producer_end_ms, consumer_start_ms,
-        consumer_end_ms,
-    };
-
-    // Contract: start producer first, then consumer; both terminate when queue closes or stop is
-    // set.
-    std::thread producer_thread(producer_worker, std::ref(rtsp_runtime.source_run),
-                                std::move(rtsp_runtime.first_frame), rtsp_runtime.first_pull_ms,
-                                rtsp_runtime.first_pull_ts, std::ref(worker_state));
-    std::thread consumer_thread(consumer_worker, std::ref(detector_runtime.detector_run),
-                                std::ref(insight_runtime.video_run),
-                                std::ref(*insight_runtime.metadata_sender),
-                                std::cref(insight_runtime.labels), rtsp_runtime.frame_w,
-                                rtsp_runtime.frame_h, std::cref(cfg), std::ref(worker_state));
-
-    if (producer_thread.joinable())
-      producer_thread.join();
-    if (consumer_thread.joinable())
-      consumer_thread.join();
-
-    std::cout << "published=" << published.load() << " video_sender=" << insight_runtime.host << ":"
-              << insight_runtime.video_port << "\n";
-    print_throughput_summary(producer_stats.count, det_outputs.load(), published.load(),
-                             producer_start_ms, producer_end_ms, consumer_start_ms,
-                             consumer_end_ms);
-    profile_window.flush(published.load());
-
-    // Contract: worker threads are joined before pipeline teardown. Explicit close avoids handing
-    // live appsrc/encoder teardown to Run move-assignment while bounded examples are exiting.
-    detector_runtime.detector_run.close();
-    insight_runtime.video_run.close();
-    rtsp_runtime.source_run.close();
+    PipelineRuntime runtime = build_pipeline(cfg);
+    run_pipeline(runtime, cfg);
+    runtime.video_run.close();
+    runtime.run.close();
     return 0;
-
-  } catch (const std::exception& e) {
-    std::cerr << "[ERR] " << e.what() << "\n";
-    return 1;
+  } catch (const std::exception& ex) {
+    std::cerr << "Error: " << ex.what() << "\n";
+    return 2;
   }
 }

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -1,18 +1,4 @@
-"""Single-camera RTSP YOLO26 segmentation Insight example using pyneat.
-
-This mirrors the intent of the C++ reference sample in the same folder:
-
-- pull one decoded RTSP stream
-- run one YOLO26 instance segmentation model
-- publish H.264 video with mask overlays plus metadata to Insight
-
-The implementation keeps those responsibilities loosely separated so the main
-runtime path is easy to reason about:
-
-1. RTSP probe/build
-2. YOLO26 segmentation inference and mask extraction
-3. Insight video/metadata publishing
-"""
+"""Single-camera RTSP YOLO26 segmentation Insight example using pyneat."""
 
 from __future__ import annotations
 
@@ -20,54 +6,22 @@ import argparse
 from dataclasses import dataclass
 import glob
 import json
+import os
+from pathlib import Path
 import sys
 import time
-from pathlib import Path
+
 import yaml
 
-DEFAULT_FPS = 30
-SOURCE_RUN_QUEUE_DEPTH = 4
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
 DEFAULT_LABELS = DEFAULT_CONFIG.parent / "coco_label.txt"
+DEFAULT_FPS = 30
 MASK_ALPHA = 0.55
-MASK_THRESHOLD = 0.5
+MASK_THRESHOLD = 0.50
+
 cv2 = None
 np = None
 pyneat = None
-
-
-@dataclass(frozen=True)
-class ModelConfig:
-    path: str
-    labels: str
-
-
-@dataclass(frozen=True)
-class SourceConfig:
-    rtsp_url: str
-    latency_ms: int
-    tcp: bool
-
-
-@dataclass(frozen=True)
-class InferenceConfig:
-    frames: int
-    min_score: float
-    nms_iou: float
-    max_detections: int
-
-
-@dataclass(frozen=True)
-class RuntimeConfig:
-    profile: bool
-    profile_interval: int
-
-
-@dataclass(frozen=True)
-class InsightConfig:
-    host: str
-    video_port: int
-    metadata_port: int
 
 
 @dataclass(frozen=True)
@@ -81,24 +35,104 @@ class OutputConfig:
 
 @dataclass(frozen=True)
 class AppConfig:
-    model: ModelConfig
-    source: SourceConfig
-    inference: InferenceConfig
-    runtime: RuntimeConfig
-    insight: InsightConfig
-    output: OutputConfig
+    model_path: str
+    labels_path: Path
+    rtsp_url: str
+    latency_ms: int = 200
+    tcp: bool = True
+    frames: int = 0
+    min_score: float = 0.55
+    nms_iou: float = 0.60
+    max_detections: int = 50
+    profile: bool = False
+    profile_interval: int = 100
+    insight_host: str = "127.0.0.1"
+    video_port: int = 9000
+    metadata_port: int = 9100
+    output: OutputConfig = OutputConfig("", 0, MASK_ALPHA, MASK_THRESHOLD, True)
+
+
+@dataclass
+class PipelineRuntime:
+    model: object
+    graph: object
+    run: object
+    video_graph: object
+    video_run: object
+    metadata_sender: object
+    labels: list[str]
+    frame_w: int
+    frame_h: int
+    output_fps: int
+    video_port: int
+
+
+class ProfileWindow:
+    def __init__(self, enabled: bool, interval: int) -> None:
+        self.enabled = enabled
+        self.interval = interval
+        self.reset()
+
+    def reset(self) -> None:
+        self.frames = 0
+        self.instances = 0
+        self.start_ms = 0.0
+        self.pull_ms = 0.0
+        self.decode_ms = 0.0
+        self.overlay_ms = 0.0
+        self.video_push_ms = 0.0
+        self.metadata_ms = 0.0
+
+    def add(
+        self,
+        pull_ms: float,
+        decode_ms: float,
+        overlay_ms: float,
+        video_push_ms: float,
+        metadata_ms: float,
+        instance_count: int,
+    ) -> None:
+        if not self.enabled:
+            return
+        if self.frames == 0:
+            self.start_ms = time_ms()
+        self.frames += 1
+        self.instances += instance_count
+        self.pull_ms += pull_ms
+        self.decode_ms += decode_ms
+        self.overlay_ms += overlay_ms
+        self.video_push_ms += video_push_ms
+        self.metadata_ms += metadata_ms
+        if self.frames >= self.interval:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self.enabled or self.frames == 0:
+            return
+        elapsed_ms = max(time_ms() - self.start_ms, 1e-6)
+        frames = float(self.frames)
+        print(
+            f"[profile] frames={self.frames} "
+            f"output_fps={self.frames * 1000.0 / elapsed_ms} "
+            f"avg_pull_ms={self.pull_ms / frames} "
+            f"avg_decode_ms={self.decode_ms / frames} "
+            f"avg_overlay_ms={self.overlay_ms / frames} "
+            f"avg_video_push_ms={self.video_push_ms / frames} "
+            f"avg_metadata_ms={self.metadata_ms / frames} "
+            f"avg_instances={self.instances / frames}",
+            flush=True,
+        )
+        self.reset()
 
 
 def load_runtime_dependencies() -> None:
-    """Import runtime-only dependencies after argparse validation."""
     global cv2, np, pyneat
     if pyneat is not None:
         return
 
-    # Prefer system OpenCV (built with GStreamer) when running inside a venv.
-    for p in glob.glob("/usr/lib/python3*/dist-packages"):
-        if p not in sys.path:
-            sys.path.insert(0, p)
+    for path in glob.glob("/usr/lib/python3*/dist-packages"):
+        if path not in sys.path:
+            sys.path.insert(0, path)
 
     import cv2 as cv2_module
     import numpy as np_module
@@ -109,25 +143,171 @@ def load_runtime_dependencies() -> None:
     pyneat = pyneat_module
 
 
-def tensor_to_numpy(tensor: pyneat.Tensor) -> np.ndarray:
-    """Copy a pyneat tensor into a NumPy array owned by Python."""
+def time_ms() -> float:
+    return time.perf_counter() * 1000.0
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Single-camera RTSP YOLO26 segmentation Insight example"
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--validate-config-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def section(raw: dict, key: str) -> dict:
+    value = raw.get(key) or {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a mapping")
+    return value
+
+
+def string_or(raw: dict, key: str, default: str = "") -> str:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def int_or(raw: dict, key: str, default: int) -> int:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if isinstance(value, str) and value.strip():
+        return int(value)
+    if not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return int(value)
+
+
+def float_or(raw: dict, key: str, default: float) -> float:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if isinstance(value, str) and value.strip():
+        return float(value)
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{key} must be numeric")
+    return float(value)
+
+
+def bool_or(raw: dict, key: str, default: bool) -> bool:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be true or false")
+    return bool(value)
+
+
+def validate_config(cfg: AppConfig) -> None:
+    if not cfg.rtsp_url:
+        raise ValueError("source.rtsp_url must be set")
+    if not cfg.model_path:
+        raise ValueError("model.path must be set")
+    if not str(cfg.labels_path):
+        raise ValueError("model.labels must be set")
+    if not cfg.insight_host:
+        raise ValueError("output.insight.host must be set")
+    if cfg.latency_ms < 0:
+        raise ValueError("source.latency_ms must be >= 0")
+    if cfg.frames < 0:
+        raise ValueError("inference.frames must be >= 0")
+    if not 0.0 <= cfg.min_score <= 1.0:
+        raise ValueError("inference.min_score must be between 0 and 1")
+    if not 0.0 <= cfg.nms_iou <= 1.0:
+        raise ValueError("inference.nms_iou must be between 0 and 1")
+    if cfg.max_detections <= 0:
+        raise ValueError("inference.max_detections must be > 0")
+    if cfg.profile_interval <= 0:
+        raise ValueError("runtime.profile_interval must be > 0")
+    if cfg.video_port <= 0:
+        raise ValueError("output.insight.video_port must be > 0")
+    if cfg.metadata_port <= 0:
+        raise ValueError("output.insight.metadata_port must be > 0")
+    if cfg.output.save_every < 0:
+        raise ValueError("output.save_every must be >= 0")
+    if not 0.0 <= cfg.output.mask_alpha <= 1.0:
+        raise ValueError("output.mask_alpha must be between 0 and 1")
+    if not 0.0 <= cfg.output.mask_threshold <= 1.0:
+        raise ValueError("output.mask_threshold must be between 0 and 1")
+
+
+def load_app_config(config_path: Path) -> AppConfig:
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("config root must be a mapping")
+
+    model = section(raw, "model")
+    source = section(raw, "source")
+    inference = section(raw, "inference")
+    runtime = section(raw, "runtime")
+    output = section(raw, "output")
+    insight = section(output, "insight")
+
+    cfg = AppConfig(
+        model_path=string_or(model, "path"),
+        labels_path=Path(string_or(model, "labels", str(DEFAULT_LABELS))),
+        rtsp_url=string_or(source, "rtsp_url"),
+        latency_ms=int_or(source, "latency_ms", 200),
+        tcp=bool_or(source, "tcp", True),
+        frames=int_or(inference, "frames", 0),
+        min_score=float_or(inference, "min_score", 0.55),
+        nms_iou=float_or(inference, "nms_iou", 0.60),
+        max_detections=int_or(inference, "max_detections", 50),
+        profile=bool_or(runtime, "profile", False),
+        profile_interval=int_or(runtime, "profile_interval", 100),
+        insight_host=string_or(insight, "host"),
+        video_port=int_or(insight, "video_port", 9000),
+        metadata_port=int_or(insight, "metadata_port", 9100),
+        output=OutputConfig(
+            save_dir=string_or(output, "save_dir"),
+            save_every=int_or(output, "save_every", 0),
+            mask_alpha=float_or(output, "mask_alpha", MASK_ALPHA),
+            mask_threshold=float_or(output, "mask_threshold", MASK_THRESHOLD),
+            draw_boxes=bool_or(output, "draw_boxes", True),
+        ),
+    )
+    validate_config(cfg)
+    return cfg
+
+
+def load_labels(labels_path: Path) -> list[str]:
+    if not labels_path.is_file():
+        raise RuntimeError(f"labels file does not exist: {labels_path}")
+    labels = [line.strip() for line in labels_path.read_text(encoding="utf-8").splitlines()]
+    labels = [label for label in labels if label]
+    if not labels:
+        raise RuntimeError(f"labels file is empty: {labels_path}")
+    return labels
+
+
+def tensor_to_numpy(tensor) -> object:
     return np.asarray(tensor.to_numpy(copy=True))
 
 
-def tensor_dim(tensor: pyneat.Tensor, name: str) -> int:
+def tensor_dim(tensor, name: str) -> int:
     value = getattr(tensor, name)
     return int(value() if callable(value) else value)
 
 
-def tensor_bgr_from_decoded(tensor: pyneat.Tensor) -> np.ndarray:
-    """Normalize decoded output into a writable HWC uint8 BGR frame."""
+def tensor_bgr_from_decoded(tensor):
     if tensor.is_nv12():
         width = tensor_dim(tensor, "width")
         height = tensor_dim(tensor, "height")
         payload = np.frombuffer(tensor.copy_payload_bytes(), dtype=np.uint8)
         expected = width * height * 3 // 2
         if payload.size < expected:
-            raise ValueError(f"NV12 payload too small: {payload.size} < {expected}")
+            raise RuntimeError(f"NV12 payload too small: {payload.size} < {expected}")
         nv12 = payload[:expected].reshape((height * 3 // 2, width))
         return np.ascontiguousarray(cv2.cvtColor(nv12, cv2.COLOR_YUV2BGR_NV12))
 
@@ -137,32 +317,21 @@ def tensor_bgr_from_decoded(tensor: pyneat.Tensor) -> np.ndarray:
         payload = np.frombuffer(tensor.copy_payload_bytes(), dtype=np.uint8)
         expected = width * height * 3 // 2
         if payload.size < expected:
-            raise ValueError(f"I420 payload too small: {payload.size} < {expected}")
+            raise RuntimeError(f"I420 payload too small: {payload.size} < {expected}")
         i420 = payload[:expected].reshape((height * 3 // 2, width))
         return np.ascontiguousarray(cv2.cvtColor(i420, cv2.COLOR_YUV2BGR_I420))
 
-    arr = tensor_to_numpy(tensor)
-    if arr.ndim == 4 and arr.shape[0] == 1:
-        arr = arr[0]
-    if arr.ndim != 3:
-        raise ValueError(f"unexpected decoded tensor shape {arr.shape}")
-    if arr.dtype != np.uint8:
-        arr = np.clip(arr, 0, 255).astype(np.uint8)
-    return np.ascontiguousarray(arr)
+    frame = tensor_to_numpy(tensor)
+    if frame.ndim == 4 and frame.shape[0] == 1:
+        frame = frame[0]
+    if frame.ndim != 3:
+        raise RuntimeError(f"unexpected decoded tensor shape {frame.shape}")
+    if frame.dtype != np.uint8:
+        frame = np.clip(frame, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(frame)
 
 
-def tensor_from_bgr_frame(frame: np.ndarray) -> pyneat.Tensor:
-    """Create an EV74 BGR image tensor for model-managed YOLO inference."""
-    return pyneat.Tensor.from_numpy(
-        np.ascontiguousarray(frame),
-        copy=True,
-        image_format=pyneat.PixelFormat.BGR,
-        memory=pyneat.TensorMemory.EV74,
-    )
-
-
-def tensor_from_rgb_frame(frame: np.ndarray) -> pyneat.Tensor:
-    """Create an EV74 RGB image tensor for VideoSender input."""
+def tensor_from_rgb_frame(frame):
     return pyneat.Tensor.from_numpy(
         np.ascontiguousarray(frame),
         copy=True,
@@ -171,42 +340,62 @@ def tensor_from_rgb_frame(frame: np.ndarray) -> pyneat.Tensor:
     )
 
 
-def is_tensor_like(value) -> bool:
-    return hasattr(value, "copy_payload_bytes") and hasattr(value, "to_numpy")
-
-
-def is_sample_like(value) -> bool:
-    return hasattr(value, "kind") and hasattr(value, "fields")
-
-
-def extract_tensors(result) -> list:
-    if isinstance(result, (list, tuple)) and all(is_tensor_like(item) for item in result):
-        return list(result)
-
-    if not is_sample_like(result):
+def extract_tensors(sample) -> list:
+    if isinstance(sample, (list, tuple)) and all(hasattr(item, "to_numpy") for item in sample):
+        return list(sample)
+    if sample is None or not hasattr(sample, "kind"):
         return []
+    if sample.kind == pyneat.SampleKind.Tensor and sample.tensor is not None:
+        return [sample.tensor]
+    if sample.kind == pyneat.SampleKind.TensorSet:
+        return list(sample.tensors)
 
     tensors = []
-    stack = [result]
-    while stack:
-        current = stack.pop()
-        stack.extend(reversed(list(current.fields)))
-        if current.kind == pyneat.SampleKind.TensorSet:
-            tensors.extend(current.tensors)
-            continue
-        if current.kind == pyneat.SampleKind.Tensor and current.tensor is not None:
-            tensors.append(current.tensor)
+    for field in sample.fields:
+        tensors.extend(extract_tensors(field))
     return tensors
 
 
-def segmentation_results_from_output(result, width: int, height: int, max_detections: int) -> list[dict]:
-    tensors = extract_tensors(result)
-    if not tensors:
-        raise RuntimeError("model returned no segmentation tensors")
+def find_field(sample, label: str):
+    if sample is None:
+        return None
+    if getattr(sample, "stream_label", "") == label:
+        return sample
+    for field in getattr(sample, "fields", []):
+        found = find_field(field, label)
+        if found is not None:
+            return found
+    return None
 
+
+def joined_field(sample, label: str, bundle_index: int):
+    field = find_field(sample, label)
+    fields = list(getattr(sample, "fields", []))
+    if field is not None:
+        return field
+    if getattr(sample, "kind", None) == pyneat.SampleKind.Bundle and len(fields) > bundle_index:
+        return fields[bundle_index]
+    raise RuntimeError(f"joined output missing {label} field")
+
+
+def frame_tensor_from_sample(sample):
+    tensors = extract_tensors(joined_field(sample, "frame", 0))
+    if not tensors:
+        raise RuntimeError("joined frame field has no tensor")
+    return tensors[0]
+
+
+def segment_tensors_from_sample(sample) -> list:
+    tensors = extract_tensors(joined_field(sample, "segments", 1))
+    if not tensors:
+        raise RuntimeError("joined segments field has no tensors")
+    return tensors
+
+
+def decode_segmentation_output(tensors: list, frame_w: int, frame_h: int, max_detections: int):
     decoded = pyneat.decode_segmentation(
         tensors,
-        clamp_to=(width, height),
+        clamp_to=(frame_w, frame_h),
         top_k=max_detections,
         strict=False,
     )
@@ -214,8 +403,6 @@ def segmentation_results_from_output(result, width: int, height: int, max_detect
     for item in decoded:
         boxes = tensor_to_numpy(item.boxes).astype(np.float32)
         masks = tensor_to_numpy(item.masks).astype(np.uint8)
-        if boxes.size == 0:
-            continue
         for row, mask in zip(boxes.reshape((-1, 6)), masks.reshape((-1, 160, 160))):
             x1, y1, x2, y2, score, class_id = row.tolist()
             if x2 <= x1 or y2 <= y1:
@@ -231,15 +418,12 @@ def segmentation_results_from_output(result, width: int, height: int, max_detect
                     "mask": mask,
                 }
             )
-    return detections[:max_detections]
+            if len(detections) >= max_detections:
+                return detections
+    return detections
 
 
 def probe_rtsp(url: str) -> tuple[int, int, int]:
-    """Probe the stream once so the rest of the pipeline uses real dimensions.
-
-    The Python sample keeps this step explicit instead of hardcoding 640x480,
-    which makes the output path behave correctly for streams such as 720p.
-    """
     cap = cv2.VideoCapture(url)
     if not cap.isOpened():
         raise RuntimeError(f"failed to open RTSP source for probing: {url}")
@@ -249,92 +433,47 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap.release()
     if width <= 0 or height <= 0:
         raise RuntimeError("failed to probe RTSP frame size")
-    if fps <= 0:
-        fps = DEFAULT_FPS
-    return width, height, fps
+    return width, height, fps if fps > 0 else DEFAULT_FPS
 
 
-def build_rtsp_run(
-    url: str,
-    width: int,
-    height: int,
-    fps: int,
-    latency_ms: int,
-    tcp: bool,
-) -> tuple[pyneat.Graph, pyneat.Run]:
-    """Build a decoded RTSP input graph that yields decoded frame tensors."""
-    ro = pyneat.RtspDecodedInputOptions()
-    ro.url = url
-    ro.latency_ms = latency_ms
-    ro.tcp = tcp
-    ro.payload_type = 96
-    ro.insert_queue = True
-    ro.auto_caps_from_stream = True
-    ro.fallback_h264_width = width
-    ro.fallback_h264_height = height
-    ro.fallback_h264_fps = fps
-    ro.sima_allocator_type = 2
-    ro.decoder_raw_output = False
-    ro.use_videoconvert = False
-    ro.use_videoscale = True
-    ro.output_caps.enable = True
-    ro.output_caps.width = width
-    ro.output_caps.height = height
-    ro.output_caps.fps = fps
-    ro.output_caps.memory = pyneat.CapsMemory.SystemMemory
-
-    graph = pyneat.Graph()
-    graph.add(pyneat.groups.rtsp_decoded_input(ro))
-    graph.add(pyneat.nodes.output(pyneat.OutputOptions.every_frame(1)))
-
-    run_opt = pyneat.RunOptions()
-    run_opt.queue_depth = SOURCE_RUN_QUEUE_DEPTH
-    run_opt.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_opt.output_memory = pyneat.OutputMemory.Owned
-    run = graph.build(run_opt)
-    return graph, run
+def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
+    opt = pyneat.RtspDecodedInputOptions()
+    opt.url = cfg.rtsp_url
+    opt.latency_ms = cfg.latency_ms
+    opt.tcp = cfg.tcp
+    opt.payload_type = 96
+    opt.insert_queue = True
+    opt.decoder_name = "decoder"
+    opt.decoder_raw_output = True
+    opt.auto_caps_from_stream = True
+    opt.fallback_h264_width = width
+    opt.fallback_h264_height = height
+    opt.fallback_h264_fps = fps
+    return opt
 
 
-def build_model(model_path: str, inference: InferenceConfig) -> pyneat.Model:
-    """Create the YOLO26 segmentation model with model-managed preprocess/decode."""
+def make_model(cfg: AppConfig):
     opt = pyneat.ModelOptions()
     opt.preprocess.kind = pyneat.InputKind.Image
     opt.preprocess.enable = pyneat.AutoFlag.On
-    opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.BGR
+    opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.NV12
     opt.preprocess.preset = pyneat.NormalizePreset.COCO_YOLO
     opt.decode_type = pyneat.BoxDecodeType.YoloV26Seg
-    opt.score_threshold = inference.min_score
-    opt.nms_iou_threshold = inference.nms_iou
-    opt.top_k = inference.max_detections
-    return pyneat.Model(model_path, opt)
+    opt.score_threshold = cfg.min_score
+    opt.nms_iou_threshold = cfg.nms_iou
+    opt.top_k = cfg.max_detections
+    return pyneat.Model(cfg.model_path, opt)
 
 
-def build_detector_run(model_path: str, width: int, height: int, inference: InferenceConfig):
-    """Build the explicit YOLO26 segmentation graph used by the RTSP loop."""
-    model = build_model(model_path, inference)
-
-    input_opt = model.input_appsrc_options(False)
-    input_opt.payload_type = pyneat.PayloadType.Image
-    input_opt.format = "BGR"
-    input_opt.width = width
-    input_opt.height = height
-    input_opt.depth = 3
-
-    graph = pyneat.Graph()
-    graph.add(pyneat.nodes.input(input_opt))
-    graph.add(model.graph())
-    graph.add(pyneat.nodes.output())
-
-    seed = tensor_from_bgr_frame(np.zeros((height, width, 3), dtype=np.uint8))
-    run_opt = pyneat.RunOptions()
-    run_opt.queue_depth = 4
-    run_opt.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_opt.output_memory = pyneat.OutputMemory.Owned
-    return model, graph, graph.build([seed], run_opt)
+def build_metadata_sender(cfg: AppConfig):
+    options = pyneat.MetadataSenderOptions()
+    options.host = cfg.insight_host
+    options.channel = 0
+    options.metadata_port_base = cfg.metadata_port
+    return pyneat.MetadataSender(options)
 
 
-def build_video_sender_run(cfg: AppConfig, width: int, height: int, fps: int):
-    """Build the VideoSender used to publish annotated RGB frames to Insight."""
+def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
     input_opt = pyneat.InputOptions()
     input_opt.payload_type = pyneat.PayloadType.Image
     input_opt.format = "RGB"
@@ -346,12 +485,12 @@ def build_video_sender_run(cfg: AppConfig, width: int, height: int, fps: int):
     input_opt.use_simaai_pool = False
 
     sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
-    sender_opt.host = cfg.insight.host
+    sender_opt.host = cfg.insight_host
     sender_opt.channel = 0
-    sender_opt.video_port_base = cfg.insight.video_port
-    sender_opt.encoder.bitrate_kbps = 4000
+    sender_opt.video_port_base = cfg.video_port
+    sender_opt.encoder.bitrate_kbps = 1000
 
-    graph = pyneat.Graph()
+    graph = pyneat.Graph("video")
     graph.add(pyneat.nodes.input(input_opt))
     graph.add(pyneat.groups.video_sender(sender_opt))
 
@@ -361,53 +500,71 @@ def build_video_sender_run(cfg: AppConfig, width: int, height: int, fps: int):
         image_format=pyneat.PixelFormat.RGB,
         memory=pyneat.TensorMemory.EV74,
     )
-    return graph, graph.build([seed])
+    return graph, graph.build([seed]), sender_opt.video_port
 
 
-def build_metadata_sender(cfg: AppConfig):
-    options = pyneat.MetadataSenderOptions()
-    options.host = cfg.insight.host
-    options.channel = 0
-    options.metadata_port_base = cfg.insight.metadata_port
-    return pyneat.MetadataSender(options)
+def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
+    frame_w, frame_h, fps = probe_rtsp(cfg.rtsp_url)
+    model = make_model(cfg)
+    labels = load_labels(cfg.labels_path)
 
+    source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, fps, frame_w, frame_h))
+    branch = pyneat.graphs.branch("source", ["frame", "model"])
 
-def load_labels(path: Path) -> list[str]:
-    if not path.is_file():
-        raise FileNotFoundError(f"Labels file does not exist: {path}")
-    labels = [
-        line.strip()
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-    if not labels:
-        raise ValueError(f"Labels file is empty: {path}")
-    return labels
+    frame_graph = pyneat.Graph("frame")
+    frame_graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(4)))
+
+    model_graph = pyneat.Graph("model")
+    model_graph.connect(pyneat.nodes.input("model"), model)
+
+    segments_graph = pyneat.Graph("segments")
+    segments_graph.add(pyneat.nodes.output("segments", pyneat.OutputOptions.every_frame(4)))
+
+    joined = pyneat.graphs.combine(
+        ["frame", "segments"], "segmentation_output", pyneat.CombinePolicy.ByFrame
+    )
+
+    graph = pyneat.Graph()
+    graph.connect(source, branch)
+    graph.connect(branch, frame_graph)
+    graph.connect(branch, model_graph)
+    graph.connect(model_graph, segments_graph)
+    graph.connect(frame_graph, joined)
+    graph.connect(segments_graph, joined)
+    if cfg.profile:
+        print(f"Backend:\n{graph.describe_backend()}")
+
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 3
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
+    run = graph.build(run_options)
+
+    video_graph, video_run, video_port = build_video_graph(cfg, frame_w, frame_h, fps)
+    metadata_sender = build_metadata_sender(cfg)
+    print(
+        f"rtsp={cfg.rtsp_url} stream={frame_w}x{frame_h}@{fps} "
+        f"insight={cfg.insight_host} video={video_port} "
+        f"metadata={metadata_sender.metadata_port()} channel=0"
+    )
+    return PipelineRuntime(
+        model=model,
+        graph=graph,
+        run=run,
+        video_graph=video_graph,
+        video_run=video_run,
+        metadata_sender=metadata_sender,
+        labels=labels,
+        frame_w=frame_w,
+        frame_h=frame_h,
+        output_fps=fps,
+        video_port=video_port,
+    )
 
 
 def class_name(labels: list[str], class_id: int) -> str:
     return labels[class_id] if 0 <= class_id < len(labels) else "unknown"
-
-
-def make_instance_segmentation_data_json(detections: list[dict], labels: list[str]) -> str:
-    """Build lightweight metadata; masks are rendered directly into the video."""
-    objects = []
-    for idx, det in enumerate(detections, start=1):
-        cls_id = int(det["class_id"])
-        objects.append(
-            {
-                "id": f"obj_{idx}",
-                "label": class_name(labels, cls_id),
-                "confidence": float(det["score"]),
-                "bbox": [
-                    float(det["x1"]),
-                    float(det["y1"]),
-                    float(det["x2"] - det["x1"]),
-                    float(det["y2"] - det["y1"]),
-                ],
-            }
-        )
-    return json.dumps({"objects": objects}, separators=(",", ":"))
 
 
 def class_color(class_id: int) -> tuple[int, int, int]:
@@ -426,28 +583,6 @@ def class_color(class_id: int) -> tuple[int, int, int]:
         (168, 153, 44),
     ]
     return palette[max(0, class_id) % len(palette)]
-
-
-def draw_box(frame: np.ndarray, det: dict, labels: list[str]) -> None:
-    cls_id = int(det["class_id"])
-    color = class_color(cls_id)
-    x1 = max(0, int(round(det["x1"])))
-    y1 = max(0, int(round(det["y1"])))
-    x2 = min(frame.shape[1] - 1, int(round(det["x2"])))
-    y2 = min(frame.shape[0] - 1, int(round(det["y2"])))
-    if x2 <= x1 or y2 <= y1:
-        return
-    cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
-    cv2.putText(
-        frame,
-        f"{class_name(labels, cls_id)} {float(det['score']):.2f}",
-        (x1, max(0, y1 - 4)),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        0.5,
-        color,
-        1,
-        cv2.LINE_AA,
-    )
 
 
 def frame_rect_for_detection(det: dict, frame_shape: tuple[int, ...]) -> tuple[int, int, int, int]:
@@ -469,10 +604,8 @@ def mask_rect_for_frame_rect(
     model_w = mask_w * 4
     model_h = mask_h * 4
     scale = min(model_w / frame_w, model_h / frame_h)
-    resized_w = frame_w * scale
-    resized_h = frame_h * scale
-    pad_x = (model_w - resized_w) * 0.5
-    pad_y = (model_h - resized_h) * 0.5
+    pad_x = (model_w - frame_w * scale) * 0.5
+    pad_y = (model_h - frame_h * scale) * 0.5
 
     def to_mask_x(frame_x: float) -> float:
         return (frame_x * scale + pad_x) * mask_w / model_w
@@ -489,421 +622,184 @@ def mask_rect_for_frame_rect(
 
 
 def project_letterbox_mask_roi(
-    mask: np.ndarray,
+    mask,
     frame_shape: tuple[int, ...],
     frame_rect: tuple[int, int, int, int],
-) -> np.ndarray:
+):
     x0, y0, x1, y1 = frame_rect
     mx0, my0, mx1, my1 = mask_rect_for_frame_rect(frame_rect, frame_shape, mask.shape)
     return cv2.resize(mask[my0:my1, mx0:mx1], (x1 - x0, y1 - y0), interpolation=cv2.INTER_LINEAR)
 
 
+def draw_box(frame, det: dict, labels: list[str]) -> None:
+    cls_id = int(det["class_id"])
+    color = class_color(cls_id)
+    x0, y0, x1, y1 = frame_rect_for_detection(det, frame.shape)
+    cv2.rectangle(frame, (x0, y0), (x1, y1), color, 2)
+    cv2.putText(
+        frame,
+        f"{class_name(labels, cls_id)} {float(det['score']):.2f}",
+        (x0, max(0, y0 - 4)),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.5,
+        color,
+        1,
+        cv2.LINE_AA,
+    )
+
+
 def overlay_segmentation(
-    frame: np.ndarray,
+    frame,
     detections: list[dict],
     min_score: float,
     cfg: OutputConfig,
     labels: list[str],
-) -> np.ndarray:
+):
     annotated = frame.copy()
     for det in detections:
-        score = float(det["score"])
-        if score < min_score:
+        if float(det["score"]) < min_score:
             continue
         mask = det.get("mask")
         if mask is None:
             continue
         mask = np.asarray(mask, dtype=np.uint8)
-        max_mask = int(mask.max()) if mask.size else 0
-        threshold = cfg.mask_threshold * (255.0 if max_mask > 1 else 1.0)
+        threshold = cfg.mask_threshold * (255.0 if int(mask.max()) > 1 else 1.0)
         x0, y0, x1, y1 = frame_rect_for_detection(det, frame.shape)
         roi_mask = project_letterbox_mask_roi(mask, frame.shape, (x0, y0, x1, y1))
-        region = roi_mask > threshold
-        if np.any(region):
-            color = np.array(class_color(int(det["class_id"])), dtype=np.float32)
+        _, binary_mask = cv2.threshold(roi_mask, threshold, 255, cv2.THRESH_BINARY)
+        if cv2.countNonZero(binary_mask) > 0:
+            color = class_color(int(det["class_id"]))
             roi = annotated[y0:y1, x0:x1]
-            roi[region] = (
-                (1.0 - cfg.mask_alpha) * roi[region].astype(np.float32)
-                + cfg.mask_alpha * color
-            ).astype(np.uint8)
-            contour_mask = region.astype(np.uint8)
-            contours, _ = cv2.findContours(contour_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-            cv2.drawContours(roi, contours, -1, class_color(int(det["class_id"])), 2, cv2.LINE_8)
+            mask_color = np.full(roi.shape, color, dtype=np.uint8)
+            blended = cv2.addWeighted(roi, 1.0 - cfg.mask_alpha, mask_color, cfg.mask_alpha, 0.0)
+            cv2.copyTo(blended, binary_mask, roi)
+            contours, _ = cv2.findContours(binary_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            cv2.drawContours(roi, contours, -1, color, 2, cv2.LINE_8)
         if cfg.draw_boxes:
             draw_box(annotated, det, labels)
     return annotated
 
 
-def save_annotated_frame(frame: np.ndarray, out_path: Path) -> None:
-    """Write one BGR frame for e2e/debug inspection."""
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    if not cv2.imwrite(str(out_path), frame):
-        raise RuntimeError(f"failed to write output frame: {out_path}")
-
-
-def build_arg_parser() -> argparse.ArgumentParser:
-    """Expose only the small set of controls needed for this reference flow."""
-    parser = argparse.ArgumentParser(
-        description="Single-camera RTSP YOLO26 segmentation Insight example"
-    )
-    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
-    parser.add_argument(
-        "--validate-config-only",
-        action="store_true",
-        help="Validate config and exit without opening the RTSP stream.",
-    )
-    return parser
-
-
-def _mapping(value, name: str) -> dict:
-    if value is None:
-        return {}
-    if not isinstance(value, dict):
-        raise ValueError(f"{name} must be a mapping")
-    return value
-
-
-def _required_string(mapping: dict, key: str, section: str) -> str:
-    value = mapping.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{section}.{key} must be a non-empty string")
-    return value
-
-
-def _optional_int(mapping: dict, key: str, default: int) -> int:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, int):
-        raise ValueError(f"{key} must be an integer")
-    return int(value)
-
-
-def _optional_float(mapping: dict, key: str, default: float) -> float:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, (int, float)):
-        raise ValueError(f"{key} must be numeric")
-    return float(value)
-
-
-def _optional_bool(mapping: dict, key: str, default: bool) -> bool:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, bool):
-        raise ValueError(f"{key} must be true or false")
-    return bool(value)
-
-
-def _optional_string(mapping: dict, key: str, default: str) -> str:
-    value = mapping.get(key, default)
-    if value is None:
-        return default
-    if not isinstance(value, str):
-        raise ValueError(f"{key} must be a string")
-    return value
-
-
-def load_app_config(config_path: Path) -> AppConfig:
-    with config_path.open("r", encoding="utf-8") as handle:
-        raw = yaml.safe_load(handle) or {}
-
-    if not isinstance(raw, dict):
-        raise ValueError("config root must be a mapping")
-
-    model_cfg = _mapping(raw.get("model"), "model")
-    source_cfg = _mapping(raw.get("source"), "source")
-    inference_cfg = _mapping(raw.get("inference"), "inference")
-    runtime_cfg = _mapping(raw.get("runtime"), "runtime")
-    output_cfg = _mapping(raw.get("output"), "output")
-    insight_cfg = _mapping(output_cfg.get("insight"), "output.insight")
-
-    cfg = AppConfig(
-        model=ModelConfig(
-            path=_required_string(model_cfg, "path", "model"),
-            labels=_optional_string(model_cfg, "labels", str(DEFAULT_LABELS)),
-        ),
-        source=SourceConfig(
-            rtsp_url=_required_string(source_cfg, "rtsp_url", "source"),
-            latency_ms=_optional_int(source_cfg, "latency_ms", 200),
-            tcp=_optional_bool(source_cfg, "tcp", True),
-        ),
-        inference=InferenceConfig(
-            frames=_optional_int(inference_cfg, "frames", 0),
-            min_score=_optional_float(inference_cfg, "min_score", 0.55),
-            nms_iou=_optional_float(inference_cfg, "nms_iou", 0.60),
-            max_detections=_optional_int(inference_cfg, "max_detections", 50),
-        ),
-        runtime=RuntimeConfig(
-            profile=_optional_bool(runtime_cfg, "profile", False),
-            profile_interval=_optional_int(runtime_cfg, "profile_interval", 100),
-        ),
-        insight=InsightConfig(
-            host=_required_string(insight_cfg, "host", "output.insight"),
-            video_port=_optional_int(insight_cfg, "video_port", 9000),
-            metadata_port=_optional_int(insight_cfg, "metadata_port", 9100),
-        ),
-        output=OutputConfig(
-            save_dir=_optional_string(output_cfg, "save_dir", ""),
-            save_every=_optional_int(output_cfg, "save_every", 0),
-            mask_alpha=_optional_float(output_cfg, "mask_alpha", MASK_ALPHA),
-            mask_threshold=_optional_float(output_cfg, "mask_threshold", MASK_THRESHOLD),
-            draw_boxes=_optional_bool(output_cfg, "draw_boxes", True),
-        ),
-    )
-
-    if cfg.source.latency_ms < 0:
-        raise ValueError("source.latency_ms must be >= 0")
-    if cfg.inference.frames < 0:
-        raise ValueError("inference.frames must be >= 0")
-    if cfg.output.save_every < 0:
-        raise ValueError("output.save_every must be >= 0")
-    if not 0.0 <= cfg.output.mask_alpha <= 1.0:
-        raise ValueError("output.mask_alpha must be between 0 and 1")
-    if not 0.0 <= cfg.output.mask_threshold <= 1.0:
-        raise ValueError("output.mask_threshold must be between 0 and 1")
-    if not 0.0 <= cfg.inference.min_score <= 1.0:
-        raise ValueError("inference.min_score must be between 0 and 1")
-    if not 0.0 <= cfg.inference.nms_iou <= 1.0:
-        raise ValueError("inference.nms_iou must be between 0 and 1")
-    if cfg.inference.max_detections <= 0:
-        raise ValueError("inference.max_detections must be > 0")
-    if cfg.runtime.profile_interval <= 0:
-        raise ValueError("runtime.profile_interval must be > 0")
-    if cfg.insight.video_port <= 0:
-        raise ValueError("output.insight.video_port must be > 0")
-    if cfg.insight.metadata_port <= 0:
-        raise ValueError("output.insight.metadata_port must be > 0")
-
-    return cfg
-
-
-class ProfileWindow:
-    def __init__(self, enabled: bool, interval: int) -> None:
-        self.enabled = enabled
-        self.interval = interval
-        self.reset()
-
-    def reset(self) -> None:
-        self.frames = 0
-        self.boxes = 0
-        self.started = 0.0
-        self.rtsp_pull_ms = 0.0
-        self.infer_ms = 0.0
-        self.decode_ms = 0.0
-        self.video_push_ms = 0.0
-        self.e2e_ms = 0.0
-        self.max_e2e_ms = 0.0
-
-    def add(
-        self,
-        *,
-        rtsp_pull_ms: float,
-        infer_ms: float,
-        decode_ms: float,
-        video_push_ms: float,
-        e2e_ms: float,
-        boxes: int,
-        published_total: int,
-    ) -> None:
-        if not self.enabled:
-            return
-        if self.frames == 0:
-            self.started = time.perf_counter()
-        self.frames += 1
-        self.boxes += boxes
-        self.rtsp_pull_ms += rtsp_pull_ms
-        self.infer_ms += infer_ms
-        self.decode_ms += decode_ms
-        self.video_push_ms += video_push_ms
-        self.e2e_ms += e2e_ms
-        self.max_e2e_ms = max(self.max_e2e_ms, e2e_ms)
-        if self.frames >= self.interval:
-            self.flush(published_total)
-
-    def flush(self, published_total: int) -> None:
-        if not self.enabled or self.frames == 0:
-            return
-        elapsed = max(time.perf_counter() - self.started, 1e-6)
-        frames = float(self.frames)
-        print(
-            f"[profile] frames={self.frames} published={published_total} "
-            f"fps={self.frames / elapsed:.2f} "
-            f"avg_rtsp_pull_ms={self.rtsp_pull_ms / frames:.2f} "
-            f"avg_infer_ms={self.infer_ms / frames:.2f} "
-            f"avg_decode_ms={self.decode_ms / frames:.2f} "
-            f"avg_video_push_ms={self.video_push_ms / frames:.2f} "
-            f"avg_e2e_ms={self.e2e_ms / frames:.2f} "
-            f"avg_boxes={self.boxes / frames:.2f} "
-            f"max_e2e_ms={self.max_e2e_ms:.2f}",
-            flush=True,
+def metadata_boxes(detections: list[dict], labels: list[str], frame_w: int, frame_h: int):
+    objects = []
+    for index, det in enumerate(detections, start=1):
+        x0, y0, x1, y1 = frame_rect_for_detection(det, (frame_h, frame_w, 3))
+        objects.append(
+            {
+                "id": f"obj_{index}",
+                "label": class_name(labels, int(det["class_id"])),
+                "confidence": float(det["score"]),
+                "bbox": [float(x0), float(y0), float(x1 - x0), float(y1 - y0)],
+            }
         )
-        self.reset()
+    return objects
+
+
+def send_metadata(runtime: PipelineRuntime, sample, detections: list[dict]) -> None:
+    frame_id = getattr(sample, "frame_id", -1)
+    if frame_id is None or frame_id < 0:
+        frame_id = 0
+    runtime.metadata_sender.send_metadata(
+        "instance-segmentation",
+        json.dumps(
+            {"objects": metadata_boxes(detections, runtime.labels, runtime.frame_w, runtime.frame_h)},
+            separators=(",", ":"),
+        ),
+        int(time.time() * 1000),
+        str(frame_id),
+    )
+
+
+def push_annotated_video(runtime: PipelineRuntime, annotated_bgr) -> None:
+    rgb = cv2.cvtColor(annotated_bgr, cv2.COLOR_BGR2RGB)
+    if not runtime.video_run.push([tensor_from_rgb_frame(rgb)]):
+        raise RuntimeError("Insight video push failed")
+
+
+def maybe_save_frame(cfg: AppConfig, processed: int, annotated_bgr) -> None:
+    if not cfg.output.save_dir or cfg.output.save_every <= 0:
+        return
+    if processed % cfg.output.save_every != 0:
+        return
+    out_path = Path(cfg.output.save_dir) / f"frame_{processed}.jpg"
+    if not cv2.imwrite(str(out_path), annotated_bgr):
+        print(f"[warn] failed to write output frame: {out_path}", file=sys.stderr)
+
+
+def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
+    profile = ProfileWindow(cfg.profile, cfg.profile_interval)
+    processed = 0
+    while cfg.frames <= 0 or processed < cfg.frames:
+        pull_start = time_ms()
+        sample = runtime.run.pull("segmentation_output", 20000)
+        pull_end = time_ms()
+        if sample is None:
+            print("[warn] timed out waiting for segmentation output", file=sys.stderr)
+            continue
+
+        decode_start = time_ms()
+        frame = tensor_bgr_from_decoded(frame_tensor_from_sample(sample))
+        detections = decode_segmentation_output(
+            segment_tensors_from_sample(sample),
+            runtime.frame_w,
+            runtime.frame_h,
+            cfg.max_detections,
+        )
+        decode_end = time_ms()
+
+        overlay_start = time_ms()
+        annotated = overlay_segmentation(frame, detections, cfg.min_score, cfg.output, runtime.labels)
+        overlay_end = time_ms()
+
+        video_start = time_ms()
+        push_annotated_video(runtime, annotated)
+        video_end = time_ms()
+
+        metadata_start = time_ms()
+        send_metadata(runtime, sample, detections)
+        metadata_end = time_ms()
+
+        processed += 1
+        maybe_save_frame(cfg, processed, annotated)
+        profile.add(
+            pull_end - pull_start,
+            decode_end - decode_start,
+            overlay_end - overlay_start,
+            video_end - video_start,
+            metadata_end - metadata_start,
+            len(detections),
+        )
+
+    profile.flush()
+    print(f"processed={processed} video_sender={cfg.insight_host}:{runtime.video_port}")
+    return processed
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_arg_parser().parse_args(argv)
     try:
+        args = parse_args(argv)
         cfg = load_app_config(args.config)
+        if args.validate_config_only:
+            print(f"Config validated: {args.config}")
+            return 0
+
+        load_runtime_dependencies()
+        if cfg.profile:
+            os.environ.setdefault("SIMA_GST_ELEMENT_TIMINGS", "1")
+            os.environ.setdefault("SIMA_GST_FLOW_DEBUG", "1")
+            os.environ.setdefault("SIMA_GST_BOUNDARY_PROBES", "1")
+        if cfg.output.save_dir:
+            Path(cfg.output.save_dir).mkdir(parents=True, exist_ok=True)
+
+        runtime = build_pipeline(cfg)
+        try:
+            return 0 if run_pipeline(runtime, cfg) > 0 else 3
+        finally:
+            runtime.video_run.close()
+            runtime.run.close()
     except Exception as exc:
-        print(f"Error: failed to load config {args.config}: {exc}", file=sys.stderr)
-        return 2
-    if args.validate_config_only:
-        print(f"Config validated: {args.config}")
-        return 0
-
-    load_runtime_dependencies()
-    model_path = cfg.model.path
-    if not model_path or not Path(model_path).is_file():
-        print("Failed to locate YOLO26 segmentation model package.", file=sys.stderr)
-        print("Set model.path to a YOLO26 segmentation package.", file=sys.stderr)
-        return 2
-    try:
-        labels = load_labels(Path(cfg.model.labels))
-    except Exception as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 2
-
-    rtsp_graph = None
-    rtsp_run = None
-    detector_graph = None
-    detector_run = None
-    video_graph = None
-    video_run = None
-    metadata_sender = None
-    try:
-        # Probe first so decode, inference, and VideoSender all agree on the
-        # same live frame dimensions.
-        frame_w, frame_h, fps = probe_rtsp(cfg.source.rtsp_url)
-        print(f"[init] probed RTSP decode dims {frame_w}x{frame_h}")
-
-        model, detector_graph, detector_run = build_detector_run(
-            model_path,
-            frame_w,
-            frame_h,
-            cfg.inference,
-        )
-        rtsp_graph, rtsp_run = build_rtsp_run(
-            cfg.source.rtsp_url,
-            frame_w,
-            frame_h,
-            fps,
-            cfg.source.latency_ms,
-            tcp=cfg.source.tcp,
-        )
-        video_graph, video_run = build_video_sender_run(cfg, frame_w, frame_h, fps)
-        metadata_sender = build_metadata_sender(cfg)
-
-        print(f"insight host={cfg.insight.host} video_port={cfg.insight.video_port} "
-              f"metadata_port={metadata_sender.metadata_port()} channel=0")
-
-        processed = 0
-        started = time.perf_counter()
-        profile_window = ProfileWindow(cfg.runtime.profile, cfg.runtime.profile_interval)
-        save_dir = Path(cfg.output.save_dir) if cfg.output.save_dir else None
-        if save_dir is not None:
-            save_dir.mkdir(parents=True, exist_ok=True)
-        # Contract: single-threaded frame order is pull -> infer -> publish video -> publish metadata.
-        while cfg.inference.frames <= 0 or processed < cfg.inference.frames:
-            t_pull0 = time.perf_counter()
-            tensors = rtsp_run.pull_tensors(timeout_ms=20000)
-            t_pull1 = time.perf_counter()
-            if not tensors:
-                print("RTSP pull timed out / stream closed", file=sys.stderr)
-                break
-
-            decoded_frame = tensors[0]
-            frame = tensor_bgr_from_decoded(decoded_frame)
-            infer_input = tensor_from_bgr_frame(frame)
-
-            t_inf0 = time.perf_counter()
-            result = detector_run.run([infer_input], timeout_ms=20000)
-            t_inf1 = time.perf_counter()
-
-            t_decode0 = time.perf_counter()
-            detections = segmentation_results_from_output(
-                result,
-                frame.shape[1],
-                frame.shape[0],
-                cfg.inference.max_detections,
-            )
-            t_decode1 = time.perf_counter()
-            annotated = overlay_segmentation(
-                frame,
-                detections,
-                cfg.inference.min_score,
-                cfg.output,
-                labels,
-            )
-            video_frame = tensor_from_rgb_frame(cv2.cvtColor(annotated, cv2.COLOR_BGR2RGB))
-
-            # Contract: publish video first, then publish matching metadata.
-            t_video0 = time.perf_counter()
-            video_ok = video_run.push([video_frame])
-            if not video_ok:
-                raise RuntimeError("Insight video push failed")
-            t_video1 = time.perf_counter()
-            fid = str(processed)
-            data_json = make_instance_segmentation_data_json(detections, labels)
-            metadata_sender.send_metadata(
-                "instance-segmentation",
-                data_json,
-                int(time.time() * 1000),
-                fid,
-            )
-            should_save = (
-                save_dir is not None
-                and cfg.output.save_every > 0
-                and (processed + 1) % cfg.output.save_every == 0
-            )
-            if should_save:
-                save_annotated_frame(
-                    annotated,
-                    save_dir / f"frame_{processed:06d}.jpg",
-                )
-
-            processed += 1
-            profile_window.add(
-                rtsp_pull_ms=(t_pull1 - t_pull0) * 1000.0,
-                infer_ms=(t_inf1 - t_inf0) * 1000.0,
-                decode_ms=(t_decode1 - t_decode0) * 1000.0,
-                video_push_ms=(t_video1 - t_video0) * 1000.0,
-                e2e_ms=(t_video1 - t_pull1) * 1000.0,
-                boxes=len(detections),
-                published_total=processed,
-            )
-
-        elapsed = max(time.perf_counter() - started, 1e-6)
-        profile_window.flush(processed)
-        print(f"processed={processed} fps={processed / elapsed:.2f} "
-              f"video_sender={cfg.insight.host}:{cfg.insight.video_port}")
-        return 0 if processed > 0 else 3
-    except Exception as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 2
-    finally:
-        # Contract: close output run, then close RTSP run.
-        try:
-            if video_run is not None:
-                video_run.close()
-        except Exception:
-            pass
-        try:
-            if detector_run is not None:
-                detector_run.close()
-        except Exception:
-            pass
-        try:
-            if rtsp_run is not None:
-                rtsp_run.close()
-        except Exception:
-            pass
-        try:
-            metadata_sender = None
-        except Exception:
-            pass
+        print(f"[ERR] {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #221.

Optimizes the single-stream YOLO26 instance segmentation RTSP + Insight path while keeping the existing CLI, config shape, e2e output contract, and C++/Python behavior aligned.

## What changed

- Reworked the C++ and Python pipelines to use the same connected graph topology:
  - `RtspDecodedInput`
  - `Branch(frame, model)`
  - YOLO26 segmentation `Model`
  - `Combine(frame, segments)` with frame-id based joining
  - app-side overlay, Insight video, Insight metadata, and optional saved JPG output
- Kept model preprocessing and decode owned by `Model`:
  - `preprocess.enable = On`
  - `input_format = NV12`
  - `preset = COCO_YOLO`
  - `decode_type = YoloV26Seg`
- Switched live run behavior to realtime streaming settings:
  - `RunPreset::Realtime`
  - `queue_depth = 3`
  - `KeepLatest`
  - `ZeroCopy`
- Simplified the C++ and Python runtime code by removing the old split pipeline, manual queues, and extra app-managed frame staging.
- Optimized Python mask overlay by replacing per-pixel NumPy boolean-index blending with OpenCV native operations:
  - threshold
  - weighted blend
  - masked copy
  - contour extraction

## Architecture

```text
RtspDecodedInput
  -> Branch(source: frame, model)
      -> frame_graph -> Output(frame)
      -> model_graph -> YOLO26 segmentation Model -> Output(segments)
  -> Combine(frame, segments) by frame id
  -> app postprocess
      -> overlay masks and boxes
      -> VideoSender annotated stream
      -> MetadataSender objects
      -> optional saved sampled frames for e2e
```

## Profiling

Before the Python overlay optimization, Python post-combine overlay was roughly `35-46 ms` per frame.

After the optimization, Python steady-state profile windows showed:

```text
avg_overlay_ms ~= 7-9 ms
output_fps     ~= 37-41 fps when not source-limited by the 30 FPS stream
```

For the C++ run, the steady-state pipeline is source-limited around the 30 FPS RTSP stream. The post-combine path is no longer dominated by model pull latency.

## Validation

Ran locally through the SDK/board flow:

- `cmake --build build-test/build-vscode-tests --target app__workspace_sima_neat_apps_examples_segmentation_single_stream_instance_segmenter_src_cpp_single_stream_instance_segmenter -j$(nproc)`
- `SIMANEAT_APPS_TEST_NO_PAUSE=1 bash tests/scripts/testing/run_vscode_test_task.sh --build-dir build-test/build-vscode-tests --skip-build --unit --cpp`
- `SIMANEAT_APPS_TEST_NO_PAUSE=1 bash tests/scripts/testing/run_vscode_test_task.sh --build-dir build-test/build-vscode-tests --skip-build --unit --python`
- Targeted C++ e2e: `single-stream-instance-segmenter.e2e`
- Targeted Python e2e: `examples/segmentation/single-stream-instance-segmenter/tests/python/test_e2e.py`
- `python3 -m pytest tests/scripts/test_scope_contract.py -q`
- `python3 -m py_compile examples/segmentation/single-stream-instance-segmenter/src/python/main.py`
- `git diff --check`

Also checked the generated sampled overlays under:

- `sandbox-test/cpp/single-stream-instance-segmenter/test_full_pipeline/out`
- `sandbox-test/python/single-stream-instance-segmenter/test_full_pipeline/out`

Early and late saved frames were visually inspected for mask/box alignment.
