### PR TITLE
Promote develop to main

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -1,6 +1,6 @@
 name: Vulcan CI
 
-run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'dev' }})
+run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'production' }})
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
     name: Resolve Vulcan Config
     uses: sima-neat/.github/.github/workflows/vulcan-resolve-config.yml@main
     with:
-      vulcan_env: ${{ vars.VULCAN_ENV || 'dev' }}
+      vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
 
   build:
     name: Build Apps on Vulcan
@@ -246,13 +246,8 @@ jobs:
           fi
 
           REF_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-            VERSION="${VERSION#v}"
-          else
-            VERSION="$(printf "%.12s" "${GITHUB_SHA}")"
-          fi
-          PACKAGE_SPEC="apps@${REF_NAME}:${VERSION}"
+          SHORT_SHA="$(printf "%.12s" "${GITHUB_SHA}")"
+          PACKAGE_SPEC="apps@${REF_NAME}:${SHORT_SHA}"
 
           mkdir -p _vulcan-test/install
           echo "Installing ${PACKAGE_SPEC} from Vulcan env ${VULCAN_ENV}"
@@ -304,6 +299,21 @@ jobs:
         if: ${{ always() }}
         run: |
           rm -rf _vulcan-test
+
+  promote-latest-tag:
+    name: Promote Vulcan latest tag
+    if: ${{ always() && (github.ref_type == 'branch' || github.ref_type == 'tag') && needs.test-runtime.result == 'success' }}
+    needs:
+      - resolve-vulcan-config
+      - test-runtime
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
+      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
+      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
+      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
+      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
+      artifact_folder: "."
 
   build-sysdoc-examples:
     name: Build SysDoc Examples Route
@@ -484,18 +494,3 @@ jobs:
             --api-key "${write_api_key}" \
             --index-name "${index_name}" \
             --sync
-
-  promote-latest-tag:
-    name: Promote Vulcan latest tag
-    if: ${{ github.ref_type == 'branch' || github.ref_type == 'tag' }}
-    needs:
-      - resolve-vulcan-config
-      - test-runtime
-    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
-    with:
-      aws_region: ${{ needs.resolve-vulcan-config.outputs.aws_region }}
-      environment_name: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
-      bucket: ${{ needs.resolve-vulcan-config.outputs.artifact_bucket }}
-      role_to_assume: ${{ needs.resolve-vulcan-config.outputs.artifact_publisher_role_arn }}
-      sse_kms_key_id: ${{ needs.resolve-vulcan-config.outputs.artifact_kms_key_id }}
-      artifact_folder: "."

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ Environment:
                             Scratch directory override for Vulcan core installs
                             (default: fresh /tmp/neat-apps-core-install.XXXXXX)
   NEAT_CORE_INSTALL_MODE    legacy or vulcan. Defaults to vulcan when NEAT_VULCAN_ENV is set.
-  NEAT_VULCAN_ENV           Vulcan artifact environment for sima-cli core installs
+  NEAT_VULCAN_ENV           Vulcan artifact environment for sima-cli core installs (default: production)
   CMAKE_TOOLCHAIN_FILE      Optional CMake toolchain file (auto-detected for cross)
   SYSROOT                   Target sysroot (used by the default cross toolchain file)
 EOF
@@ -776,7 +776,7 @@ ensure_neat_core() {
     fi
   fi
   if [[ "${install_mode}" == "vulcan" ]]; then
-    vulcan_env="${NEAT_VULCAN_ENV:-dev}"
+    vulcan_env="${NEAT_VULCAN_ENV:-production}"
   fi
 
   # Resolve "latest" to an exact tag before checking installed state.

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 DEST_DIR="${NEAT_APPS_INSTALL_DIR:-neat-apps}"
 RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-neat-apps-runtime}"
 RUNTIME_DST="${DEST_DIR}/neat-apps-runtime"
-VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-dev}}"
+VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-production}}"
 NEAT_CORE_INSTALL_DIR=""
 NEAT_CORE_INSTALL_DIR_OWNED=0
 


### PR DESCRIPTION
## Summary
- promote the Apps Vulcan install/tag workflow fixes from `develop` to `main`
- default Apps Vulcan CI and package installer dependency resolution to production
- validate tag/branch packages by exact git hash before promoting `latest.tag`

## Validation
- Apps tag build was tested from `develop` with temporary release tags
- `sima-cli neat install apps@v0.1.0` resolution was confirmed after the tag build succeeded
- temporary `v0.1.0` test tag was deleted after validation
