### PR TITLE
[codex] Fix production examples portal publishing

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -198,7 +198,7 @@ jobs:
     if: ${{ github.ref_type == 'branch' }}
     uses: sima-neat/.github/.github/workflows/vulcan-resolve-config.yml@main
     with:
-      vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env == 'prod' && 'staging' || needs.resolve-vulcan-config.outputs.vulcan_env }}
+      vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env == 'prod' && github.ref_name != 'main' && 'staging' || needs.resolve-vulcan-config.outputs.vulcan_env }}
 
   resolve-test-runner:
     name: Resolve Test Runner


### PR DESCRIPTION
## Summary
- Publish the `/examples` sysdoc route to the production apps portal bucket when the Vulcan production workflow runs on `main`.
- Keep the existing guardrail for non-main branch builds: production-configured branch runs still publish the portal route to staging.

## Root Cause
The `main` production run resolved the portal publish config to staging unconditionally whenever `resolve-vulcan-config` returned `prod`.

CI evidence from run `27454911501`, job `81158404117`:
- bucket: `sima-neat-apps-portal-staging`
- role: `NeatStagingAppsPortalPublisherRole`
- CloudFront distribution: `E8LQIX3XJ0GEC`

As a result, `developer-stg.sima.ai/examples` was updated, but production never received `sima-neat-apps-portal-production/examples/index.html`. Production CloudFront routing is configured correctly, but the origin object is missing, which surfaces as a CloudFront/S3 403 at `https://developer.sima.ai/examples`.

## Validation
- Parsed `.github/workflows/vulcan-ci.yml` with PyYAML.
- Ran `git diff --check`.
- Ran `actionlint apps/.github/workflows/vulcan-ci.yml`; it reports pre-existing custom runner label and dynamic shell-source warnings unrelated to this change.
- Verified via AWS production profile that `sima-neat-apps-portal-production/examples/index.html` is missing while production sysdoc CloudFront has the expected `/examples` behaviors.
