### PR TITLE
Fix Apps tag install latest resolution

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -1,6 +1,6 @@
 name: Vulcan CI
 
-run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'dev' }})
+run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'production' }})
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
     name: Resolve Vulcan Config
     uses: sima-neat/.github/.github/workflows/vulcan-resolve-config.yml@main
     with:
-      vulcan_env: ${{ vars.VULCAN_ENV || 'dev' }}
+      vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
 
   build:
     name: Build Apps on Vulcan

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -192,21 +192,6 @@ jobs:
       artifact_glob: "*"
       min_artifact_count: 4
 
-  promote-latest-tag:
-    name: Promote Vulcan latest tag
-    if: ${{ github.ref_type == 'branch' || github.ref_type == 'tag' }}
-    needs:
-      - resolve-vulcan-config
-      - publish-vulcan-artifacts
-    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
-    with:
-      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
-      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
-      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
-      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
-      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
-      artifact_folder: "."
-
   resolve-portal-publish-config:
     name: Resolve Portal Publish Config
     needs: resolve-vulcan-config
@@ -224,7 +209,7 @@ jobs:
     needs:
       - resolve-vulcan-config
       - resolve-test-runner
-      - promote-latest-tag
+      - publish-vulcan-artifacts
     runs-on:
       group: ${{ needs.resolve-test-runner.outputs.modalix_runner_group }}
       labels: [self-hosted, Linux, ARM64, modalix, "vulcan-${{ needs.resolve-vulcan-config.outputs.vulcan_env }}"]
@@ -261,7 +246,8 @@ jobs:
           fi
 
           REF_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          PACKAGE_SPEC="apps@${REF_NAME}"
+          SHORT_SHA="$(printf "%.12s" "${GITHUB_SHA}")"
+          PACKAGE_SPEC="apps@${REF_NAME}:${SHORT_SHA}"
 
           mkdir -p _vulcan-test/install
           echo "Installing ${PACKAGE_SPEC} from Vulcan env ${VULCAN_ENV}"
@@ -313,6 +299,21 @@ jobs:
         if: ${{ always() }}
         run: |
           rm -rf _vulcan-test
+
+  promote-latest-tag:
+    name: Promote Vulcan latest tag
+    if: ${{ always() && (github.ref_type == 'branch' || github.ref_type == 'tag') && needs.test-runtime.result == 'success' }}
+    needs:
+      - resolve-vulcan-config
+      - test-runtime
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
+      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
+      artifact_folder: "."
 
   build-sysdoc-examples:
     name: Build SysDoc Examples Route

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -192,6 +192,21 @@ jobs:
       artifact_glob: "*"
       min_artifact_count: 4
 
+  promote-latest-tag:
+    name: Promote Vulcan latest tag
+    if: ${{ github.ref_type == 'branch' || github.ref_type == 'tag' }}
+    needs:
+      - resolve-vulcan-config
+      - publish-vulcan-artifacts
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
+      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
+      artifact_folder: "."
+
   resolve-portal-publish-config:
     name: Resolve Portal Publish Config
     needs: resolve-vulcan-config
@@ -209,7 +224,7 @@ jobs:
     needs:
       - resolve-vulcan-config
       - resolve-test-runner
-      - publish-vulcan-artifacts
+      - promote-latest-tag
     runs-on:
       group: ${{ needs.resolve-test-runner.outputs.modalix_runner_group }}
       labels: [self-hosted, Linux, ARM64, modalix, "vulcan-${{ needs.resolve-vulcan-config.outputs.vulcan_env }}"]
@@ -246,13 +261,7 @@ jobs:
           fi
 
           REF_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-            VERSION="${VERSION#v}"
-          else
-            VERSION="$(printf "%.12s" "${GITHUB_SHA}")"
-          fi
-          PACKAGE_SPEC="apps@${REF_NAME}:${VERSION}"
+          PACKAGE_SPEC="apps@${REF_NAME}"
 
           mkdir -p _vulcan-test/install
           echo "Installing ${PACKAGE_SPEC} from Vulcan env ${VULCAN_ENV}"
@@ -484,18 +493,3 @@ jobs:
             --api-key "${write_api_key}" \
             --index-name "${index_name}" \
             --sync
-
-  promote-latest-tag:
-    name: Promote Vulcan latest tag
-    if: ${{ github.ref_type == 'branch' || github.ref_type == 'tag' }}
-    needs:
-      - resolve-vulcan-config
-      - test-runtime
-    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
-    with:
-      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
-      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
-      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
-      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
-      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
-      artifact_folder: "."

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ Environment:
                             Scratch directory override for Vulcan core installs
                             (default: fresh /tmp/neat-apps-core-install.XXXXXX)
   NEAT_CORE_INSTALL_MODE    legacy or vulcan. Defaults to vulcan when NEAT_VULCAN_ENV is set.
-  NEAT_VULCAN_ENV           Vulcan artifact environment for sima-cli core installs
+  NEAT_VULCAN_ENV           Vulcan artifact environment for sima-cli core installs (default: production)
   CMAKE_TOOLCHAIN_FILE      Optional CMake toolchain file (auto-detected for cross)
   SYSROOT                   Target sysroot (used by the default cross toolchain file)
 EOF
@@ -776,7 +776,7 @@ ensure_neat_core() {
     fi
   fi
   if [[ "${install_mode}" == "vulcan" ]]; then
-    vulcan_env="${NEAT_VULCAN_ENV:-dev}"
+    vulcan_env="${NEAT_VULCAN_ENV:-production}"
   fi
 
   # Resolve "latest" to an exact tag before checking installed state.

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 DEST_DIR="${NEAT_APPS_INSTALL_DIR:-neat-apps}"
 RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-neat-apps-runtime}"
 RUNTIME_DST="${DEST_DIR}/neat-apps-runtime"
-VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-dev}}"
+VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-production}}"
 NEAT_CORE_INSTALL_DIR=""
 NEAT_CORE_INSTALL_DIR_OWNED=0
 


### PR DESCRIPTION
## Summary

This PR fixes Apps Vulcan install/release behavior so branch and tag packages can be installed reliably with `sima-cli neat install`, and so users do not accidentally pull dependency artifacts from the old dev Vulcan environment.

## Problems fixed

### 1. Manual Apps installs could pull matching Core from the dev environment

The Apps package installer had its own Vulcan environment fallback:

```bash
VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-dev}}"
```

That meant a user could install Apps from production, but the Apps installer would then try to install its matching Core dependency from the dev environment. In practice this produced requests to the old dev artifact host and failed with 403s, for example:

```text
https://artifacts.neat.paconsultings.com/core/...
```

This was particularly bad because normal/manual user installs were broken unless the user knew to override the env explicitly. The installer now defaults to production while still preserving overrides:

1. `NEAT_VULCAN_ENV` wins if set.
2. `VULCAN_ENV` is used if set.
3. Otherwise the fallback is `production`.

### 2. Apps CI defaulted Vulcan config to dev

The Vulcan CI workflow also used `dev` as the fallback when `vars.VULCAN_ENV` was unset. This PR changes that default to `production`, matching the intended user-facing package environment.

### 3. Tag-build runtime install tests used the wrong package spec

The runtime test previously derived a tag version and installed a spec like:

```bash
apps@v0.1.0:0.1.0
```

That does not match how Vulcan artifacts are laid out for the published commit and can cause metadata lookup under the wrong path. The runtime test now validates the exact artifact from the current commit:

```bash
apps@<ref>:<short-git-sha>
```

This works for both branch and tag builds because it does not require `latest.tag` to exist before the artifact is validated.

### 4. `latest.tag` should be promoted only after validation

Apps now follows the safer Core-style flow:

```text
build -> publish-vulcan-artifacts -> test-runtime -> promote-latest-tag
```

The runtime test installs the exact artifact by git hash first. Only after that test passes does the workflow promote `latest.tag` for branches or tags. After promotion, normal installs such as the following resolve through `latest.tag` to the tested artifact:

```bash
sima-cli neat install apps@<branch-or-tag>
```

## Validation

- `actionlint -ignore 'label "modalix" is unknown' -ignore 'SC1090' .github/workflows/vulcan-ci.yml`
- `bash -n scripts/install-vulcan-apps-package.sh build.sh`
- `git diff --check`
- Verified the production-published package contains the corrected installer fallback to `production`
- Previous Vulcan CI run passed publish, latest-tag promotion, and Apps runtime install after the production default fix; latest run is validating the final promote-after-test workflow order
