### PR TITLE
Prepare apps for 2.1.2

### DIFF
--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -3,7 +3,7 @@
     "policy": "snap"
   },
   "sdk": {
-    "channel": "main"
+    "channel": "develop"
   },
-  "platform-version": "2.0.0"
+  "platform-version": "2.1.2"
 }


### PR DESCRIPTION
## Summary
- set the apps SDK channel to develop
- update the apps platform version to 2.1.2
- keep neat-core on policy=snap so CI resolves from the dependency branch

## Validation
- python3 -m json.tool deps/manifest.json >/dev/null
- python3 -m pytest tests/scripts/test_manifest_contract.py
- python3 -m pytest -vv tests/scripts/test_scope_contract.py::test_download_models_uses_manifest_platform_version_for_modelzoo (skipped locally: /bin/bash lacks mapfile support)