### PR TITLE
Fix e2e runtime regressions

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/multi-stream-object-detector/src/common/config.yaml
@@ -18,7 +18,7 @@ runtime:                     # Runtime and profiling settings.
 inference:                   # Detection controls.
   frames: 0                  # Frame limit per stream. 0 means unlimited.
   fps: 0                     # Max per-stream processing and output FPS. 0 means use source FPS.
-  min_score: 0.55            # Detection score threshold.
+  min_score: 0.30            # Detection score threshold.
   nms_iou: 0.60              # NMS IoU threshold.
   max_detections: 50         # Max detections to keep per frame after NMS.
 

--- a/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
@@ -50,7 +50,8 @@ int main(int argc, char** argv) {
                     {"output.debug_dir", output_dir},
                     {"output.insight.host", insight_host},
                     {"output.insight.video_port_base", std::to_string(video_port_base)},
-                    {"output.insight.metadata_port_base", std::to_string(metadata_port_base)}},
+                    {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
+                    {"inference.frames", "140"}},
                    {{"streams", {rtsp_urls[0], rtsp_urls[1]}}});
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
@@ -67,8 +68,8 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
-                                                        output_dir, total_saved_frames, timeout_ms);
+  const ProcessResult result =
+      spawn_and_wait(binary, {"--config", config_path.string()}, timeout_ms);
 
   int rc = 0;
   if (result.exit_code != 0) {

--- a/examples/object-detection/single-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/single-stream-object-detector/src/common/config.yaml
@@ -9,7 +9,7 @@ source:
 
 inference:
   frames: 0                  # Frame limit. 0 means run continuously.
-  min_score: 0.55            # Detection score threshold.
+  min_score: 0.30            # Detection score threshold.
   nms_iou: 0.60              # NMS IoU threshold.
   max_detections: 50         # Max detections to keep per frame.
 

--- a/examples/object-detection/yolo26-object-detector/src/common/config.yaml
+++ b/examples/object-detection/yolo26-object-detector/src/common/config.yaml
@@ -7,7 +7,7 @@ io:
   output_dir: sandbox/yolo26-object-detector
 
 decode:
-  score_threshold: 0.55
+  score_threshold: 0.40
   nms_iou: 0.60
   max_detections: 50
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -476,7 +476,7 @@ def build_metadata_sender(cfg: AppConfig):
 def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
     input_opt = pyneat.InputOptions()
     input_opt.payload_type = pyneat.PayloadType.Image
-    input_opt.format = "RGB"
+    input_opt.format = pyneat.Format.RGB
     input_opt.width = width
     input_opt.height = height
     input_opt.depth = 3


### PR DESCRIPTION
## Summary
- Fix Python segmentation VideoSender input format to use the typed pyneat format enum.
- Keep multi-stream detector C++ e2e alive for a fixed frame count so all streams can send metadata before validation.
- Carry object-detection config threshold updates already on the branch.

## Validation
- Verified on board with the targeted `multi-stream-object-detector.e2e` ctest command.