### PR TITLE
Honor tags for snapped core dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -312,6 +312,18 @@ current_dependency_branch() {
   echo "develop"
 }
 
+current_dependency_tag() {
+  if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+    printf '%s\n' "${GITHUB_REF_NAME}"
+    return 0
+  fi
+  if command -v git >/dev/null 2>&1 && git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "${ROOT_DIR}" describe --tags --exact-match HEAD 2>/dev/null || true
+    return 0
+  fi
+  printf '\n'
+}
+
 protected_manifest_branch_context() {
   if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
     printf '%s\n' "${GITHUB_BASE_REF}"
@@ -594,7 +606,15 @@ validate_explicit_core_ref() {
 }
 
 resolve_empty_neat_core_branch() {
-  local branch
+  local branch tag
+  if [[ -z "${NEAT_APPS_DEPENDENCY_BRANCH:-}" ]]; then
+    tag="$(current_dependency_tag)"
+    if [[ -n "${tag}" ]]; then
+      printf '%s\n' "${tag}"
+      return 0
+    fi
+  fi
+
   branch="$(current_dependency_branch)"
 
   if [[ "${branch}" == "main" || "${branch}" == "develop" ]]; then
@@ -714,7 +734,7 @@ run_sima_cli_core_install() {
 }
 
 ensure_neat_core() {
-  local branch version install_mode sima_cli_bin vulcan_env
+  local branch exact_tag install_mode sima_cli_bin version vulcan_env
   mkdir -p "${DEPS_DIR}" "${NEAT_DEBS_DIR}"
   load_neat_core_target
   branch="${NEAT_CORE_TARGET_BRANCH}"
@@ -733,7 +753,13 @@ ensure_neat_core() {
 
   # Resolve "latest" to an exact tag before checking installed state.
   if [[ "${version}" == "latest" ]]; then
-    version="$(resolve_latest_version "${branch}")"
+    if ! version="$(resolve_latest_version "${branch}")"; then
+      exact_tag="$(current_dependency_tag)"
+      if [[ -n "${exact_tag}" && "${branch}" == "${exact_tag}" ]]; then
+        echo "ERROR: Failed to resolve exact tag-snap NEAT core artifact for tag '${branch}'." >&2
+      fi
+      exit 1
+    fi
   fi
 
   local expected_tag="${branch}/${version}"
@@ -830,7 +856,13 @@ if [[ "${INSTALL_CORE}" -eq 1 ]]; then
   NEAT_CORE_DISPLAY_BRANCH="${NEAT_CORE_TARGET_BRANCH}"
   NEAT_CORE_DISPLAY_VERSION="${NEAT_CORE_TARGET_VERSION}"
   if [[ "${NEAT_CORE_DISPLAY_VERSION}" == "latest" ]]; then
-    NEAT_CORE_DISPLAY_VERSION="$(resolve_latest_version "${NEAT_CORE_DISPLAY_BRANCH}")"
+    if ! NEAT_CORE_DISPLAY_VERSION="$(resolve_latest_version "${NEAT_CORE_DISPLAY_BRANCH}")"; then
+      exact_tag="$(current_dependency_tag)"
+      if [[ -n "${exact_tag}" && "${NEAT_CORE_DISPLAY_BRANCH}" == "${exact_tag}" ]]; then
+        echo "ERROR: Failed to resolve exact tag-snap NEAT core artifact for tag '${NEAT_CORE_DISPLAY_BRANCH}'." >&2
+      fi
+      exit 1
+    fi
   fi
 fi
 

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -161,6 +161,7 @@ def _run_build(
         "GITHUB_BASE_REF",
         "GITHUB_HEAD_REF",
         "GITHUB_REF_NAME",
+        "GITHUB_REF_TYPE",
         "NEAT_APPS_ARTIFACT_BRANCH_KEY",
         "NEAT_APPS_ARTIFACT_SHORT_SHA",
         "NEAT_APPS_DEPENDENCY_BRANCH",
@@ -202,6 +203,19 @@ def _run_build(
         stderr=subprocess.PIPE,
         check=False,
     )
+
+
+def _installer_env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "NEAT_INSTALLER_URL": "https://installer.test/install-neat.sh",
+        "NEAT_APPS_TEST_INSTALLER_URL": "https://installer.test/install-neat.sh",
+        "NEAT_APPS_TEST_INSTALLER_PWD": str(tmp_path / "installer-pwd.txt"),
+        "NEAT_APPS_TEST_INSTALLER_ARGS": str(tmp_path / "installer-args.txt"),
+    }
+
+
+def _installer_args(tmp_path: Path) -> str:
+    return (tmp_path / "installer-args.txt").read_text(encoding="utf-8").strip()
 
 
 def _curl_log(tmp_path: Path) -> list[str]:
@@ -246,12 +260,12 @@ def _write_fake_neat_json(tmp_path: Path, *, channel: str, tag: str, env: str) -
 def test_empty_manifest_resolves_from_dependency_branch_and_platform_version(tmp_path):
     proc = _run_build(
         tmp_path,
-        env={"NEAT_APPS_DEPENDENCY_BRANCH": "develop"},
+        args=["--only-install-neat-core"],
+        env={**_installer_env(tmp_path), "NEAT_APPS_DEPENDENCY_BRANCH": "develop"},
     )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "Platform version      : 2.0.0" in proc.stdout
-    assert "NEAT core target      : develop:devsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum develop devsha1"
     assert _curl_log(tmp_path).count("https://core.test/develop/latest.tag") == 1
 
 
@@ -259,22 +273,27 @@ def test_snap_manifest_resolves_from_dependency_branch(tmp_path):
     proc = _run_build(
         tmp_path,
         neat_core={"policy": "snap"},
-        env={"NEAT_APPS_DEPENDENCY_BRANCH": "develop"},
+        args=["--only-install-neat-core"],
+        env={**_installer_env(tmp_path), "NEAT_APPS_DEPENDENCY_BRANCH": "develop"},
     )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "NEAT core target      : develop:devsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum develop devsha1"
     assert _curl_log(tmp_path).count("https://core.test/develop/latest.tag") == 1
 
 
 def test_empty_manifest_custom_branch_uses_matching_core_artifact_once(tmp_path):
     proc = _run_build(
         tmp_path,
-        env={"NEAT_APPS_DEPENDENCY_BRANCH": "zz-core-artifact-for-test"},
+        args=["--only-install-neat-core"],
+        env={
+            **_installer_env(tmp_path),
+            "NEAT_APPS_DEPENDENCY_BRANCH": "zz-core-artifact-for-test",
+        },
     )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "NEAT core target      : zz-core-artifact-for-test:featsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum zz-core-artifact-for-test featsha1"
     assert (
         _curl_log(tmp_path).count(
             "https://core.test/zz-core-artifact-for-test/latest.tag"
@@ -286,11 +305,15 @@ def test_empty_manifest_custom_branch_uses_matching_core_artifact_once(tmp_path)
 def test_empty_manifest_custom_branch_falls_back_to_develop(tmp_path):
     proc = _run_build(
         tmp_path,
-        env={"NEAT_APPS_DEPENDENCY_BRANCH": "zz-missing-core-artifact-for-test"},
+        args=["--only-install-neat-core"],
+        env={
+            **_installer_env(tmp_path),
+            "NEAT_APPS_DEPENDENCY_BRANCH": "zz-missing-core-artifact-for-test",
+        },
     )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "NEAT core target      : develop:devsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum develop devsha1"
     assert "using develop-latest" in proc.stderr
 
 
@@ -298,19 +321,28 @@ def test_snap_manifest_custom_branch_falls_back_to_develop(tmp_path):
     proc = _run_build(
         tmp_path,
         neat_core={"policy": "snap"},
-        env={"NEAT_APPS_DEPENDENCY_BRANCH": "zz-missing-core-artifact-for-test"},
+        args=["--only-install-neat-core"],
+        env={
+            **_installer_env(tmp_path),
+            "NEAT_APPS_DEPENDENCY_BRANCH": "zz-missing-core-artifact-for-test",
+        },
     )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "NEAT core target      : develop:devsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum develop devsha1"
     assert "using develop-latest" in proc.stderr
 
 
 def test_explicit_manifest_uses_valid_branch_version(tmp_path):
-    proc = _run_build(tmp_path, neat_core="zz-core-artifact-for-test-pinnedsha1")
+    proc = _run_build(
+        tmp_path,
+        neat_core="zz-core-artifact-for-test-pinnedsha1",
+        args=["--only-install-neat-core"],
+        env=_installer_env(tmp_path),
+    )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "NEAT core target      : zz-core-artifact-for-test:pinnedsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum zz-core-artifact-for-test pinnedsha1"
     assert (
         "https://core.test/zz-core-artifact-for-test/pinnedsha1/metadata.json"
         in _curl_log(tmp_path)
@@ -322,10 +354,12 @@ def test_dependency_object_manifest_uses_valid_artifact(tmp_path, ref_key):
     proc = _run_build(
         tmp_path,
         neat_core={ref_key: "zz-core-artifact-for-test", "spec": "pinnedsha1"},
+        args=["--only-install-neat-core"],
+        env=_installer_env(tmp_path),
     )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "NEAT core target      : zz-core-artifact-for-test:pinnedsha1" in proc.stdout
+    assert _installer_args(tmp_path) == "--minimum zz-core-artifact-for-test pinnedsha1"
     assert (
         "https://core.test/zz-core-artifact-for-test/pinnedsha1/metadata.json"
         in _curl_log(tmp_path)
@@ -333,7 +367,11 @@ def test_dependency_object_manifest_uses_valid_artifact(tmp_path, ref_key):
 
 
 def test_explicit_manifest_fails_when_artifact_is_invalid(tmp_path):
-    proc = _run_build(tmp_path, neat_core="zz-missing-core-artifact-for-test-pinnedsha1")
+    proc = _run_build(
+        tmp_path,
+        neat_core="zz-missing-core-artifact-for-test-pinnedsha1",
+        args=["--only-install-neat-core"],
+    )
 
     assert proc.returncode != 0
     assert "unavailable NEAT core artifact" in proc.stderr
@@ -343,6 +381,7 @@ def test_protected_branch_rejects_explicit_manifest_value(tmp_path):
     proc = _run_build(
         tmp_path,
         neat_core="main-mainsha1",
+        args=["--only-install-neat-core"],
         env={"GITHUB_REF_NAME": "main"},
     )
 
@@ -354,6 +393,7 @@ def test_protected_branch_rejects_explicit_dependency_object_manifest(tmp_path):
     proc = _run_build(
         tmp_path,
         neat_core={"branch": "main", "spec": "mainsha1"},
+        args=["--only-install-neat-core"],
         env={"GITHUB_REF_NAME": "main"},
     )
 
@@ -362,10 +402,51 @@ def test_protected_branch_rejects_explicit_dependency_object_manifest(tmp_path):
 
 
 def test_unsupported_manifest_object_fails(tmp_path):
-    proc = _run_build(tmp_path, neat_core={"policy": "latest"})
+    proc = _run_build(
+        tmp_path,
+        neat_core={"policy": "latest"},
+        args=["--only-install-neat-core"],
+    )
 
     assert proc.returncode != 0
     assert "unsupported neat-core.policy" in proc.stderr
+
+
+def test_snap_manifest_tag_build_uses_matching_core_tag(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env={
+            **_installer_env(tmp_path),
+            "GITHUB_REF_TYPE": "tag",
+            "GITHUB_REF_NAME": "v2.1.0",
+            "NEAT_APPS_TEST_LATEST_TAGS": "\n".join(
+                [
+                    "develop=devsha1",
+                    "v2.1.0=tagsha1",
+                ]
+            ),
+        },
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == "--minimum v2.1.0 tagsha1"
+    assert "https://core.test/v2.1.0/latest.tag" in _curl_log(tmp_path)
+
+
+def test_snap_manifest_tag_build_fails_without_matching_core_tag(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env={
+            "GITHUB_REF_TYPE": "tag",
+            "GITHUB_REF_NAME": "v9.9.9",
+        },
+    )
+
+    assert proc.returncode != 0
+    assert "exact tag-snap NEAT core artifact" in proc.stderr
+    assert "using develop-latest" not in proc.stderr
 
 
 def test_core_installer_runs_from_deps_debs_scratch_dir(tmp_path):


### PR DESCRIPTION
## Context

Apps resolves a snapped NEAT core dependency from the current dependency branch. For branch builds, falling back to `develop` is useful because feature branches do not always publish matching core artifacts. That fallback is not appropriate for release tags.

A tag represents a release boundary. When apps is built from a tag, it must use the matching NEAT core tag artifact. If that artifact is missing, the release input is incomplete and the build should fail instead of silently installing a `develop` core package.

## Summary

- Detect exact tag builds from GitHub Actions tag refs and local exact-tag checkouts.
- Resolve snapped NEAT core dependencies from the current tag for tagged apps builds.
- Preserve existing branch-based snap behavior for non-tag branch builds.
- Keep the `develop` fallback only for non-tag branch snap resolution.
- Fail hard when the exact tag-snap NEAT core artifact is missing.
- Update manifest contract tests to cover install-time dependency resolution and exact tag behavior.

## Expected behavior

- Apps branch build on `feature/foo`: try `feature-foo-latest`, then fall back to `develop-latest` if needed.
- Apps tag build on `v2.1.0`: require the NEAT core artifact for `v2.1.0`.
- If the tagged NEAT core artifact is missing, stop the build with an explicit error.

## Validation

- `bash -n build.sh`
- `git diff --check`
- `python3 -m pytest -q tests/scripts/test_manifest_contract.py`
