### PR TITLE
Promote develop to main

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -198,7 +198,7 @@ jobs:
     if: ${{ github.ref_type == 'branch' }}
     uses: sima-neat/.github/.github/workflows/vulcan-resolve-config.yml@main
     with:
-      vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env == 'prod' && 'staging' || needs.resolve-vulcan-config.outputs.vulcan_env }}
+      vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env == 'prod' && github.ref_name != 'main' && 'staging' || needs.resolve-vulcan-config.outputs.vulcan_env }}
 
   resolve-test-runner:
     name: Resolve Test Runner


### PR DESCRIPTION
## Summary
- Promote `develop` into `main` for apps.
- Includes the production `/examples` portal publishing fix from #248.

## Context
The production `main` Vulcan run had resolved the SysDoc examples publish target to staging, so `developer.sima.ai/examples` was not populated from production CI. This promotion brings the workflow fix into `main` so future production runs publish the examples portal to the production apps portal bucket and invalidate the production sysdoc CloudFront distribution.

## Validation
- Compared `origin/main..origin/develop`.
- Diff is limited to `.github/workflows/vulcan-ci.yml`.
- The original fix PR validated YAML parsing and `git diff --check`; `actionlint` only reported pre-existing custom runner label / shellcheck warnings unrelated to the change.
