### PR TITLE
Honor tags for apps release versioning

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -143,6 +143,8 @@ jobs:
 
         docker exec \
           -e SIMA_CLI_CHECK_FOR_UPDATE=0 \
+          -e GITHUB_REF_NAME="${GITHUB_REF_NAME}" \
+          -e GITHUB_REF_TYPE="${GITHUB_REF_TYPE}" \
           -e GITHUB_SHA="${GITHUB_SHA}" \
           "${sdk_container}" \
           bash -lc '
@@ -156,10 +158,15 @@ jobs:
               export PATH="${HOME}/.sima-cli/.venv/bin:${PATH}"
             fi
             cd /workspace
-            short_sha="$(printf "%.12s" "${GITHUB_SHA}")"
+            if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+              version="${GITHUB_REF_NAME}"
+              version="${version#v}"
+            else
+              version="$(printf "%.12s" "${GITHUB_SHA}")"
+            fi
             sima-cli packages build dist \
               --name gh:sima-neat/apps \
-              --version "${short_sha}" \
+              --version "${version}" \
               --description "SiMa.ai Neat example applications and portal runtime" \
               --install-script install_vulcan_apps_package.sh
           '
@@ -240,8 +247,13 @@ jobs:
           fi
 
           REF_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          SHORT_SHA="$(printf "%.12s" "${GITHUB_SHA}")"
-          PACKAGE_SPEC="apps@${REF_NAME}:${SHORT_SHA}"
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION="$(printf "%.12s" "${GITHUB_SHA}")"
+          fi
+          PACKAGE_SPEC="apps@${REF_NAME}:${VERSION}"
 
           mkdir -p _vulcan-test/install
           echo "Installing ${PACKAGE_SPEC} from Vulcan env ${VULCAN_ENV}"

--- a/build.sh
+++ b/build.sh
@@ -99,10 +99,29 @@ git_branch_key() {
   sanitize_branch_key "${raw}"
 }
 
+tag_version() {
+  local tag
+  tag="$(current_dependency_tag)"
+  if [[ -z "${tag}" ]]; then
+    return 1
+  fi
+  if [[ "${tag}" =~ ^v[0-9] ]]; then
+    tag="${tag#v}"
+  fi
+  printf '%s\n' "${tag}"
+}
+
+artifact_version() {
+  if tag_version; then
+    return 0
+  fi
+  git_short_sha
+}
+
 package_distribution() {
   local build_path="${ROOT_DIR}/${BUILD_DIR}"
   local stage_dir="${ROOT_DIR}/neat-apps-runtime"
-  local branch_key short_sha archive_name archive_path
+  local branch_key version archive_name archive_path
   local neat_core_branch neat_core_version
 
   if [[ ! -d "${build_path}" ]]; then
@@ -111,8 +130,8 @@ package_distribution() {
   fi
 
   branch_key="$(git_branch_key)"
-  short_sha="$(git_short_sha)"
-  archive_name="neat-apps-${branch_key}-${short_sha}.tar.gz"
+  version="$(artifact_version)"
+  archive_name="neat-apps-${branch_key}-${version}.tar.gz"
   archive_path="${ROOT_DIR}/${archive_name}"
 
   rm -rf "${stage_dir}"


### PR DESCRIPTION
## Summary
- Use the exact checkout tag as the apps release version when building from a tag.
- Preserve the existing short-SHA versioning behavior for non-tag branch builds.
- Apply the same version rule to the packaged apps archive, Vulcan package metadata, and runtime test install spec.
- Normalize release tags by stripping a leading v, matching the core and LLiMa release version convention.

## Validation
- bash -n build.sh
- git diff --check

## Note
- actionlint currently reports pre-existing issues in vulcan-ci.yml for the custom modalix runner label and dynamic source paths; this change does not introduce those findings.