### PR TITLE
docs(skills): add Neat application builder

### DIFF
--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neat-application-builder
-description: Use when building Neat Library applications with public C++ or Python APIs, including choosing between Model, Graph, GenAIModel, and GenAIServer; using Run handles returned by built graphs; reading packaged core headers/docs; composing application pipelines; and validating Neat Development Environment or DevKit behavior. Do not use for repository maintenance, release automation, review workflows, performance-tuning recipes, or project-specific delivery work.
+description: Use when building Neat Library applications with public C++ or Python APIs, including choosing between Model, Graph, GenAIModel, and GenAIServer; using Run handles returned by built graphs; reading packaged core headers/docs; composing application pipelines; and validating Neat Development Environment or DevKit behavior. Do not use for repository maintenance, release automation, review workflows, or work outside the public Neat Library application surface.
 ---
 
 # Neat Application Builder
@@ -44,7 +44,7 @@ reference implementations after the API shape is chosen.
 
 - Do not describe this as a repository maintenance skill.
 - Do not add repository publication, release automation, review workflow, or contributor-process guidance.
-- Do not include performance-tuning methods, queue-tuning recipes, memory-placement recipes, project-specific delivery patterns, or issue-specific lessons.
+- Use only public Neat Library APIs, packaged source, installed headers, official docs, and public examples.
 - Do not guess API behavior from memory. Verify against current packaged core source or installed docs.
 
 ## References

--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: neat-application-builder
+description: Use when building Neat Library applications with public C++ or Python APIs, including choosing between Model, Graph, Run, GenAIModel, and GenAIServer; reading packaged core headers/docs; composing application pipelines; and validating Neat Development Environment or DevKit behavior. Do not use for repository maintenance, release automation, review workflows, performance-tuning recipes, or project-specific delivery work.
+---
+
+# Neat Application Builder
+
+## Overview
+
+Build applications against the installed Neat Library. Treat the current Neat
+Development Environment's packaged core source, installed headers, and local
+documentation as the source of truth. Use apps examples only as optional
+reference implementations after the API shape is chosen.
+
+Keep this skill generic. Do not encode project-specific pipeline lessons,
+performance recipes, or internal repository workflow.
+
+## Official Naming
+
+- Use `Neat Library` for the C++/Python API and runtime.
+- Use `Neat Development Environment` for the Docker-based development environment.
+- Use `Model Compiler` for quantization, compilation, and validation.
+- Keep `LLiMa` unchanged.
+- Keep command, repository, package, image, path, and artifact names verbatim.
+  Examples: `sima-cli sdk`, `ghcr:sima-neat/sdk`, `sdk`, `core`, and `/neat-resources/core-src`.
+
+## Workflow
+
+1. Establish the environment and source of truth.
+   - In the Neat Development Environment, read `/neat-resources/core-src` first.
+   - Prefer installed public headers under the Neat Development Environment sysroot when checking the user-facing contract.
+   - Read `references/source-of-truth.md`.
+2. Choose the application API shape before writing code.
+   - Read `references/api-decision-map.md`.
+3. If the request touches APIs outside the main Model/Graph/Run/GenAI path, read `references/api-surface-map.md` and inspect the referenced headers/docs.
+4. For classic compiled model applications, read `references/model-graph-run.md`.
+5. For LLM, VLM, ASR, or HTTP model serving applications, read `references/genai.md`.
+6. Before claiming success, read `references/validation.md` and run the validation that is possible in the current environment.
+
+## Defaults
+
+- C++ applications should start with `#include <neat.h>` unless a narrower public include is clearly better.
+- Python applications should use installed `pyneat` and `pyneat.genai`.
+- Use only public APIs from installed headers and bindings.
+- Prefer clear application endpoint names such as `image`, `detections`, `classes`, `preview`, `prompt`, and `tokens`.
+- Keep generated application code runnable with explicit build and run commands.
+
+## API Selection
+
+- Use `Model` for a single classic compiled model archive and direct request/response inference.
+- Use `Graph` when the application needs multiple stages, named inputs or outputs, branching, fan-in, reusable fragments, or source/output nodes.
+- Use `Run` after a `Graph` is built and the application needs long-lived push/pull execution.
+- Use `GenAIModel` for in-process GenAI calls against LLiMa model directories.
+- Use `GenAIServer` when a browser, service, or remote client should call GenAI models over HTTP.
+
+## Boundaries
+
+- Do not describe this as a repository maintenance skill.
+- Do not add repository publication, release automation, review workflow, or contributor-process guidance.
+- Do not include performance-tuning methods, queue-tuning recipes, memory-placement recipes, project-specific delivery patterns, or issue-specific lessons.
+- Do not guess API behavior from memory. Verify against current packaged core source or installed docs.
+
+## References
+
+- `references/source-of-truth.md`
+- `references/api-decision-map.md`
+- `references/api-surface-map.md`
+- `references/model-graph-run.md`
+- `references/genai.md`
+- `references/validation.md`

--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -12,9 +12,6 @@ Development Environment's packaged core source, installed headers, and local
 documentation as the source of truth. Use apps examples only as optional
 reference implementations after the API shape is chosen.
 
-Keep this skill generic. Do not encode project-specific pipeline lessons,
-performance recipes, or internal repository workflow.
-
 ## Official Naming
 
 - Use `Neat Library` for the C++/Python API and runtime.

--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neat-application-builder
-description: Use when building Neat Library applications with public C++ or Python APIs, including choosing between Model, Graph, Run, GenAIModel, and GenAIServer; reading packaged core headers/docs; composing application pipelines; and validating Neat Development Environment or DevKit behavior. Do not use for repository maintenance, release automation, review workflows, performance-tuning recipes, or project-specific delivery work.
+description: Use when building Neat Library applications with public C++ or Python APIs, including choosing between Model, Graph, GenAIModel, and GenAIServer; using Run handles returned by built graphs; reading packaged core headers/docs; composing application pipelines; and validating Neat Development Environment or DevKit behavior. Do not use for repository maintenance, release automation, review workflows, performance-tuning recipes, or project-specific delivery work.
 ---
 
 # Neat Application Builder
@@ -11,15 +11,6 @@ Build applications against the installed Neat Library. Treat the current Neat
 Development Environment's packaged core source, installed headers, and local
 documentation as the source of truth. Use apps examples only as optional
 reference implementations after the API shape is chosen.
-
-## Official Naming
-
-- Use `Neat Library` for the C++/Python API and runtime.
-- Use `Neat Development Environment` for the Docker-based development environment.
-- Use `Model Compiler` for quantization, compilation, and validation.
-- Keep `LLiMa` unchanged.
-- Keep command, repository, package, image, path, and artifact names verbatim.
-  Examples: `sima-cli sdk`, `ghcr:sima-neat/sdk`, `sdk`, `core`, and `/neat-resources/core-src`.
 
 ## Workflow
 
@@ -46,7 +37,6 @@ reference implementations after the API shape is chosen.
 
 - Use `Model` for a single classic compiled model archive and direct request/response inference.
 - Use `Graph` when the application needs multiple stages, named inputs or outputs, branching, fan-in, reusable fragments, or source/output nodes.
-- Use `Run` after a `Graph` is built and the application needs long-lived push/pull execution.
 - Use `GenAIModel` for in-process GenAI calls against LLiMa model directories.
 - Use `GenAIServer` when a browser, service, or remote client should call GenAI models over HTTP.
 

--- a/skills/neat-application-builder/agents/openai.yaml
+++ b/skills/neat-application-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Neat Application Builder"
+  short_description: "Build applications with the Neat Library APIs"
+  default_prompt: "Use $neat-application-builder to build a Neat Library application with the right public API shape."

--- a/skills/neat-application-builder/playbook.yml
+++ b/skills/neat-application-builder/playbook.yml
@@ -1,0 +1,9 @@
+id: neat-application-builder
+name: Neat Application Builder
+version: 0.1.0
+agents: [codex, claude]
+description: Generic application-building guidance for the installed Neat Library public APIs, including Model, Graph, Run, GenAIModel, and GenAIServer.
+compatibility:
+  env_types: [sdk]
+  env_subtypes: [linux, palette]
+  min_cli_version: 2.1.1

--- a/skills/neat-application-builder/playbook.yml
+++ b/skills/neat-application-builder/playbook.yml
@@ -2,7 +2,7 @@ id: neat-application-builder
 name: Neat Application Builder
 version: 0.1.0
 agents: [codex, claude]
-description: Generic application-building guidance for the installed Neat Library public APIs, including Model, Graph, Run, GenAIModel, and GenAIServer.
+description: Generic application-building guidance for the installed Neat Library public APIs, including Model, Graph, GenAIModel, and GenAIServer.
 compatibility:
   env_types: [sdk]
   env_subtypes: [linux, palette]

--- a/skills/neat-application-builder/references/api-decision-map.md
+++ b/skills/neat-application-builder/references/api-decision-map.md
@@ -28,13 +28,6 @@ Use `Graph` when:
 - The app needs branching, fan-in, reusable graph fragments, or source/output nodes.
 - The app must expose an application boundary beyond a single model call.
 
-Use `Run` when:
-
-- A `Graph` has been built.
-- The app needs long-lived asynchronous execution.
-- The app needs named `push("input", ...)` or `pull("output", ...)`.
-- The app needs timeout handling, close/drain behavior, or measurement scopes.
-
 ## GenAI
 
 Use `GenAIModel` when:

--- a/skills/neat-application-builder/references/api-decision-map.md
+++ b/skills/neat-application-builder/references/api-decision-map.md
@@ -1,0 +1,64 @@
+# API Decision Map
+
+Choose the public API shape before writing code. Start with the smallest API that
+matches the application boundary.
+
+## Classic Model
+
+Use `Model.run(...)` when:
+
+- The artifact is a compiled model archive, usually `.tar.gz`.
+- The app runs one model on one request or one frame at a time.
+- Synchronous request/response behavior is acceptable.
+- The app does not need custom input/output nodes, branching, fan-in, or a long-lived producer/consumer loop.
+
+Use `Model.build(...)` when:
+
+- The app still centers on one model.
+- The app needs a long-lived runner with repeated `push` / `pull`.
+- The model-owned `Runner` interface is enough.
+
+## Graph And Run
+
+Use `Graph` when:
+
+- The app has multiple stages.
+- The app composes a model with public nodes or node groups.
+- The app needs named public inputs or outputs.
+- The app needs branching, fan-in, reusable graph fragments, or source/output nodes.
+- The app must expose an application boundary beyond a single model call.
+
+Use `Run` when:
+
+- A `Graph` has been built.
+- The app needs long-lived asynchronous execution.
+- The app needs named `push("input", ...)` or `pull("output", ...)`.
+- The app needs timeout handling, close/drain behavior, or measurement scopes.
+
+## GenAI
+
+Use `GenAIModel` when:
+
+- The artifact is a deployed LLiMa model directory.
+- The app calls an LLM, VLM, or ASR model in-process.
+- The app needs `run(...)`, `stream(...)`, task detection, or model capability checks.
+
+Use task-specific GenAI handles when the app knows the task:
+
+- `VisionLanguageModel` for text-only LLMs and image-capable VLMs.
+- `ASRModel` for speech-to-text.
+
+Use `GenAIServer` when:
+
+- The app boundary is HTTP.
+- A browser, UI, companion service, or remote client should call one or more models.
+- The server owns model registration and request routing.
+
+Use GenAI graph fragments only when GenAI is one stage inside a larger Neat
+`Graph`.
+
+## Reference Examples
+
+After choosing the API family, use public examples only as implementation
+references. Do not start from an apps example and infer the API shape from it.
+The API contract lives in the installed Neat Library.

--- a/skills/neat-application-builder/references/api-decision-map.md
+++ b/skills/neat-application-builder/references/api-decision-map.md
@@ -18,7 +18,7 @@ Use `Model.build(...)` when:
 - The app needs a long-lived runner with repeated `push` / `pull`.
 - The model-owned `Runner` interface is enough.
 
-## Graph And Run
+## Graph
 
 Use `Graph` when:
 

--- a/skills/neat-application-builder/references/api-surface-map.md
+++ b/skills/neat-application-builder/references/api-surface-map.md
@@ -1,0 +1,123 @@
+# API Surface Map
+
+Use this file to discover important Neat Library API areas without turning the
+skill into an API manual. Mention the area, then inspect the current packaged
+source before writing code or explaining behavior.
+
+## Contents
+
+- Core Application Surface
+- Data And Boundary Types
+- Nodes And Graph Fragments
+- Model Pre/Post And Decode Helpers
+- GenAI Surface
+- Diagnostics And Measurement
+- Python Surface
+- Tools Outside This Skill
+
+## Core Application Surface
+
+- `Model`, `Model::Options`, `Model::RouteOptions`, and `Model::Runner`
+  - Inspect `include/model/Model.h`
+  - Read `docs/develop-apps/development-workflow/model.mdx`
+- `Graph`, `GraphOptions`, validation, save/load, describe helpers, and RTSP serving
+  - Inspect `include/pipeline/Graph.h`
+  - Inspect `include/pipeline/GraphOptions.h`
+  - Read `docs/develop-apps/development-workflow/graph.mdx`
+- `Run`, `RunOptions`, push/pull, endpoint names, measurement, and close/drain behavior
+  - Inspect `include/pipeline/Run.h`
+  - Read `docs/develop-apps/development-workflow/overview.mdx`
+
+## Data And Boundary Types
+
+- `Tensor`, `TensorList`, `TensorSpec`, dtype/layout/pixel-format helpers, and OpenCV/NumPy adapters
+  - Inspect `include/pipeline/Tensor*.h`
+  - Read `docs/develop-apps/development-workflow/core_types.mdx`
+- `Sample`, bundles, frame IDs, timestamps, and metadata-carrying payloads
+  - Inspect `include/pipeline/Tensor.h`
+  - Read `docs/develop-apps/development-workflow/core_types.mdx`
+- Encoded media helpers and payload types
+  - Inspect `include/pipeline/EncodedSampleUtil.h`
+  - Inspect `include/pipeline/PayloadType.h`
+  - Inspect `include/pipeline/FormatSpec.h`
+
+## Nodes And Graph Fragments
+
+- Public node umbrella includes
+  - Inspect `include/neat/nodes.h`
+  - Inspect `include/neat/node_groups.h`
+- Boundary nodes and common graph nodes
+  - Inspect `include/nodes/io/Input.h`
+  - Inspect `include/nodes/common/Output.h`
+  - Inspect `include/nodes/common/Queue.h`
+  - Inspect `include/nodes/common/Caps.h`
+- Image, video, RTSP, UDP, and metadata I/O
+  - Inspect `include/nodes/io/RTSPInput.h`
+  - Inspect `include/nodes/io/StillImageInput.h`
+  - Inspect `include/nodes/io/UdpOutput.h`
+  - Inspect `include/nodes/io/MetadataSender.h`
+- Pre-built node groups for common application plumbing
+  - Inspect `include/nodes/groups/*.h`
+  - Start with `RtspDecodedInput.h`, `VideoSender.h`, `ImageInputGroup.h`, and `ModelGroups.h`
+- Graph helpers such as branching and combining
+  - Inspect `include/graphs/Fragments.h`
+  - Read `docs/develop-apps/development-workflow/graph.mdx`
+
+## Model Pre/Post And Decode Helpers
+
+- Preprocess and model route options
+  - Inspect `include/model/PreprocessPlan.h`
+  - Inspect `include/nodes/sima/Preproc.h`
+- Detection and segmentation decode helpers
+  - Inspect `include/pipeline/DetectionTypes.h`
+  - Inspect `include/pipeline/BoxDecodeType.h`
+  - Inspect `include/nodes/sima/SimaBoxDecode.h`
+  - Read `docs/reference/boxdecode_decode_types.md`
+- Fixed-function Sima nodes when composing lower-level graph routes
+  - Inspect `include/nodes/sima/*.h`
+
+## GenAI Surface
+
+- GenAI umbrella include and task model APIs
+  - Inspect `include/neat/genai.h`
+  - Inspect `include/genai/GenAIModel.h`
+  - Inspect `include/genai/VisionLanguageModel.h`
+  - Inspect `include/genai/ASRModel.h`
+  - Inspect `include/genai/GenAITypes.h`
+- GenAI serving and graph fragments
+  - Inspect `include/genai/GenAIServer.h`
+  - Inspect `include/genai/GraphFragments.h`
+  - Inspect `include/genai/GenAIOptions.h`
+  - Read `docs/develop-apps/development-workflow/genai-model.mdx`
+
+## Diagnostics And Measurement
+
+- Structured errors, graph reports, and error code taxonomy
+  - Inspect `include/pipeline/NeatError.h`
+  - Inspect `include/pipeline/GraphReport.h`
+  - Inspect `include/pipeline/ErrorCodes.h`
+- Graph inspection helpers
+  - Inspect `Graph::validate`, `Graph::describe`, `Graph::describe_backend`, `Graph::save`, and `Graph::load` in `include/pipeline/Graph.h`
+- Measurement and runtime reports
+  - Inspect `MeasureScope`, `MeasureReport`, and `Run::start_measurement` in `include/pipeline/Run.h`
+
+## Python Surface
+
+- Python bindings mirror the public C++ application concepts but names and helper methods can differ.
+- Inspect `python/src/module.cpp` in packaged core source for binding truth.
+- Read `docs/reference/pythonapi/` when present in the installed docs.
+- For NumPy/image interop, inspect binding definitions for `Tensor`, `ModelOptions`, `RunOptions`, `GenAIModel`, and `GenAIServer`.
+
+## Tools Outside This Skill
+
+These are important Neat ecosystem areas, but this skill should only route to
+their docs. Do not inline their workflows here.
+
+- Model Compiler and model preparation
+  - Read the Model Compiler and compile-a-model docs.
+- Model Zoo and precompiled model retrieval
+  - Read the Model Zoo docs.
+- LLiMa compile, test, and benchmark workflows
+  - Read the LLiMa / GenAI tooling docs.
+- Insight visualization or UI workflows
+  - Read the Insight docs.

--- a/skills/neat-application-builder/references/api-surface-map.md
+++ b/skills/neat-application-builder/references/api-surface-map.md
@@ -59,9 +59,6 @@ source before writing code or explaining behavior.
 - Pre-built node groups for common application plumbing
   - Inspect `include/nodes/groups/*.h`
   - Start with `RtspDecodedInput.h`, `VideoSender.h`, `ImageInputGroup.h`, and `ModelGroups.h`
-- Graph helpers such as branching and combining
-  - Inspect `include/graphs/Fragments.h`
-  - Read `docs/develop-apps/development-workflow/graph.mdx`
 
 ## Model Pre/Post And Decode Helpers
 
@@ -115,8 +112,6 @@ their docs. Do not inline their workflows here.
 
 - Model Compiler and model preparation
   - Read the Model Compiler and compile-a-model docs.
-- Model Zoo and precompiled model retrieval
-  - Read the Model Zoo docs.
 - LLiMa compile, test, and benchmark workflows
   - Read the LLiMa / GenAI tooling docs.
 - Insight visualization or UI workflows

--- a/skills/neat-application-builder/references/genai.md
+++ b/skills/neat-application-builder/references/genai.md
@@ -1,0 +1,83 @@
+# GenAI APIs
+
+Use this reference for LLM, VLM, and ASR applications built with Neat GenAI APIs.
+These APIs consume deployed LLiMa model directories, not classic MPK `.tar.gz`
+model archives.
+
+## Choose The Handle
+
+Start with `GenAIModel` unless the application has a narrower known task.
+
+- `genai::GenAIModel` / `pyneat.genai.GenAIModel`: auto-detect LLM, VLM, or ASR model directories.
+- `genai::VisionLanguageModel` / `pyneat.genai.VisionLanguageModel`: text-only LLMs and image-capable VLMs.
+- `genai::ASRModel` / `pyneat.genai.ASRModel`: speech-to-text models.
+- `genai::GenAIServer` / `pyneat.genai.GenAIServer`: HTTP serving for one or more GenAI models.
+
+## GenAIModel
+
+Use `GenAIModel` for direct in-process application logic.
+
+Relevant public methods:
+
+- `task()`
+- `accepts_text()`
+- `accepts_image()`
+- `accepts_audio()`
+- `model_id()`
+- `run(request)`
+- `stream(request)`
+
+`run(...)` waits for a full `GenerationResult`. `stream(...)` yields
+`TokenSample` values and should be used when callers need incremental output or
+cancellation.
+
+## GenerationRequest
+
+Keep requests explicit.
+
+- Use `prompt` for a simple single-turn request.
+- Use `messages` for chat history.
+- Do not use `prompt` and `messages` together.
+- Use `system_prompt` only with `prompt`.
+- Use `images` for VLM prompt images.
+- Use per-message images when using chat history.
+- Use `audio` or `audio_file` for ASR.
+- Do not mix direct images with cached images in the same request.
+
+Capability-check the model before constructing task-specific requests when the
+model directory is user-provided.
+
+## GenAIServer
+
+Use `GenAIServer` when the Neat application should expose HTTP endpoints.
+
+Common steps:
+
+1. Create `GenAIServerOptions` when the default host or port is not correct.
+2. Construct `GenAIServer`.
+3. Add one or more model directories with stable served names.
+4. Use `serve()` for a blocking server or `start()` / `stop()` for managed lifetime.
+5. Use `model_names()` and `remove_model(...)` for model management when needed.
+
+Do not use a server when the app can call the model directly inside one process.
+Direct APIs are the simpler starting point for embedded application logic and
+tests.
+
+## GenAI In Graphs
+
+Direct GenAI calls are the default. Use public GenAI graph fragments only when
+GenAI is one stage inside a larger Neat `Graph`.
+
+Relevant public fragments:
+
+- `genai::graphs::VisionLanguage(...)`
+- `genai::graphs::SpeechTranscriber(...)`
+
+When graph fragments are used, follow the same named endpoint rules as other
+Neat graphs.
+
+## Boundary
+
+This skill does not cover compiling, quantizing, benchmarking, or selecting
+GenAI models. Use the public LLiMa/model tooling documentation for model
+preparation. This skill begins after a deployed model directory exists.

--- a/skills/neat-application-builder/references/model-graph-run.md
+++ b/skills/neat-application-builder/references/model-graph-run.md
@@ -1,0 +1,87 @@
+# Model, Graph, And Run
+
+Use this reference for classic compiled model applications. These are models
+packaged for Neat as compiled archives, commonly `.tar.gz` MPK artifacts.
+
+## Model
+
+`Model` loads and validates a compiled model archive. Use it first for classic
+classification, detection, segmentation, depth, embedding, and similar fixed
+shape model workflows.
+
+Common application steps:
+
+1. Construct `simaai::neat::Model` or `pyneat.Model` from the model path.
+2. Inspect `input_specs()`, `output_specs()`, `metadata()`, and `info()` when the input/output contract is not obvious.
+3. Use `model.run(inputs, timeout_ms)` for the shortest synchronous path.
+4. Use `model.build(...)` for repeated push/pull workloads that still need only the model route.
+5. Use `model.graph()` when the model is one fragment inside a larger `Graph`.
+
+Do not manually recreate the model route unless the public API requires it. Let
+`Model` assemble the model-owned preprocess, inference, and postprocess stages.
+
+## Graph
+
+`Graph` is the application assembly boundary.
+
+Use `add(...)` for linear chains:
+
+```cpp
+simaai::neat::Graph graph("classifier");
+graph.add(simaai::neat::nodes::Input("image"));
+graph.add(model);
+graph.add(simaai::neat::nodes::Output("classes"));
+```
+
+Use `connect(...)` for explicit topology:
+
+- connecting reusable fragments
+- branching one input to multiple paths
+- combining multiple inputs into one output
+- wiring named endpoints
+
+Names on `nodes::Input("name")` and `nodes::Output("name")` define public graph
+endpoints. A `Graph("name")` constructor label is diagnostic metadata, not a
+runtime endpoint.
+
+Prefer application-meaning names:
+
+- `image`
+- `left_camera`
+- `classes`
+- `detections`
+- `preview`
+
+Avoid runtime plumbing names such as `appsrc0`, `sink1`, or `out` in customer
+application code.
+
+## Run
+
+`Run` is the live handle returned by `Graph::build(...)`. Application code uses
+it to push input samples and pull output samples.
+
+Use named endpoints when the graph has more than one public input or output:
+
+```cpp
+run.push("image", simaai::neat::TensorList{image_tensor});
+auto detections = run.pull("detections", 1000);
+```
+
+Unnamed `push(...)` and `pull(...)` are appropriate only when the graph has one
+public input or output. If more than one endpoint exists, use the names.
+
+Use `Sample` when the application needs frame IDs, timestamps, bundled values,
+or other metadata. Use `TensorList` when raw tensor payloads are enough.
+
+## Diagnostics
+
+Catch `simaai::neat::NeatError` around `Model`, `Graph`, and `Run` operations
+that can fail. Start triage from structured fields:
+
+1. `report().error_code`
+2. `report().repro_note`
+3. `report().bus`
+4. `report().repro_gst_launch`
+
+Do not start with low-level runtime logs unless the structured report points
+there.

--- a/skills/neat-application-builder/references/model-graph-run.md
+++ b/skills/neat-application-builder/references/model-graph-run.md
@@ -73,15 +73,3 @@ public input or output. If more than one endpoint exists, use the names.
 Use `Sample` when the application needs frame IDs, timestamps, bundled values,
 or other metadata. Use `TensorList` when raw tensor payloads are enough.
 
-## Diagnostics
-
-Catch `simaai::neat::NeatError` around `Model`, `Graph`, and `Run` operations
-that can fail. Start triage from structured fields:
-
-1. `report().error_code`
-2. `report().repro_note`
-3. `report().bus`
-4. `report().repro_gst_launch`
-
-Do not start with low-level runtime logs unless the structured report points
-there.

--- a/skills/neat-application-builder/references/source-of-truth.md
+++ b/skills/neat-application-builder/references/source-of-truth.md
@@ -1,0 +1,77 @@
+# Source Of Truth
+
+Use the current Neat Development Environment's packaged source and installed
+public surface before writing or changing application code. This skill is
+guidance, not the API contract.
+
+## Preferred Order
+
+1. Packaged Neat Library source in the Neat Development Environment:
+   - `/neat-resources/core-src`
+2. Installed public headers:
+   - `$SYSROOT/usr/include`
+   - `/opt/toolchain/aarch64/modalix/usr/include`
+   - target-device `/usr/include`
+3. Local Neat docs in the packaged core source:
+   - `docs/develop-apps/development-workflow/`
+   - `docs/reference/`
+   - `tutorials/`
+4. Public apps examples as reference implementations only:
+   - `/neat-resources/apps-src/examples`
+   - `https://github.com/sima-neat/apps/tree/main/examples`
+
+If examples disagree with the current installed headers or docs, trust the
+current installed Neat Library contract.
+
+## Headers To Check
+
+- Umbrella include: `include/neat.h`
+- Classic model API: `include/model/Model.h`
+- Graph composition: `include/pipeline/Graph.h`
+- Runtime handle: `include/pipeline/Run.h`
+- Tensor and sample contracts:
+  - `include/pipeline/Tensor.h`
+  - `include/pipeline/TensorCore.h`
+  - `include/pipeline/TensorTypes.h`
+- Diagnostics:
+  - `include/pipeline/NeatError.h`
+  - `include/pipeline/GraphReport.h`
+- GenAI:
+  - `include/neat/genai.h`
+  - `include/genai/GenAIModel.h`
+  - `include/genai/GenAIServer.h`
+  - `include/genai/GenAITypes.h`
+  - `include/genai/VisionLanguageModel.h`
+  - `include/genai/ASRModel.h`
+  - `include/genai/GraphFragments.h`
+
+## Docs To Check
+
+- `development-workflow/index.md`: end-to-end application loop.
+- `development-workflow/overview.mdx`: direct model run vs graph/run.
+- `development-workflow/model.mdx`: `Model`, model specs, and route fragments.
+- `development-workflow/graph.mdx`: graph boundaries, `add`, `connect`, named endpoints.
+- `development-workflow/core_types.mdx`: `Tensor` and `Sample`.
+- `development-workflow/genai-model.mdx`: GenAI model and server APIs.
+- `development-workflow/node.mdx`: public nodes and node groups.
+- `development-workflow/pipeline.mdx`: built pipeline/runtime view.
+- `advanced-concepts/application-design/graphs.md`: graph composition details.
+- `advanced-concepts/application-design/video_sender.md`: video output patterns.
+- `advanced-concepts/application-design/metadata_sender.md`: metadata output patterns.
+- `advanced-concepts/data-model-contracts/data_formats.md`: data and media format contracts.
+- `reference/`: generated C++ and Python API reference.
+
+## Verification Rule
+
+Before making a factual claim about an API, search the current source:
+
+```bash
+rg -n "Model|Graph|Run|GenAIModel|GenAIServer" /neat-resources/core-src/include /neat-resources/core-src/docs
+```
+
+Use the exact path available in the Neat Development Environment. If
+`/neat-resources/core-src` is absent, inspect the installed headers and tell the
+user what source was used.
+
+For broader API discovery, read `api-surface-map.md` and search the exact header
+families listed there.

--- a/skills/neat-application-builder/references/validation.md
+++ b/skills/neat-application-builder/references/validation.md
@@ -15,7 +15,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(SimaNeat REQUIRED)
+find_package(SimaNeat REQUIRED CONFIG)
 
 add_executable(neat_app main.cpp)
 target_link_libraries(neat_app PRIVATE SimaNeat::sima_neat)

--- a/skills/neat-application-builder/references/validation.md
+++ b/skills/neat-application-builder/references/validation.md
@@ -1,0 +1,77 @@
+# Validation
+
+Validate at the level the environment supports. Do not claim Neat Library
+runtime behavior is verified from source inspection alone.
+
+## C++ Build Check
+
+For standalone C++ apps, use the installed package:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(neat_app LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(SimaNeat REQUIRED)
+
+add_executable(neat_app main.cpp)
+target_link_libraries(neat_app PRIVATE SimaNeat::sima_neat)
+```
+
+Build in the Neat Development Environment or target-appropriate environment. A
+laptop host compile is not proof of Modalix runtime behavior unless it uses the
+correct Neat Development Environment toolchain and runtime target.
+
+## Python Import Check
+
+Use the installed Python binding:
+
+```bash
+python3 - <<'PY'
+import pyneat
+print(pyneat.__name__)
+PY
+```
+
+On a DevKit or Neat Development Environment image, activate the packaged
+environment if the installation requires it.
+
+## Artifact Checks
+
+Before running:
+
+- Confirm classic `Model` inputs point at a compiled model archive.
+- Confirm GenAI inputs point at a deployed LLiMa model directory.
+- Confirm image, video, audio, config, and output paths exist or are created by the app.
+- Confirm the app uses public endpoint names that exist in the built graph.
+
+## Runtime Checks
+
+When hardware Neat Library runtime behavior matters, run on Modalix or the
+connected DevKit.
+
+Exercise at least:
+
+- one successful request
+- missing model path
+- bad input path
+- timeout or empty-output behavior when the app exposes a timeout
+- wrong endpoint name for multi-input or multi-output graphs
+- invalid GenAI request shape when working with GenAI APIs
+
+For graph failures, read structured diagnostics first:
+
+1. `error_code`
+2. `repro_note`
+3. first terminal entry in `bus`
+4. `repro_gst_launch`
+
+## Apps Examples
+
+Use public apps examples for reference commands and full application patterns
+after the Neat API shape is selected. Do not treat reference-repository build,
+publication, documentation, or automation rules as required for standalone
+applications.


### PR DESCRIPTION
## Summary

- add `neat-application-builder` as a generic customer-facing skill for building with Neat Library public APIs
- route agents to packaged Neat Library source, installed headers, and docs before making API claims
- cover API selection for Model, Graph, Run, GenAIModel, GenAIServer, broader source-navigation, and validation

## Validation

- `python3 /Users/onatinak/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/onatinak/workspace/sima-neat/apps/skills/neat-application-builder`
- `PYTHONPATH=/Users/onatinak/workspace/sima-neat/sima-cli /Users/onatinak/.sima-cli/.venv/bin/python - <<'PY' ... SkillManager.install(..., dry_run=True) ... PY`
