### PR TITLE
Use platform version for model downloads

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -187,6 +187,8 @@ PY
 
   cp -a "${ROOT_DIR}/tests" "${stage_dir}/tests"
   rm -f "${stage_dir}/tests/.env.local"
+  mkdir -p "${stage_dir}/deps"
+  cp "${APPS_MANIFEST}" "${stage_dir}/deps/manifest.json"
   mkdir -p "${stage_dir}/scripts"
   cp "${ROOT_DIR}/scripts/download_models.sh" "${stage_dir}/scripts/download_models.sh"
   cp "${ROOT_DIR}/tests/conftest.py" "${stage_dir}/examples/conftest.py"

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -22,16 +22,18 @@ Optional. If you have a demo screenshot for the portal detail page, place it her
 ```
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Also works with: `<model_variant_1>`, `<model_variant_2>`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get <model_variant_1> && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get <model_variant_1> && cd ../..`
 
 ## Prerequisites
 - Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get <default_model_name> && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get <default_model_name> && cd ../..`
 
 ## Important Behavior
 - This example expects the model path to be provided explicitly at runtime.

--- a/examples/benchmarking/model-benchmark/tests/test-scope.yaml
+++ b/examples/benchmarking/model-benchmark/tests/test-scope.yaml
@@ -9,11 +9,11 @@ models:
     file: depth_anything_v2_vits_mpk.tar.gz
   retinaface_mobilenet25:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
     file: retinaface_mobilenet25_mod_0_mpk.tar.gz
   detr_resnet50_modified_class_embed_bbox_embed:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
     file: detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
   yolo_v8n_seg:
     source: modelzoo
@@ -21,63 +21,63 @@ models:
     file: yolo_v8n_seg_mpk.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
   yolo26n-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
     file: yolo26n-seg-bf16-mla_tess.tar.gz
   yolo26s-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
     file: yolo26s-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
     file: yolo26m-seg-bf16-mla_tess.tar.gz
   yolo26l-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
     file: yolo26l-seg-bf16-mla_tess.tar.gz
   yolo26x-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
     file: yolo26x-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
     file: yolo26m-seg-bf16-b1.tar.gz
   yolo26m-seg-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
     file: yolo26m-seg-bf16-mla_tess-b1.tar.gz
   yolo26m-seg-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
     file: yolo26m-seg-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -19,15 +19,17 @@ The pipeline is trying to classify this goldfish image.
 ![Image classifier goldfish input](../../../assets/portal/classification/image-classifier/image.jpeg)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Primary model: `resnet_50`
 
 Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get resnet_50 && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get resnet_50 && cd ../..`
 
 ## Prerequisites
 - Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get resnet_50 && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get resnet_50 && cd ../..`
 
 ## Important Behavior
 - Runtime settings live in `src/common/config.yaml`.

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -19,15 +19,17 @@ Snippet from a pipeline run:
 ![Depth estimator preview](../../../assets/portal/depth-estimation/depth-estimator/image.png)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Primary model: `depth_anything_v2_vits`
 
 Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits && cd ../..`
 
 ## Prerequisites
 - Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get depth_anything_v2_vits && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits && cd ../..`
 
 ## Important Behavior
 - Runtime settings are read from `src/common/config.yaml` by default.

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -9,7 +9,7 @@
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | face-detector |
-| Model | retinaface_mobilenet25 [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz] |
+| Model | retinaface_mobilenet25 |
 
 ## Concept
 This example demonstrates folder-based face detection with **RetinaFace**, a one-stage dense detector designed for robust face localization across pose, scale, and occlusion conditions.
@@ -29,6 +29,8 @@ Snippet from a pipeline run:
 ![Face detector preview](../../../assets/portal/face-detection/face-detector/image.png)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Validated with: `retinaface_mobilenet25`
 
 Download into `assets/models/`:
@@ -39,7 +41,7 @@ Download into `assets/models/`:
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - Preferred download command: `./scripts/download_models.sh retinaface_mobilenet25`
 - Direct URL fallback:
-  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz && cd ../..`
+  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz && cd ../..`
 
 ## Important Behavior
 - C++ and Python read runtime values from `src/common/config.yaml`.

--- a/examples/face-detection/face-detector/tests/test-scope.yaml
+++ b/examples/face-detection/face-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   retinaface_mobilenet25:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
     file: retinaface_mobilenet25_mod_0_mpk.tar.gz
 unit:
   python: true

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -27,6 +27,8 @@ Detection metadata visualized in Insight:
 - OpenAI-compatible Gemma server running when `openai.enabled` is true.
 
 ## Download Models
+Use the platform version wherever `<platform-version>` appears.
+
 Supported batch-1 YOLO26 detector models:
 - `yolo26n-det-bf16-mla_tess-b1.tar.gz`
 - `yolo26s-det-bf16-mla_tess-b1.tar.gz`
@@ -42,7 +44,7 @@ Download the default detector model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/genai/detection-to-vlm-assistant/tests/test-scope.yaml
+++ b/examples/genai/detection-to-vlm-assistant/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   gemma4-openai-server:
     source: huggingface

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -9,7 +9,7 @@
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | detr-object-detector |
-| Model | detr_resnet50_modified_class_embed_bbox_embed [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz] |
+| Model | detr_resnet50_modified_class_embed_bbox_embed |
 
 ## Concept
 This example demonstrates folder-based object detection with a compiled **DETR** model. Each input image is resized with aspect-ratio preservation into the model frame, normalized with ImageNet mean and standard deviation, run through the NEAT pipeline, and then decoded into object boxes and class scores.
@@ -22,6 +22,8 @@ Snippet from a pipeline run:
 ![DETR object detector preview](../../../assets/portal/object-detection/detr-object-detector/image.png)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Validated with: `detr_resnet50_modified_class_embed_bbox_embed`
 
 Download into `assets/models/`:
@@ -32,7 +34,7 @@ Download into `assets/models/`:
 - Model artifacts are user-managed and should be placed under `assets/models/`.
 - Preferred download command: `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
 - Direct URL fallback:
-  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz && cd ../..`
+  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz && cd ../..`
 - Default model path:
   `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz`
 

--- a/examples/object-detection/detr-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/detr-object-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   detr_resnet50_modified_class_embed_bbox_embed:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
     file: detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
 unit:
   python: true

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -45,6 +45,8 @@ Per-stream graph:
 - `--help`: print the CLI help text
 
 ## Download Models
+Use the platform version wherever `<platform-version>` appears.
+
 The default model is `yolo26m-det-int8-b1.tar.gz`.
 
 Supported batch-1 YOLO26 detection models:
@@ -62,13 +64,13 @@ Download all supported batch-1 variants:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/object-detection/multi-stream-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/multi-stream-object-detector/tests/test-scope.yaml
@@ -1,31 +1,31 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -73,6 +73,8 @@ This separation keeps the RTSP graph from being tightly coupled to the inference
 - Model artifacts are user-managed. Download the model variant you want to run into `assets/models/`.
 
 ## Download Models
+Use the platform version wherever `<platform-version>` appears.
+
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
 Supported batch-1 YOLO26 detection models:
@@ -90,13 +92,13 @@ Download all supported batch-1 variants:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```
@@ -228,7 +230,7 @@ Download the default YOLO26 detector model if it is not already available:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 cd ../..
 ```
 

--- a/examples/object-detection/single-stream-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/single-stream-object-detector/tests/test-scope.yaml
@@ -1,31 +1,31 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -9,7 +9,7 @@
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | yolo26-object-detector |
-| Model | yolo26m-det-bf16-mla_tess-b1 [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz] |
+| Model | yolo26m-det-bf16-mla_tess-b1 |
 
 ## Concept
 Minimal image-folder object detection pipeline using yolo26m. Each image is inferred, annotated with bounding boxes and labels, and written to an output folder. The pipeline demonstrates the NEAT API for model loading, inference, and result decoding.
@@ -20,6 +20,8 @@ Snippet from a pipeline run:
 ![YOLO26 object detector preview](../../../assets/portal/object-detection/yolo26-object-detector/image.png)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Supported model:
 - `yolo26m-det-bf16-mla_tess-b1.tar.gz`
 
@@ -29,7 +31,7 @@ Download the supported model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/object-detection/yolo26-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/yolo26-object-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
 unit:
   python: true

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -9,7 +9,7 @@
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | single-stream-instance-segmenter |
-| Model | yolo26m-seg-bf16-b1 [https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz] |
+| Model | yolo26m-seg-bf16-b1 |
 
 ## Concept
 `single-stream-instance-segmenter` is a single-camera YOLO26 instance segmentation example:
@@ -29,6 +29,8 @@ Snippet from a pipeline run:
 ![Single stream instance segmenter preview](../../../assets/portal/segmentation/single-stream-instance-segmenter/image.png)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Supported YOLO26 segmentation models:
 
 - `yolo26n-seg-bf16-mla_tess.tar.gz`
@@ -43,18 +45,18 @@ Supported YOLO26 segmentation models:
 Download the supported variants:
 
 ```bash
-SDK_VERSION=${NEAT_APPS_MODEL_SDK_VERSION:-2.0.0}
+PLATFORM_VERSION=<platform-version>
 mkdir -p assets/models/YOLO26-SEGMENTATION
 cd assets/models/YOLO26-SEGMENTATION
 
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${SDK_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz"
 
 cd ../../..
 ```

--- a/examples/segmentation/single-stream-instance-segmenter/tests/test-scope.yaml
+++ b/examples/segmentation/single-stream-instance-segmenter/tests/test-scope.yaml
@@ -1,35 +1,35 @@
 models:
   yolo26n-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
     file: yolo26n-seg-bf16-mla_tess.tar.gz
   yolo26s-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
     file: yolo26s-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
     file: yolo26m-seg-bf16-mla_tess.tar.gz
   yolo26l-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
     file: yolo26l-seg-bf16-mla_tess.tar.gz
   yolo26x-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
     file: yolo26x-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
     file: yolo26m-seg-bf16-b1.tar.gz
   yolo26m-seg-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
     file: yolo26m-seg-bf16-mla_tess-b1.tar.gz
   yolo26m-seg-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{sdk_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
     file: yolo26m-seg-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -19,15 +19,17 @@ Snippet from a pipeline run:
 ![Instance segmenter preview](../../../assets/portal/segmentation/yolov8-instance-segmenter/image.jpg)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Also works with: `yolo_v8s_seg`, `yolo_v8m_seg`, `yolo_v8l_seg`
 
 Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n_seg && cd ../..`
+- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get yolo_v8n_seg && cd ../..`
 
 ## Prerequisites
 - Installed Neat SDK.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v 2.0.0 get yolo_v8n_seg && cd ../..`
+- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get yolo_v8n_seg && cd ../..`
 
 ## Important Behavior
 - Model path is positional and required.

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -32,6 +32,8 @@ Preview image from a live run:
 ![Multi-stream people tracker preview](../../../assets/portal/tracking/multi-stream-people-tracker/image.png)
 
 ## Supported Models
+Use the platform version wherever `<platform-version>` appears.
+
 Default model: `yolo26m-det-int8-b1.tar.gz`.
 
 Supported batch-1 YOLO26 detection models:
@@ -49,13 +51,13 @@ Download all supported batch-1 variants:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/tracking/multi-stream-people-tracker/tests/test-scope.yaml
+++ b/examples/tracking/multi-stream-people-tracker/tests/test-scope.yaml
@@ -1,31 +1,31 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK2.0.0/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
 unit:
   python: true

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -25,18 +25,37 @@ SCOPE_PYTHON="${TEST_SCOPE_PYTHON_BIN:-${PYTHON_TEST_BIN:-python3}}"
 VERSION_PYTHON="${PYTHON_TEST_BIN:-python3}"
 export SIMA_CLI_CHECK_FOR_UPDATE="${SIMA_CLI_CHECK_FOR_UPDATE:-0}"
 
-detect_model_sdk_version() {
-    "$VERSION_PYTHON" - "$ROOT/deps/manifest.json" <<'PY' 2>/dev/null || printf '2.0.0\n'
+detect_platform_version() {
+    "$VERSION_PYTHON" - "$ROOT/deps/manifest.json" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(manifest.get("platform-version") or "2.0.0")
+path = Path(sys.argv[1])
+try:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+except FileNotFoundError:
+    print(
+        f"ERROR: Missing manifest: {path}. Set NEAT_APPS_PLATFORM_VERSION to override.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+platform_version = manifest.get("platform-version")
+if not isinstance(platform_version, str) or not platform_version.strip():
+    print(f"ERROR: {path} must define platform-version as a non-empty string.", file=sys.stderr)
+    raise SystemExit(1)
+print(platform_version.strip())
 PY
 }
 
-MODEL_SDK_VERSION="${NEAT_APPS_MODEL_SDK_VERSION:-$(detect_model_sdk_version)}"
+PLATFORM_VERSION="${NEAT_APPS_PLATFORM_VERSION:-}"
+
+ensure_platform_version() {
+    if [[ -z "$PLATFORM_VERSION" ]]; then
+        PLATFORM_VERSION="$(detect_platform_version)"
+    fi
+}
 
 usage() {
     cat <<'EOF'
@@ -48,7 +67,7 @@ Options:
   --scope-file <path>   Test scope source file or directory (default: examples)
   --kind <kind>         Scope kind to resolve (default: e2e)
   --language <lang>     Scope language to include; repeatable (python, cpp)
-  NEAT_APPS_MODEL_SDK_VERSION can override {sdk_version} URL placeholders.
+  NEAT_APPS_PLATFORM_VERSION can override the platform version.
   -h, --help            Show help
 EOF
 }
@@ -177,11 +196,12 @@ download_modelzoo_model() {
         return 0
     fi
     ensure_sima_cli_bin
+    ensure_platform_version
 
     local before
     before=$(find "$MODELS_DIR" -maxdepth 1 -type f -name '*.tar.gz' | wc -l)
-    echo "[download] $model_id (modelzoo: $model_name)"
-    (cd "$MODELS_DIR" && "$SIMA_CLI_BIN" modelzoo -v 2.0.0 get "$model_name")
+    echo "[download] $model_id (modelzoo: $model_name, platform-version: $PLATFORM_VERSION)"
+    (cd "$MODELS_DIR" && "$SIMA_CLI_BIN" modelzoo -v "$PLATFORM_VERSION" get "$model_name")
 
     local after
     after=$(find "$MODELS_DIR" -maxdepth 1 -type f -name '*.tar.gz' | wc -l)
@@ -200,7 +220,10 @@ download_url_model() {
     local expected_file="$3"
     local tmpdir
     local downloaded_files=()
-    url="${url//\{sdk_version\}/$MODEL_SDK_VERSION}"
+    if [[ "$url" == *"{platform_version}"* ]]; then
+        ensure_platform_version
+        url="${url//\{platform_version\}/$PLATFORM_VERSION}"
+    fi
 
     if model_exists "$model_id" "$expected_file"; then
         echo "[skip] $model_id already exists"

--- a/support/runtime/asset_utils.cpp
+++ b/support/runtime/asset_utils.cpp
@@ -8,6 +8,19 @@ namespace sima_examples {
 
 namespace fs = std::filesystem;
 
+namespace {
+
+bool download_modelzoo_model(const fs::path& root, const std::string& model_name) {
+  const fs::path script = root / "scripts" / "download_models.sh";
+  if (!fs::exists(script))
+    return false;
+  const std::string cmd = "cd " + shell_quote(root.string()) +
+                          " && bash scripts/download_models.sh " + shell_quote(model_name);
+  return std::system(cmd.c_str()) == 0;
+}
+
+} // namespace
+
 std::string shell_quote(const std::string& s) {
   std::string out = "'";
   for (char c : s) {
@@ -118,8 +131,7 @@ std::string resolve_resnet50_tar(const fs::path& root_in) {
   if (fs::exists(local))
     return local.string();
 
-  const int rc = std::system("sima-cli modelzoo -v 2.0.0 get resnet_50");
-  if (rc != 0)
+  if (!download_modelzoo_model(root, "resnet_50"))
     return "";
 
   if (fs::exists(local))
@@ -234,8 +246,7 @@ std::string resolve_modelzoo_tar(const std::string& model_name, const fs::path& 
     }
   }
 
-  const std::string cmd = "sima-cli modelzoo -v 2.0.0 get " + shell_quote(model_name);
-  if (std::system(cmd.c_str()) != 0)
+  if (!download_modelzoo_model(root, model_name))
     return "";
 
   if (fs::exists(local))

--- a/tests/scripts/test_modelzoo_version_pin.py
+++ b/tests/scripts/test_modelzoo_version_pin.py
@@ -15,6 +15,7 @@ def _files_requiring_pinned_modelzoo_calls() -> list[Path]:
         APPS_ROOT / "examples" / "TEMPLATE_README.md",
     ]
     files.extend(sorted((APPS_ROOT / "examples").glob("*/*/README.md")))
+    files.extend(sorted((APPS_ROOT / "examples").glob("*/*/tests/test-scope.yaml")))
     files.append(
         APPS_ROOT
         / "examples"
@@ -27,12 +28,21 @@ def _files_requiring_pinned_modelzoo_calls() -> list[Path]:
     return files
 
 
-def test_apps_surfaces_do_not_use_unpinned_modelzoo_get():
+def test_apps_surfaces_do_not_hardcode_model_platform_version():
     offenders: list[str] = []
+    blocked = [
+        "modelzoo get",
+        "modelzoo -v 2.0.0",
+        "SDK2.0.0",
+        "{sdk_version}",
+        "NEAT_APPS_MODEL_SDK_VERSION",
+        "MODEL_SDK_VERSION",
+    ]
 
     for path in _files_requiring_pinned_modelzoo_calls():
         text = path.read_text(encoding="utf-8")
-        if "modelzoo get" in text:
-            offenders.append(str(path.relative_to(APPS_ROOT)))
+        matches = [pattern for pattern in blocked if pattern in text]
+        if matches:
+            offenders.append(f"{path.relative_to(APPS_ROOT)}: {', '.join(matches)}")
 
     assert offenders == []

--- a/tests/scripts/test_scope_contract.py
+++ b/tests/scripts/test_scope_contract.py
@@ -235,14 +235,14 @@ def test_download_models_preserves_empty_url_model_name(tmp_path):
     assert "[skip] url-demo already exists" in result.stdout
 
 
-def test_download_models_expands_sdk_version_placeholder(tmp_path):
+def test_download_models_expands_platform_version_placeholder(tmp_path):
     if subprocess.run(["bash", "-lc", "type mapfile"], capture_output=True).returncode != 0:
         pytest.skip("download_models.sh requires bash with mapfile support")
 
     fake_scope_python = tmp_path / "fake_scope_python"
     fake_scope_python.write_text(
         "#!/usr/bin/env bash\n"
-        "printf 'url-demo\\turl\\t\\thttps://example.test/SDK{sdk_version}/demo-file.tar.gz\\tdemo-file.tar.gz\\t\\t\\n'\n",
+        "printf 'url-demo\\turl\\t\\thttps://example.test/SDK{platform_version}/demo-file.tar.gz\\tdemo-file.tar.gz\\t\\t\\n'\n",
         encoding="utf-8",
     )
     fake_scope_python.chmod(0o755)
@@ -270,7 +270,7 @@ def test_download_models_expands_sdk_version_placeholder(tmp_path):
             "MODELS_DIR": str(tmp_path / "models"),
             "TEST_SCOPE_PYTHON_BIN": str(fake_scope_python),
             "SIMA_CLI_BIN": str(fake_sima_cli),
-            "NEAT_APPS_MODEL_SDK_VERSION": "2.1.1",
+            "NEAT_APPS_PLATFORM_VERSION": "2.1.1",
             "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(sima_cli_args),
         },
         capture_output=True,
@@ -280,4 +280,49 @@ def test_download_models_expands_sdk_version_placeholder(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "https://example.test/SDK2.1.1/demo-file.tar.gz" in sima_cli_args.read_text(
         encoding="utf-8"
+    )
+
+
+def test_download_models_uses_manifest_platform_version_for_modelzoo(tmp_path):
+    if subprocess.run(["bash", "-lc", "type mapfile"], capture_output=True).returncode != 0:
+        pytest.skip("download_models.sh requires bash with mapfile support")
+
+    root = tmp_path / "apps"
+    script = root / "scripts" / "download_models.sh"
+    manifest = root / "deps" / "manifest.json"
+    script.parent.mkdir(parents=True)
+    manifest.parent.mkdir(parents=True)
+    script.write_text(
+        (APPS_ROOT / "scripts" / "download_models.sh").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    manifest.write_text('{"platform-version": "2.1.1"}\n', encoding="utf-8")
+
+    sima_cli_args = tmp_path / "sima-cli-args.txt"
+    fake_sima_cli = tmp_path / "sima-cli"
+    fake_sima_cli.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$*\" > \"$NEAT_APPS_TEST_SIMA_CLI_ARGS\"\n",
+        encoding="utf-8",
+    )
+    fake_sima_cli.chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(script), "resnet_50"],
+        cwd=root,
+        env={
+            **os.environ,
+            "MODELS_DIR": str(tmp_path / "models"),
+            "PYTHON_TEST_BIN": sys.executable,
+            "SIMA_CLI_BIN": str(fake_sima_cli),
+            "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(sima_cli_args),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert sima_cli_args.read_text(encoding="utf-8").strip() == (
+        "modelzoo -v 2.1.1 get resnet_50"
     )


### PR DESCRIPTION
## Summary
- Resolve model downloads from the platform version instead of hardcoded SDK 2.0.0 paths.
- Update example README commands to use `<platform-version>`.
- Package the version metadata needed by runtime downloads.

## Validation
- `cmake --build build` in the SDK container
- `./tests/test.sh --unit` in the SDK container
- README, test-scope, catalog, shell syntax, and targeted pytest checks
- Vulcan CI: passed
- Strict local E2E attempted; blocked by local SDK/runtime mismatch outside this patch (`neatboxdecode` factory and pyneat API/runtime failures).

Refs #200