### PR TITLE
Prepare apps for 2.1.2

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -108,6 +108,21 @@ jobs:
             fi
 
             cd /workspace
+            echo "SDK release:"
+            cat /etc/sdk-release || true
+            echo "Build compiler environment:"
+            echo "  CC=${CC:-}"
+            echo "  CXX=${CXX:-}"
+            if [[ -n "${CC:-}" ]]; then
+              command -v "${CC}" || true
+              "${CC}" --version | head -n 1 || true
+            fi
+            if [[ -n "${CXX:-}" ]]; then
+              command -v "${CXX}" || true
+              "${CXX}" --version | head -n 1 || true
+            fi
+            echo "Cross compiler symlinks:"
+            ls -l /usr/bin/aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-g++ || true
             chmod +x build.sh scripts/ci/check_public_includes.sh scripts/install-vulcan-apps-package.sh
             ./build.sh --all --clean
             ./scripts/ci/check_public_includes.sh

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Examples are organized under `examples/<category>/<example>`. Each example is so
 | `examples/<category>/<example>/src/common/` | Files shared by the example implementations |
 
 > **IMPORTANT:** Use this structure when reading, extending, or adding examples, and follow each example README for any example-specific entrypoints.
-> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
+> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://developer.sima.ai/examples>).
 
 ### Contributor Guidelines
 

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -3,7 +3,7 @@
     "policy": "snap"
   },
   "sdk": {
-    "channel": "main"
+    "channel": "develop"
   },
-  "platform-version": "2.0.0"
+  "platform-version": "2.1.2"
 }

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -12,7 +12,7 @@
 | Model | yolo26m-det-bf16-mla_tess-b1 |
 
 ## Concept
-This example decodes an RTSP stream, runs YOLO26 detection with internal box decode, and sends video plus object-detection metadata to Insight. When OpenAI is enabled, the highest-score detected person is cropped and sent to the configured OpenAI-compatible Gemma server from a bounded background worker, so the detection and Insight loop keeps running.
+This example decodes an RTSP stream, runs YOLO26 detection with internal box decode, and sends video plus object-detection metadata to Insight. Insight video uses `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. When OpenAI is enabled, the highest-score detected person is cropped and sent to the configured OpenAI-compatible Gemma server from a bounded background worker, so the detection and Insight loop keeps running.
 
 ## Preview
 Detection metadata visualized in Insight:

--- a/examples/genai/detection-to-vlm-assistant/src/python/main.py
+++ b/examples/genai/detection-to-vlm-assistant/src/python/main.py
@@ -200,6 +200,8 @@ def main() -> int:
             if cfg.debug:
                 print(f"frame={frame_id} detections={len(boxes)}")
         return 0 if frame_id > 0 else 3
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -22,7 +22,7 @@ Snippet from a pipeline run:
 Architecture:
 - one complete graph per RTSP stream
 - each stream branches decoded NV12 frames into video and model paths
-- clean Insight video is sent through `VideoSender`
+- clean Insight video is sent through `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output
 - YOLO26 detections are sent as metadata for Insight overlay
 - optional debug output joins decoded frames and detections by frame id before saving
 
@@ -136,6 +136,7 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-str
 ## Notes
 - Point `model.path` at a YOLO26 detection pack. This example does not use a `model.family` config key.
 - Both C++ and Python use the same public graph shape: `RtspDecodedInput`, `graphs::Branch`, `model.graph()`, `graphs::Combine` for debug saves, and `VideoSender`.
+- The app does not add lower-level video conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes around `VideoSender`.
 - The live path keeps video and metadata separate. Insight overlays metadata on the clean video stream.
 - `output.video_enabled: false` disables per-stream H.264 video output. Metadata still runs.
 

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -26,16 +26,21 @@
 #include <opencv2/imgcodecs.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
+#include <functional>
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -119,6 +124,8 @@ struct StreamRuntime {
   int index = 0;
   std::string url;
   std::unique_ptr<simaai::neat::Model> model;
+  simaai::neat::Graph graph;
+  simaai::neat::Run run;
   std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
   std::vector<std::string> labels;
   std::string output_name;
@@ -406,8 +413,7 @@ std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg) {
 }
 
 StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const std::string& url,
-                                   const std::vector<std::string>& labels,
-                                   simaai::neat::Graph& app_graph) {
+                                   const std::vector<std::string>& labels) {
   StreamRuntime runtime;
   runtime.index = stream_index;
   runtime.url = url;
@@ -425,12 +431,11 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   runtime.profile.enabled = cfg.profile;
   runtime.profile.stream_index = stream_index;
 
-  const std::string suffix = std::to_string(stream_index);
-  const std::string model_name = "model_" + suffix;
-  const std::string video_name = "video_" + suffix;
-  const std::string debug_frame_name = "debug_frame_" + suffix;
-  const std::string detections_name = "detections_" + suffix;
-  const std::string debug_output_name = "debug_output_" + suffix;
+  const std::string model_name = "model";
+  const std::string video_name = "video";
+  const std::string debug_frame_name = "debug_frame";
+  const std::string detections_name = "detections";
+  const std::string debug_output_name = "debug_output";
   runtime.output_name =
       (!cfg.save_dir.empty() && cfg.save_every > 0) ? debug_output_name : detections_name;
 
@@ -447,7 +452,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
 
   simaai::neat::GraphLinkOptions live_link_options;
   live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
-  app_graph.connect(source, branch);
+  runtime.graph.connect(source, branch);
   if (cfg.video_enabled) {
     auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
         runtime.frame_w, runtime.frame_h, runtime.output_fps);
@@ -459,7 +464,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     simaai::neat::Graph video_graph(video_name);
     video_graph.connect(simaai::neat::nodes::Input(video_name),
                         simaai::neat::nodes::groups::VideoSender(video_options));
-    app_graph.connect(branch, video_graph, live_link_options);
+    runtime.graph.connect(branch, video_graph, live_link_options);
   }
 
   simaai::neat::Graph model_graph(model_name);
@@ -467,8 +472,8 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   simaai::neat::Graph detections_graph(detections_name);
   detections_graph.add(
       simaai::neat::nodes::Output(detections_name, simaai::neat::OutputOptions::EveryFrame(4)));
-  app_graph.connect(branch, model_graph, live_link_options);
-  app_graph.connect(model_graph, detections_graph);
+  runtime.graph.connect(branch, model_graph, live_link_options);
+  runtime.graph.connect(model_graph, detections_graph);
 
   if (save_debug_frames) {
     simaai::neat::Graph frames(debug_frame_name);
@@ -477,10 +482,22 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     auto debug_join =
         simaai::neat::graphs::Combine({debug_frame_name, detections_name}, debug_output_name,
                                       simaai::neat::CombinePolicy::ByFrame);
-    app_graph.connect(branch, frames, live_link_options);
-    app_graph.connect(frames, debug_join);
-    app_graph.connect(detections_graph, debug_join);
+    runtime.graph.connect(branch, frames, live_link_options);
+    runtime.graph.connect(frames, debug_join);
+    runtime.graph.connect(detections_graph, debug_join);
   }
+
+  if (cfg.profile) {
+    std::cout << "Backend stream=" << stream_index << ":\n"
+              << runtime.graph.describe_backend() << "\n";
+  }
+
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 3;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
+  runtime.run = runtime.graph.build(run_options);
 
   simaai::neat::MetadataSenderOptions metadata_options;
   metadata_options.host = cfg.insight_host;
@@ -544,12 +561,12 @@ void maybe_save_debug_frame(const AppConfig& cfg, const StreamRuntime& stream,
   }
 }
 
-bool process_stream_once(simaai::neat::Run& run, StreamRuntime& stream, const AppConfig& cfg) {
+bool process_stream_once(StreamRuntime& stream, const AppConfig& cfg) {
   constexpr int kPullTimeoutMs = 50;
   simaai::neat::Sample sample;
   simaai::neat::PullError pull_error;
   const double pull_start = sima_examples::time_ms();
-  const auto status = run.pull(stream.output_name, kPullTimeoutMs, sample, &pull_error);
+  const auto status = stream.run.pull(stream.output_name, kPullTimeoutMs, sample, &pull_error);
   const double pull_end = sima_examples::time_ms();
   if (status == simaai::neat::PullStatus::Timeout) {
     return false;
@@ -585,6 +602,23 @@ bool process_stream_once(simaai::neat::Run& run, StreamRuntime& stream, const Ap
   return true;
 }
 
+void consume_stream(StreamRuntime& stream, const AppConfig& cfg, std::atomic_bool& stop_requested,
+                    std::exception_ptr& first_error, std::mutex& error_mutex) {
+  try {
+    while (!stop_requested.load() && g_stop_requested == 0 && !stream.closed &&
+           (cfg.frames <= 0 || stream.processed < cfg.frames)) {
+      (void)process_stream_once(stream, cfg);
+    }
+  } catch (...) {
+    {
+      std::lock_guard<std::mutex> lock(error_mutex);
+      if (!first_error)
+        first_error = std::current_exception();
+    }
+    stop_requested.store(true);
+  }
+}
+
 void run_app(const AppConfig& cfg) {
   g_stop_requested = 0;
   auto previous_sigint = std::signal(SIGINT, request_stop);
@@ -598,44 +632,38 @@ void run_app(const AppConfig& cfg) {
   }
 
   const auto labels = load_labels(cfg.labels_path);
-  simaai::neat::Graph app_graph("multi_stream");
   std::vector<StreamRuntime> streams;
   streams.reserve(cfg.rtsp_urls.size());
   for (std::size_t index = 0; index < cfg.rtsp_urls.size(); ++index) {
-    streams.push_back(build_stream_runtime(cfg, static_cast<int>(index), cfg.rtsp_urls[index],
-                                           labels, app_graph));
+    streams.push_back(
+        build_stream_runtime(cfg, static_cast<int>(index), cfg.rtsp_urls[index], labels));
   }
 
-  if (cfg.profile) {
-    std::cout << "Backend:\n" << app_graph.describe_backend() << "\n";
+  std::atomic_bool stop_requested{false};
+  std::exception_ptr first_error;
+  std::mutex error_mutex;
+  std::vector<std::thread> consumers;
+  consumers.reserve(streams.size());
+  for (auto& stream : streams) {
+    consumers.emplace_back(consume_stream, std::ref(stream), std::cref(cfg),
+                           std::ref(stop_requested), std::ref(first_error), std::ref(error_mutex));
   }
 
-  simaai::neat::RunOptions run_options;
-  run_options.preset = simaai::neat::RunPreset::Realtime;
-  run_options.queue_depth = 3;
-  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
-  auto run = app_graph.build(run_options);
-
-  bool all_done = false;
-  while (g_stop_requested == 0 && !all_done) {
-    all_done = true;
-    for (auto& stream : streams) {
-      if (stream.closed || (cfg.frames > 0 && stream.processed >= cfg.frames)) {
-        continue;
-      }
-      all_done = false;
-      (void)process_stream_once(run, stream, cfg);
+  for (auto& consumer : consumers) {
+    if (consumer.joinable()) {
+      consumer.join();
     }
   }
 
   for (auto& stream : streams) {
     stream.profile.flush();
+    stream.run.close();
     std::cout << "[stream " << stream.index << "] processed=" << stream.processed << "\n";
   }
-  run.close();
-
   std::signal(SIGINT, previous_sigint);
+  if (first_error) {
+    std::rethrow_exception(first_error);
+  }
 }
 
 } // namespace

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -387,6 +387,14 @@ make_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, 
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -441,6 +441,8 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   }
   auto branch = simaai::neat::graphs::Branch("source", outputs);
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
   if (cfg.video_enabled) {
     auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
@@ -453,7 +455,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     simaai::neat::Graph video_graph("video");
     video_graph.connect(simaai::neat::nodes::Input("video"),
                         simaai::neat::nodes::groups::VideoSender(video_options));
-    runtime.graph.connect(branch, video_graph);
+    runtime.graph.connect(branch, video_graph, live_link_options);
   }
 
   simaai::neat::Graph model_graph("model");
@@ -461,7 +463,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   simaai::neat::Graph detections_graph("detections");
   detections_graph.add(
       simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
-  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(branch, model_graph, live_link_options);
   runtime.graph.connect(model_graph, detections_graph);
 
   if (save_debug_frames) {

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -26,21 +26,16 @@
 #include <opencv2/imgcodecs.hpp>
 
 #include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
-#include <exception>
 #include <filesystem>
-#include <functional>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -124,10 +119,9 @@ struct StreamRuntime {
   int index = 0;
   std::string url;
   std::unique_ptr<simaai::neat::Model> model;
-  simaai::neat::Graph graph;
-  simaai::neat::Run run;
   std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
   std::vector<std::string> labels;
+  std::string output_name;
   ProfileWindow profile;
   int frame_w = 0;
   int frame_h = 0;
@@ -412,7 +406,8 @@ std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg) {
 }
 
 StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const std::string& url,
-                                   const std::vector<std::string>& labels) {
+                                   const std::vector<std::string>& labels,
+                                   simaai::neat::Graph& app_graph) {
   StreamRuntime runtime;
   runtime.index = stream_index;
   runtime.url = url;
@@ -430,20 +425,29 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   runtime.profile.enabled = cfg.profile;
   runtime.profile.stream_index = stream_index;
 
-  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
+  const std::string suffix = std::to_string(stream_index);
+  const std::string model_name = "model_" + suffix;
+  const std::string video_name = "video_" + suffix;
+  const std::string debug_frame_name = "debug_frame_" + suffix;
+  const std::string detections_name = "detections_" + suffix;
+  const std::string debug_output_name = "debug_output_" + suffix;
+  runtime.output_name =
+      (!cfg.save_dir.empty() && cfg.save_every > 0) ? debug_output_name : detections_name;
+
   const bool save_debug_frames = !cfg.save_dir.empty() && cfg.save_every > 0;
-  std::vector<std::string> outputs = {"model"};
+  std::vector<std::string> outputs = {model_name};
   if (cfg.video_enabled) {
-    outputs.push_back("video");
+    outputs.push_back(video_name);
   }
   if (save_debug_frames) {
-    outputs.push_back("debug_frame");
+    outputs.push_back(debug_frame_name);
   }
+  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
   auto branch = simaai::neat::graphs::Branch("source", outputs);
 
   simaai::neat::GraphLinkOptions live_link_options;
   live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
-  runtime.graph.connect(source, branch);
+  app_graph.connect(source, branch);
   if (cfg.video_enabled) {
     auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
         runtime.frame_w, runtime.frame_h, runtime.output_fps);
@@ -452,41 +456,31 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     video_options.video_port_base = cfg.video_port_base;
     video_options.encoder.bitrate_kbps = 1000;
     runtime.video_port = video_options.video_port();
-    simaai::neat::Graph video_graph("video");
-    video_graph.connect(simaai::neat::nodes::Input("video"),
+    simaai::neat::Graph video_graph(video_name);
+    video_graph.connect(simaai::neat::nodes::Input(video_name),
                         simaai::neat::nodes::groups::VideoSender(video_options));
-    runtime.graph.connect(branch, video_graph, live_link_options);
+    app_graph.connect(branch, video_graph, live_link_options);
   }
 
-  simaai::neat::Graph model_graph("model");
-  model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
-  simaai::neat::Graph detections_graph("detections");
+  simaai::neat::Graph model_graph(model_name);
+  model_graph.connect(simaai::neat::nodes::Input(model_name), *runtime.model);
+  simaai::neat::Graph detections_graph(detections_name);
   detections_graph.add(
-      simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
-  runtime.graph.connect(branch, model_graph, live_link_options);
-  runtime.graph.connect(model_graph, detections_graph);
+      simaai::neat::nodes::Output(detections_name, simaai::neat::OutputOptions::EveryFrame(4)));
+  app_graph.connect(branch, model_graph, live_link_options);
+  app_graph.connect(model_graph, detections_graph);
 
   if (save_debug_frames) {
-    simaai::neat::Graph frames("debug_frame");
+    simaai::neat::Graph frames(debug_frame_name);
     frames.add(
-        simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
-    auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
-                                                    simaai::neat::CombinePolicy::ByFrame);
-    runtime.graph.connect(branch, frames);
-    runtime.graph.connect(frames, debug_join);
-    runtime.graph.connect(detections_graph, debug_join);
+        simaai::neat::nodes::Output(debug_frame_name, simaai::neat::OutputOptions::EveryFrame(4)));
+    auto debug_join =
+        simaai::neat::graphs::Combine({debug_frame_name, detections_name}, debug_output_name,
+                                      simaai::neat::CombinePolicy::ByFrame);
+    app_graph.connect(branch, frames, live_link_options);
+    app_graph.connect(frames, debug_join);
+    app_graph.connect(detections_graph, debug_join);
   }
-  if (cfg.profile) {
-    std::cout << "Backend stream=" << stream_index << ":\n"
-              << runtime.graph.describe_backend() << "\n";
-  }
-
-  simaai::neat::RunOptions run_options;
-  run_options.preset = simaai::neat::RunPreset::Realtime;
-  run_options.queue_depth = 3;
-  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
-  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
-  runtime.run = runtime.graph.build(run_options);
 
   simaai::neat::MetadataSenderOptions metadata_options;
   metadata_options.host = cfg.insight_host;
@@ -550,13 +544,12 @@ void maybe_save_debug_frame(const AppConfig& cfg, const StreamRuntime& stream,
   }
 }
 
-bool process_stream_once(StreamRuntime& stream, const AppConfig& cfg,
-                         const std::string& output_name) {
+bool process_stream_once(simaai::neat::Run& run, StreamRuntime& stream, const AppConfig& cfg) {
   constexpr int kPullTimeoutMs = 50;
   simaai::neat::Sample sample;
   simaai::neat::PullError pull_error;
   const double pull_start = sima_examples::time_ms();
-  const auto status = stream.run.pull(output_name, kPullTimeoutMs, sample, &pull_error);
+  const auto status = run.pull(stream.output_name, kPullTimeoutMs, sample, &pull_error);
   const double pull_end = sima_examples::time_ms();
   if (status == simaai::neat::PullStatus::Timeout) {
     return false;
@@ -592,24 +585,6 @@ bool process_stream_once(StreamRuntime& stream, const AppConfig& cfg,
   return true;
 }
 
-void consume_stream(StreamRuntime& stream, const AppConfig& cfg, const std::string& output_name,
-                    std::atomic_bool& stop_requested, std::exception_ptr& first_error,
-                    std::mutex& error_mutex) {
-  try {
-    while (!stop_requested.load() && g_stop_requested == 0 && !stream.closed &&
-           (cfg.frames <= 0 || stream.processed < cfg.frames)) {
-      (void)process_stream_once(stream, cfg, output_name);
-    }
-  } catch (...) {
-    {
-      std::lock_guard<std::mutex> lock(error_mutex);
-      if (!first_error)
-        first_error = std::current_exception();
-    }
-    stop_requested.store(true);
-  }
-}
-
 void run_app(const AppConfig& cfg) {
   g_stop_requested = 0;
   auto previous_sigint = std::signal(SIGINT, request_stop);
@@ -623,39 +598,44 @@ void run_app(const AppConfig& cfg) {
   }
 
   const auto labels = load_labels(cfg.labels_path);
+  simaai::neat::Graph app_graph("multi_stream");
   std::vector<StreamRuntime> streams;
   streams.reserve(cfg.rtsp_urls.size());
   for (std::size_t index = 0; index < cfg.rtsp_urls.size(); ++index) {
-    streams.push_back(
-        build_stream_runtime(cfg, static_cast<int>(index), cfg.rtsp_urls[index], labels));
+    streams.push_back(build_stream_runtime(cfg, static_cast<int>(index), cfg.rtsp_urls[index],
+                                           labels, app_graph));
   }
 
-  const std::string output_name =
-      (!cfg.save_dir.empty() && cfg.save_every > 0) ? "debug_output" : "detections";
-  std::atomic_bool stop_requested{false};
-  std::exception_ptr first_error;
-  std::mutex error_mutex;
-  std::vector<std::thread> consumers;
-  consumers.reserve(streams.size());
-  for (auto& stream : streams) {
-    consumers.emplace_back(consume_stream, std::ref(stream), std::cref(cfg), std::cref(output_name),
-                           std::ref(stop_requested), std::ref(first_error), std::ref(error_mutex));
+  if (cfg.profile) {
+    std::cout << "Backend:\n" << app_graph.describe_backend() << "\n";
   }
 
-  for (auto& consumer : consumers) {
-    if (consumer.joinable())
-      consumer.join();
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 3;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
+  auto run = app_graph.build(run_options);
+
+  bool all_done = false;
+  while (g_stop_requested == 0 && !all_done) {
+    all_done = true;
+    for (auto& stream : streams) {
+      if (stream.closed || (cfg.frames > 0 && stream.processed >= cfg.frames)) {
+        continue;
+      }
+      all_done = false;
+      (void)process_stream_once(run, stream, cfg);
+    }
   }
 
   for (auto& stream : streams) {
     stream.profile.flush();
-    stream.run.close();
     std::cout << "[stream " << stream.index << "] processed=" << stream.processed << "\n";
   }
+  run.close();
 
   std::signal(SIGINT, previous_sigint);
-  if (first_error)
-    std::rethrow_exception(first_error);
 }
 
 } // namespace

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -10,6 +10,7 @@ import json
 import os
 import struct
 import sys
+import threading
 import time
 
 import yaml
@@ -48,6 +49,8 @@ class StreamRuntime:
     index: int
     url: str
     model: object
+    graph: object
+    run: object
     metadata_sender: object
     labels: list[str]
     profile: "ProfileWindow"
@@ -400,18 +403,17 @@ def make_model(cfg: AppConfig):
 
 
 def build_stream_runtime(
-    cfg: AppConfig, stream_index: int, url: str, labels: list[str], app_graph
+    cfg: AppConfig, stream_index: int, url: str, labels: list[str]
 ) -> StreamRuntime:
     frame_w, frame_h, fps = probe_rtsp(url)
     output_fps = cfg.fps if cfg.fps > 0 else fps
     model = make_model(cfg)
 
-    suffix = str(stream_index)
-    model_name = f"model_{suffix}"
-    video_name = f"video_{suffix}"
-    debug_frame_name = f"debug_frame_{suffix}"
-    detections_name = f"detections_{suffix}"
-    debug_output_name = f"debug_output_{suffix}"
+    model_name = "model"
+    video_name = "video"
+    debug_frame_name = "debug_frame"
+    detections_name = "detections"
+    debug_output_name = "debug_output"
     output_name = debug_output_name if cfg.save_dir and cfg.save_every > 0 else detections_name
 
     source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, url, fps, frame_w, frame_h))
@@ -423,9 +425,10 @@ def build_stream_runtime(
         outputs.append(debug_frame_name)
     branch = pyneat.graphs.branch("source", outputs)
 
+    graph = pyneat.Graph()
     live_link_options = pyneat.GraphLinkOptions()
     live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
-    app_graph.connect(source, branch)
+    graph.connect(source, branch)
     video_port = 0
     if cfg.video_enabled:
         video_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, output_fps)
@@ -437,14 +440,14 @@ def build_stream_runtime(
 
         video_graph = pyneat.Graph(video_name)
         video_graph.connect(pyneat.nodes.input(video_name), pyneat.groups.video_sender(video_options))
-        app_graph.connect(branch, video_graph, live_link_options)
+        graph.connect(branch, video_graph, live_link_options)
 
     model_graph = pyneat.Graph(model_name)
     model_graph.connect(pyneat.nodes.input(model_name), model)
     detections_graph = pyneat.Graph(detections_name)
     detections_graph.add(pyneat.nodes.output(detections_name, pyneat.OutputOptions.every_frame(4)))
-    app_graph.connect(branch, model_graph, live_link_options)
-    app_graph.connect(model_graph, detections_graph)
+    graph.connect(branch, model_graph, live_link_options)
+    graph.connect(model_graph, detections_graph)
 
     if save_debug_frames:
         frames = pyneat.Graph(debug_frame_name)
@@ -452,9 +455,18 @@ def build_stream_runtime(
         debug_join = pyneat.graphs.combine(
             [debug_frame_name, detections_name], debug_output_name, pyneat.CombinePolicy.ByFrame
         )
-        app_graph.connect(branch, frames, live_link_options)
-        app_graph.connect(frames, debug_join)
-        app_graph.connect(detections_graph, debug_join)
+        graph.connect(branch, frames, live_link_options)
+        graph.connect(frames, debug_join)
+        graph.connect(detections_graph, debug_join)
+    if cfg.profile:
+        print(f"Backend stream={stream_index}:\n{graph.describe_backend()}")
+
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 3
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
+    run = graph.build(run_options)
 
     metadata_options = pyneat.MetadataSenderOptions()
     metadata_options.host = cfg.insight_host
@@ -472,6 +484,8 @@ def build_stream_runtime(
         index=stream_index,
         url=url,
         model=model,
+        graph=graph,
+        run=run,
         metadata_sender=metadata_sender,
         labels=labels,
         profile=ProfileWindow(cfg.profile, stream_index),
@@ -579,16 +593,16 @@ def maybe_save_debug_frame(cfg: AppConfig, stream: StreamRuntime, sample, boxes:
         print(f"[warn] failed to write output frame: {out_path}", file=sys.stderr)
 
 
-def process_stream_once(run, stream: StreamRuntime, cfg: AppConfig) -> bool:
+def process_stream_once(stream: StreamRuntime, cfg: AppConfig) -> bool:
     pull_start = time_ms()
-    sample = run.pull(stream.output_name, 50)
+    sample = stream.run.pull(stream.output_name, 50)
     pull_end = time_ms()
     if sample is None:
-        last_error_fn = getattr(run, "last_error", None)
+        last_error_fn = getattr(stream.run, "last_error", None)
         last_error = last_error_fn() if callable(last_error_fn) else ""
         if last_error:
             raise RuntimeError(f"stream {stream.index} runtime error: {last_error}")
-        running_fn = getattr(run, "running", None)
+        running_fn = getattr(stream.run, "running", None)
         if callable(running_fn) and not running_fn():
             stream.closed = True
         return False
@@ -607,6 +621,24 @@ def process_stream_once(run, stream: StreamRuntime, cfg: AppConfig) -> bool:
     return True
 
 
+def consume_stream(
+    stream: StreamRuntime,
+    cfg: AppConfig,
+    stop_event: threading.Event,
+    errors: list[Exception],
+) -> None:
+    try:
+        while (
+            not stop_event.is_set()
+            and not stream.closed
+            and (cfg.frames <= 0 or stream.processed < cfg.frames)
+        ):
+            process_stream_once(stream, cfg)
+    except Exception as exc:
+        errors.append(exc)
+        stop_event.set()
+
+
 def run_app(cfg: AppConfig) -> None:
     if cfg.profile:
         os.environ.setdefault("SIMA_GST_ELEMENT_TIMINGS", "1")
@@ -616,40 +648,41 @@ def run_app(cfg: AppConfig) -> None:
         Path(cfg.save_dir).mkdir(parents=True, exist_ok=True)
 
     labels = load_labels(cfg.labels_path)
-    graph = pyneat.Graph("multi_stream")
     streams = [
-        build_stream_runtime(cfg, index, url, labels, graph)
+        build_stream_runtime(cfg, index, url, labels)
         for index, url in enumerate(cfg.rtsp_urls)
     ]
-
-    if cfg.profile:
-        print(f"Backend:\n{graph.describe_backend()}")
-
-    run_options = pyneat.RunOptions()
-    run_options.preset = pyneat.RunPreset.Realtime
-    run_options.queue_depth = 3
-    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
-    run = graph.build(run_options)
+    stop_event = threading.Event()
+    errors: list[Exception] = []
+    consumers = [
+        threading.Thread(
+            target=consume_stream,
+            args=(stream, cfg, stop_event, errors),
+            name=f"stream-{stream.index}-consumer",
+        )
+        for stream in streams
+    ]
 
     try:
-        all_done = False
-        while not all_done:
-            all_done = True
-            for stream in streams:
-                if stream.closed or (
-                    cfg.frames > 0 and stream.processed >= cfg.frames
-                ):
-                    continue
-                all_done = False
-                process_stream_once(run, stream, cfg)
+        for consumer in consumers:
+            consumer.start()
+        for consumer in consumers:
+            consumer.join()
     except KeyboardInterrupt:
-        pass
+        stop_event.set()
+        raise
     finally:
-        run.close()
+        stop_event.set()
+        for stream in streams:
+            stream.run.close()
+        for consumer in consumers:
+            if consumer.is_alive():
+                consumer.join(timeout=2.0)
         for stream in streams:
             stream.profile.flush()
             print(f"[stream {stream.index}] processed={stream.processed}")
+    if errors:
+        raise errors[0]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -666,6 +699,8 @@ def main(argv: list[str] | None = None) -> int:
         load_runtime_dependencies()
         run_app(cfg)
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -379,6 +379,12 @@ def make_source_options(cfg: AppConfig, url: str, fps: int, width: int, height: 
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -418,6 +418,8 @@ def build_stream_runtime(
     branch = pyneat.graphs.branch("source", outputs)
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
     video_port = 0
     if cfg.video_enabled:
@@ -430,13 +432,13 @@ def build_stream_runtime(
 
         video_graph = pyneat.Graph("video")
         video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
-        graph.connect(branch, video_graph)
+        graph.connect(branch, video_graph, live_link_options)
 
     model_graph = pyneat.Graph("model")
     model_graph.connect(pyneat.nodes.input("model"), model)
     detections_graph = pyneat.Graph("detections")
     detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
-    graph.connect(branch, model_graph)
+    graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
 
     if save_debug_frames:

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -10,7 +10,6 @@ import json
 import os
 import struct
 import sys
-import threading
 import time
 
 import yaml
@@ -49,8 +48,6 @@ class StreamRuntime:
     index: int
     url: str
     model: object
-    graph: object
-    run: object
     metadata_sender: object
     labels: list[str]
     profile: "ProfileWindow"
@@ -58,6 +55,7 @@ class StreamRuntime:
     frame_h: int
     output_fps: int
     video_port: int
+    output_name: str
     processed: int = 0
     closed: bool = False
 
@@ -402,25 +400,32 @@ def make_model(cfg: AppConfig):
 
 
 def build_stream_runtime(
-    cfg: AppConfig, stream_index: int, url: str, labels: list[str]
+    cfg: AppConfig, stream_index: int, url: str, labels: list[str], app_graph
 ) -> StreamRuntime:
     frame_w, frame_h, fps = probe_rtsp(url)
     output_fps = cfg.fps if cfg.fps > 0 else fps
     model = make_model(cfg)
 
+    suffix = str(stream_index)
+    model_name = f"model_{suffix}"
+    video_name = f"video_{suffix}"
+    debug_frame_name = f"debug_frame_{suffix}"
+    detections_name = f"detections_{suffix}"
+    debug_output_name = f"debug_output_{suffix}"
+    output_name = debug_output_name if cfg.save_dir and cfg.save_every > 0 else detections_name
+
     source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, url, fps, frame_w, frame_h))
     save_debug_frames = bool(cfg.save_dir and cfg.save_every > 0)
-    outputs = ["model"]
+    outputs = [model_name]
     if cfg.video_enabled:
-        outputs.append("video")
+        outputs.append(video_name)
     if save_debug_frames:
-        outputs.append("debug_frame")
+        outputs.append(debug_frame_name)
     branch = pyneat.graphs.branch("source", outputs)
 
-    graph = pyneat.Graph()
     live_link_options = pyneat.GraphLinkOptions()
     live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
-    graph.connect(source, branch)
+    app_graph.connect(source, branch)
     video_port = 0
     if cfg.video_enabled:
         video_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, output_fps)
@@ -430,35 +435,26 @@ def build_stream_runtime(
         video_options.encoder.bitrate_kbps = 1000
         video_port = video_options.video_port
 
-        video_graph = pyneat.Graph("video")
-        video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
-        graph.connect(branch, video_graph, live_link_options)
+        video_graph = pyneat.Graph(video_name)
+        video_graph.connect(pyneat.nodes.input(video_name), pyneat.groups.video_sender(video_options))
+        app_graph.connect(branch, video_graph, live_link_options)
 
-    model_graph = pyneat.Graph("model")
-    model_graph.connect(pyneat.nodes.input("model"), model)
-    detections_graph = pyneat.Graph("detections")
-    detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
-    graph.connect(branch, model_graph, live_link_options)
-    graph.connect(model_graph, detections_graph)
+    model_graph = pyneat.Graph(model_name)
+    model_graph.connect(pyneat.nodes.input(model_name), model)
+    detections_graph = pyneat.Graph(detections_name)
+    detections_graph.add(pyneat.nodes.output(detections_name, pyneat.OutputOptions.every_frame(4)))
+    app_graph.connect(branch, model_graph, live_link_options)
+    app_graph.connect(model_graph, detections_graph)
 
     if save_debug_frames:
-        frames = pyneat.Graph("debug_frame")
-        frames.add(pyneat.nodes.output("debug_frame", pyneat.OutputOptions.every_frame(4)))
+        frames = pyneat.Graph(debug_frame_name)
+        frames.add(pyneat.nodes.output(debug_frame_name, pyneat.OutputOptions.every_frame(4)))
         debug_join = pyneat.graphs.combine(
-            ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByFrame
+            [debug_frame_name, detections_name], debug_output_name, pyneat.CombinePolicy.ByFrame
         )
-        graph.connect(branch, frames)
-        graph.connect(frames, debug_join)
-        graph.connect(detections_graph, debug_join)
-    if cfg.profile:
-        print(f"Backend stream={stream_index}:\n{graph.describe_backend()}")
-
-    run_options = pyneat.RunOptions()
-    run_options.preset = pyneat.RunPreset.Realtime
-    run_options.queue_depth = 3
-    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
-    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
-    run = graph.build(run_options)
+        app_graph.connect(branch, frames, live_link_options)
+        app_graph.connect(frames, debug_join)
+        app_graph.connect(detections_graph, debug_join)
 
     metadata_options = pyneat.MetadataSenderOptions()
     metadata_options.host = cfg.insight_host
@@ -476,8 +472,6 @@ def build_stream_runtime(
         index=stream_index,
         url=url,
         model=model,
-        graph=graph,
-        run=run,
         metadata_sender=metadata_sender,
         labels=labels,
         profile=ProfileWindow(cfg.profile, stream_index),
@@ -485,6 +479,7 @@ def build_stream_runtime(
         frame_h=frame_h,
         output_fps=output_fps,
         video_port=video_port,
+        output_name=output_name,
     )
 
 
@@ -584,12 +579,17 @@ def maybe_save_debug_frame(cfg: AppConfig, stream: StreamRuntime, sample, boxes:
         print(f"[warn] failed to write output frame: {out_path}", file=sys.stderr)
 
 
-def process_stream_once(stream: StreamRuntime, cfg: AppConfig, output_name: str) -> bool:
+def process_stream_once(run, stream: StreamRuntime, cfg: AppConfig) -> bool:
     pull_start = time_ms()
-    sample = stream.run.pull(output_name, 50)
+    sample = run.pull(stream.output_name, 50)
     pull_end = time_ms()
     if sample is None:
-        if hasattr(stream.run, "can_pull") and not stream.run.can_pull():
+        last_error_fn = getattr(run, "last_error", None)
+        last_error = last_error_fn() if callable(last_error_fn) else ""
+        if last_error:
+            raise RuntimeError(f"stream {stream.index} runtime error: {last_error}")
+        running_fn = getattr(run, "running", None)
+        if callable(running_fn) and not running_fn():
             stream.closed = True
         return False
 
@@ -607,25 +607,6 @@ def process_stream_once(stream: StreamRuntime, cfg: AppConfig, output_name: str)
     return True
 
 
-def consume_stream(
-    stream: StreamRuntime,
-    cfg: AppConfig,
-    output_name: str,
-    stop_event: threading.Event,
-    errors: list[Exception],
-) -> None:
-    try:
-        while (
-            not stop_event.is_set()
-            and not stream.closed
-            and (cfg.frames <= 0 or stream.processed < cfg.frames)
-        ):
-            process_stream_once(stream, cfg, output_name)
-    except Exception as exc:
-        errors.append(exc)
-        stop_event.set()
-
-
 def run_app(cfg: AppConfig) -> None:
     if cfg.profile:
         os.environ.setdefault("SIMA_GST_ELEMENT_TIMINGS", "1")
@@ -635,40 +616,40 @@ def run_app(cfg: AppConfig) -> None:
         Path(cfg.save_dir).mkdir(parents=True, exist_ok=True)
 
     labels = load_labels(cfg.labels_path)
+    graph = pyneat.Graph("multi_stream")
     streams = [
-        build_stream_runtime(cfg, index, url, labels) for index, url in enumerate(cfg.rtsp_urls)
-    ]
-    output_name = "debug_output" if cfg.save_dir and cfg.save_every > 0 else "detections"
-    stop_event = threading.Event()
-    errors: list[Exception] = []
-    consumers = [
-        threading.Thread(
-            target=consume_stream,
-            args=(stream, cfg, output_name, stop_event, errors),
-            name=f"stream-{stream.index}-consumer",
-        )
-        for stream in streams
+        build_stream_runtime(cfg, index, url, labels, graph)
+        for index, url in enumerate(cfg.rtsp_urls)
     ]
 
+    if cfg.profile:
+        print(f"Backend:\n{graph.describe_backend()}")
+
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 3
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
+    run = graph.build(run_options)
+
     try:
-        for consumer in consumers:
-            consumer.start()
-        for consumer in consumers:
-            consumer.join()
+        all_done = False
+        while not all_done:
+            all_done = True
+            for stream in streams:
+                if stream.closed or (
+                    cfg.frames > 0 and stream.processed >= cfg.frames
+                ):
+                    continue
+                all_done = False
+                process_stream_once(run, stream, cfg)
     except KeyboardInterrupt:
-        stop_event.set()
+        pass
     finally:
-        stop_event.set()
-        for stream in streams:
-            stream.run.close()
-        for consumer in consumers:
-            if consumer.is_alive():
-                consumer.join(timeout=2.0)
+        run.close()
         for stream in streams:
             stream.profile.flush()
             print(f"[stream {stream.index}] processed={stream.processed}")
-    if errors:
-        raise errors[0]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
@@ -12,6 +12,10 @@
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
 
+namespace {
+constexpr const char* kE2eInsightHost = "127.0.0.1";
+} // namespace
+
 int main(int argc, char** argv) {
   if (argc < 2) {
     std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
@@ -39,9 +43,6 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       : "127.0.0.1";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
@@ -50,7 +51,7 @@ int main(int argc, char** argv) {
   write_e2e_config("multi-stream-object-detector", config_path,
                    {{"model.path", model_path},
                     {"output.debug_dir", output_dir},
-                    {"output.insight.host", insight_host},
+                    {"output.insight.host", kE2eInsightHost},
                     {"output.insight.video_port_base", std::to_string(video_port_base)},
                     {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
                     {"inference.frames", "140"}},
@@ -58,7 +59,7 @@ int main(int argc, char** argv) {
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   MetadataJsonListenerOptions metadata_options;
-  metadata_options.host = insight_host;
+  metadata_options.host = kE2eInsightHost;
   metadata_options.base_port = metadata_port_base;
   metadata_options.num_ports = 2;
   metadata_options.timeout_ms = 5000;
@@ -70,8 +71,8 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const ProcessResult result =
-      spawn_and_wait(binary, {"--config", config_path.string()}, timeout_ms);
+  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
+                                                        output_dir, total_saved_frames, timeout_ms);
 
   int rc = 0;
   if (result.exit_code != 0) {

--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_e2e.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_e2e.py
@@ -9,9 +9,12 @@ import sys
 
 import pytest
 
+from tests.utils.metadata_json_listener import MetadataJsonListener
+
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+E2E_INSIGHT_HOST = "127.0.0.1"
 
 
 def _runtime_deps_ready() -> bool:
@@ -21,10 +24,6 @@ def _runtime_deps_ready() -> bool:
 def _env_int_or_default(name: str, default: int) -> int:
     raw = os.environ.get(name, "").strip()
     return int(raw) if raw else default
-
-
-def _env_str_or_default(name: str, default: str) -> str:
-    return os.environ.get(name, "").strip() or default
 
 
 @pytest.mark.e2e
@@ -47,21 +46,18 @@ class TestE2E:
         skip_unless_e2e_ready(len(rtsp_urls) >= 2, "need at least two RTSP URLs for multistream e2e")
         output_cfg = e2e_config_section("multi-stream-object-detector", "testing.e2e.output")
         total_saved_frames = int(output_cfg["total_saved_frames"])
+        metadata_port_base = _env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100)
 
         config_path = e2e_config_writer(
             {
                 "streams": rtsp_urls[:2],
                 "output": {
                     "insight": {
-                        "host": _env_str_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_HOST", "127.0.0.1"
-                        ),
+                        "host": E2E_INSIGHT_HOST,
                         "video_port_base": _env_int_or_default(
                             "SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000
                         ),
-                        "metadata_port_base": _env_int_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100
-                        ),
+                        "metadata_port_base": metadata_port_base,
                     },
                     "debug_dir": str(tmp_output_dir),
                 },
@@ -74,17 +70,28 @@ class TestE2E:
             "--config",
             str(config_path),
         ]
-        result = run_until_output_files(
-            cmd,
-            tmp_output_dir,
-            total_saved_frames,
-            test_timeout_ms / 1000,
-            cwd=str(EXAMPLE_DIR),
-        )
+        with MetadataJsonListener(
+            E2E_INSIGHT_HOST,
+            metadata_port_base,
+            num_ports=2,
+            require_all_ports=True,
+        ) as metadata_listener:
+            result = run_until_output_files(
+                cmd,
+                tmp_output_dir,
+                total_saved_frames,
+                test_timeout_ms / 1000,
+                cwd=str(EXAMPLE_DIR),
+            )
+            metadata = metadata_listener.wait_for_messages(5.0)
 
         assert result.returncode == 0, (
             f"main.py exited with code {result.returncode}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert metadata.success, (
+            "object-detection metadata was not received on all streams: "
+            f"{metadata.error}"
         )
 
         files = [

--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
@@ -180,6 +180,7 @@ class TestMetadata:
             frame_h=100,
             output_fps=30,
             video_port=9000,
+            output_name="detections",
         )
         boxes = [
             {

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -49,7 +49,7 @@ The sample is split into three independent runtime stages:
    The model stage is isolated from transport logic so detection behavior can be debugged separately from RTSP or Insight issues.
 
 3. `Insight output`
-   The original decoded frame is pushed into `VideoSender`. The nodegroup owns the raw-frame video transport path, including conversion, H.264 encoding, RTP packetization, and UDP output. Detection results from the YOLO path are converted into Insight metadata and sent on the metadata side channel.
+   The original decoded frame is pushed into `VideoSender`. The nodegroup owns the raw-frame video transport path, including conversion, raw NV12 caps, H.264 encoding, RTP packetization, and UDP output. Detection results from the YOLO path are converted into Insight metadata and sent on the metadata side channel.
 
 ## Neat Library API Usage
 
@@ -120,7 +120,7 @@ cd ../..
 - The sample always publishes to Insight.
 - Video is sent to the configured Insight video UDP port.
 - Detection metadata is sent to the configured Insight metadata UDP port.
-- The app adds only the `VideoSender` nodegroup for video output. It does not manually add lower-level color conversion, encoder, parser, packetizer, or UDP nodes.
+- The app adds only the `VideoSender` nodegroup for video output. It does not manually add lower-level color conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes.
 - This example feeds raw decoded frames to `VideoSender` with the raw-frame option. If an upstream pipeline already produces H.264, `VideoSender` also supports the encoded-input option, where it parses, packetizes, and sends without re-encoding.
 - `model.path` must point to a valid YOLO compiled model package file.
 - `source.rtsp_url` must be set before running.

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -34,7 +34,7 @@ Insight is SiMa.ai's lightweight, cross-platform development and visualization t
 
 For this sample, the most important part is the viewer/output contract: the application sends video on the Insight video channel and sends detection metadata as JSON on the Insight side channel. That allows the browser UI to display the live stream together with object detections without relying on external tools such as `ffplay`, VLC, or ad hoc debug viewers.
 
-For more information regarding Insight, please refer to this [page](https://docs.sima.ai/pages/insight/main.html#).
+For more information regarding Insight, please refer to this [page](https://developer.sima.ai/software/tools/insight).
 
 ## Architecture
 The sample is split into three independent runtime stages:
@@ -271,4 +271,4 @@ Python-specific notes:
 - C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
 - Python source: `src/python/main.py`
 - Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Insight documentation: <https://docs.sima.ai/pages/insight/main.html>
+- Insight documentation: <https://developer.sima.ai/software/tools/insight>

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -344,9 +344,11 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   detections_graph.add(
       simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
-  runtime.graph.connect(branch, video_graph);
-  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(branch, video_graph, live_link_options);
+  runtime.graph.connect(branch, model_graph, live_link_options);
   runtime.graph.connect(model_graph, detections_graph);
   if (save_debug_frames) {
     simaai::neat::Graph frames("debug_frame");

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -283,6 +283,14 @@ make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& hei
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -348,7 +348,11 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
   runtime.graph.connect(branch, video_graph, live_link_options);
-  runtime.graph.connect(branch, model_graph, live_link_options);
+  if (save_debug_frames) {
+    runtime.graph.connect(branch, model_graph);
+  } else {
+    runtime.graph.connect(branch, model_graph, live_link_options);
+  }
   runtime.graph.connect(model_graph, detections_graph);
   if (save_debug_frames) {
     simaai::neat::Graph frames("debug_frame");
@@ -356,7 +360,7 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
         simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
     auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
                                                     simaai::neat::CombinePolicy::ByPts);
-    runtime.graph.connect(branch, frames, live_link_options);
+    runtime.graph.connect(branch, frames);
     runtime.graph.connect(frames, debug_join);
     runtime.graph.connect(detections_graph, debug_join);
   }

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -356,7 +356,7 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
         simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
     auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
                                                     simaai::neat::CombinePolicy::ByPts);
-    runtime.graph.connect(branch, frames);
+    runtime.graph.connect(branch, frames, live_link_options);
     runtime.graph.connect(frames, debug_join);
     runtime.graph.connect(detections_graph, debug_join);
   }

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -413,7 +413,10 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
     graph.connect(branch, video_graph, live_link_options)
-    graph.connect(branch, model_graph, live_link_options)
+    if save_debug_frames:
+        graph.connect(branch, model_graph)
+    else:
+        graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
     if save_debug_frames:
         frames = pyneat.Graph("debug_frame")
@@ -421,7 +424,7 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
         debug_join = pyneat.graphs.combine(
             ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByPts
         )
-        graph.connect(branch, frames, live_link_options)
+        graph.connect(branch, frames)
         graph.connect(frames, debug_join)
         graph.connect(detections_graph, debug_join)
     if cfg.profile:

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -421,7 +421,7 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
         debug_join = pyneat.graphs.combine(
             ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByPts
         )
-        graph.connect(branch, frames)
+        graph.connect(branch, frames, live_link_options)
         graph.connect(frames, debug_join)
         graph.connect(detections_graph, debug_join)
     if cfg.profile:

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -359,6 +359,12 @@ def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -609,6 +609,8 @@ def main(argv: list[str] | None = None) -> int:
         finally:
             runtime.run.close()
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -409,9 +409,11 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
-    graph.connect(branch, video_graph)
-    graph.connect(branch, model_graph)
+    graph.connect(branch, video_graph, live_link_options)
+    graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
     if save_debug_frames:
         frames = pyneat.Graph("debug_frame")

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -90,6 +90,7 @@ After this setup, follow the example-specific commands below.
 - Masks are rendered into the video stream. Metadata contains object labels, confidences, and boxes.
 - `output.save_dir` and `output.save_every` can be used to save sampled annotated frames.
 - The model path uses model-managed preprocessing with `COCO_YOLO` normalization and `YoloV26Seg` decode.
+- Insight video is sent through `VideoSender`; the app passes raw frames plus stream geometry, and the nodegroup owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output.
 
 ## Command-Line Options
 - `--config <path>`

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -339,6 +339,14 @@ make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& hei
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -558,9 +558,11 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   auto joined = simaai::neat::graphs::Combine({"frame", "segments"}, "segmentation_output",
                                               simaai::neat::CombinePolicy::ByFrame);
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
-  runtime.graph.connect(branch, frame_graph);
-  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(branch, frame_graph, live_link_options);
+  runtime.graph.connect(branch, model_graph, live_link_options);
   runtime.graph.connect(model_graph, segments_graph);
   runtime.graph.connect(frame_graph, joined);
   runtime.graph.connect(segments_graph, joined);

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -558,11 +558,9 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   auto joined = simaai::neat::graphs::Combine({"frame", "segments"}, "segmentation_output",
                                               simaai::neat::CombinePolicy::ByFrame);
 
-  simaai::neat::GraphLinkOptions live_link_options;
-  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
-  runtime.graph.connect(branch, frame_graph, live_link_options);
-  runtime.graph.connect(branch, model_graph, live_link_options);
+  runtime.graph.connect(branch, frame_graph);
+  runtime.graph.connect(branch, model_graph);
   runtime.graph.connect(model_graph, segments_graph);
   runtime.graph.connect(frame_graph, joined);
   runtime.graph.connect(segments_graph, joined);

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -449,6 +449,12 @@ def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -531,9 +531,11 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     )
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
-    graph.connect(branch, frame_graph)
-    graph.connect(branch, model_graph)
+    graph.connect(branch, frame_graph, live_link_options)
+    graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, segments_graph)
     graph.connect(frame_graph, joined)
     graph.connect(segments_graph, joined)

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -531,11 +531,9 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     )
 
     graph = pyneat.Graph()
-    live_link_options = pyneat.GraphLinkOptions()
-    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
-    graph.connect(branch, frame_graph, live_link_options)
-    graph.connect(branch, model_graph, live_link_options)
+    graph.connect(branch, frame_graph)
+    graph.connect(branch, model_graph)
     graph.connect(model_graph, segments_graph)
     graph.connect(frame_graph, joined)
     graph.connect(segments_graph, joined)
@@ -805,6 +803,8 @@ def main(argv: list[str] | None = None) -> int:
         finally:
             runtime.video_run.close()
             runtime.run.close()
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -19,7 +19,7 @@ Both the Python and C++ entrypoints use one complete graph per RTSP stream:
 ```text
 RtspDecodedInput
   -> Branch(video, model[, debug_frame])
-    -> video: VideoSender(H.264 RTP/UDP)
+    -> video: VideoSender(raw caps + H.264 RTP/UDP)
     -> model: YOLO26 model.graph() -> Output(detections)
     -> debug only: Combine(debug_frame, detections, ByFrame) -> debug_output
 ```
@@ -92,6 +92,7 @@ After this setup, follow the example-specific commands below.
 - `inference.min_score`, `inference.nms_iou`, and `inference.max_detections` are explicit detector decode parameters in the checked-in config.
 - The example defaults to person class id `0`, and tracker behavior is configurable from the config file.
 - Both C++ and Python add the `VideoSender` nodegroup for video transport and use `model.graph()` for model-owned preprocessing, inference, and YOLO26 decode.
+- `VideoSender` owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. The app does not add those lower-level nodes itself.
 - Debug saves use `Combine(ByFrame)` so saved frames and tracks stay aligned.
 
 ## Command-Line Options

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -663,8 +663,9 @@ void run_app(const AppConfig& cfg) {
   }
 
   std::signal(SIGINT, previous_sigint);
-  if (first_error)
+  if (first_error) {
     std::rethrow_exception(first_error);
+  }
 }
 
 } // namespace

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -390,6 +390,14 @@ make_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, 
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -443,6 +443,8 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   }
   auto branch = simaai::neat::graphs::Branch("source", outputs);
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
   if (cfg.video_enabled) {
     auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
@@ -455,7 +457,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     simaai::neat::Graph video_graph("video");
     video_graph.connect(simaai::neat::nodes::Input("video"),
                         simaai::neat::nodes::groups::VideoSender(video_options));
-    runtime.graph.connect(branch, video_graph);
+    runtime.graph.connect(branch, video_graph, live_link_options);
   }
 
   simaai::neat::Graph model_graph("model");
@@ -463,7 +465,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   simaai::neat::Graph detections_graph("detections");
   detections_graph.add(
       simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
-  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(branch, model_graph, live_link_options);
   runtime.graph.connect(model_graph, detections_graph);
 
   if (save_debug_frames) {

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -674,6 +674,7 @@ def run_app(cfg: AppConfig) -> None:
             consumer.join()
     except KeyboardInterrupt:
         stop_event.set()
+        raise
     finally:
         stop_event.set()
         for stream in streams:
@@ -702,6 +703,8 @@ def main(argv: list[str] | None = None) -> int:
         load_runtime_dependencies()
         run_app(cfg)
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -427,6 +427,8 @@ def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamR
     branch = pyneat.graphs.branch("source", outputs)
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
     video_port = 0
     if cfg.video_enabled:
@@ -439,13 +441,13 @@ def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamR
 
         video_graph = pyneat.Graph("video")
         video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
-        graph.connect(branch, video_graph)
+        graph.connect(branch, video_graph, live_link_options)
 
     model_graph = pyneat.Graph("model")
     model_graph.connect(pyneat.nodes.input("model"), model)
     detections_graph = pyneat.Graph("detections")
     detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
-    graph.connect(branch, model_graph)
+    graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
 
     if save_debug_frames:

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -390,6 +390,12 @@ def make_source_options(cfg: AppConfig, url: str, fps: int, width: int, height: 
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 

--- a/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
+++ b/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
@@ -12,6 +12,10 @@
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
 
+namespace {
+constexpr const char* kE2eInsightHost = "127.0.0.1";
+} // namespace
+
 int main(int argc, char** argv) {
   if (argc < 2) {
     std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
@@ -39,9 +43,6 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       : "127.0.0.1";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
@@ -50,7 +51,7 @@ int main(int argc, char** argv) {
   write_e2e_config("multi-stream-people-tracker", config_path,
                    {{"model.path", model_path},
                     {"output.debug_dir", output_dir},
-                    {"output.insight.host", insight_host},
+                    {"output.insight.host", kE2eInsightHost},
                     {"output.insight.video_port_base", std::to_string(video_port_base)},
                     {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
                     {"inference.frames", "140"}},
@@ -58,7 +59,7 @@ int main(int argc, char** argv) {
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   MetadataJsonListenerOptions metadata_options;
-  metadata_options.host = insight_host;
+  metadata_options.host = kE2eInsightHost;
   metadata_options.base_port = metadata_port_base;
   metadata_options.num_ports = 2;
   metadata_options.timeout_ms = 5000;
@@ -72,8 +73,8 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const ProcessResult result =
-      spawn_and_wait(binary, {"--config", config_path.string()}, timeout_ms);
+  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
+                                                        output_dir, total_saved_frames, timeout_ms);
 
   int rc = 0;
   if (result.exit_code != 0) {

--- a/examples/tracking/multi-stream-people-tracker/tests/python/test_e2e.py
+++ b/examples/tracking/multi-stream-people-tracker/tests/python/test_e2e.py
@@ -9,9 +9,12 @@ import sys
 
 import pytest
 
+from tests.utils.metadata_json_listener import MetadataJsonListener
+
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+E2E_INSIGHT_HOST = "127.0.0.1"
 
 
 def _runtime_deps_ready() -> bool:
@@ -21,10 +24,6 @@ def _runtime_deps_ready() -> bool:
 def _env_int_or_default(name: str, default: int) -> int:
     raw = os.environ.get(name, "").strip()
     return int(raw) if raw else default
-
-
-def _env_str_or_default(name: str, default: str) -> str:
-    return os.environ.get(name, "").strip() or default
 
 
 @pytest.mark.e2e
@@ -47,21 +46,18 @@ class TestE2E:
         skip_unless_e2e_ready(len(rtsp_urls) >= 2, "need at least two RTSP URLs for multistream e2e")
         output_cfg = e2e_config_section("multi-stream-people-tracker", "testing.e2e.output")
         total_saved_frames = int(output_cfg["total_saved_frames"])
+        metadata_port_base = _env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100)
 
         config_path = e2e_config_writer(
             {
                 "streams": rtsp_urls[:2],
                 "output": {
                     "insight": {
-                        "host": _env_str_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_HOST", "127.0.0.1"
-                        ),
+                        "host": E2E_INSIGHT_HOST,
                         "video_port_base": _env_int_or_default(
                             "SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000
                         ),
-                        "metadata_port_base": _env_int_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100
-                        ),
+                        "metadata_port_base": metadata_port_base,
                     },
                     "debug_dir": str(tmp_output_dir),
                 },
@@ -77,17 +73,29 @@ class TestE2E:
             "--config",
             str(config_path),
         ]
-        result = run_until_output_files(
-            cmd,
-            tmp_output_dir,
-            0,
-            test_timeout_ms / 1000,
-            cwd=str(EXAMPLE_DIR),
-        )
+        with MetadataJsonListener(
+            E2E_INSIGHT_HOST,
+            metadata_port_base,
+            num_ports=2,
+            metadata_type="tracking",
+            data_array_key="tracks",
+            require_all_ports=True,
+        ) as metadata_listener:
+            result = run_until_output_files(
+                cmd,
+                tmp_output_dir,
+                total_saved_frames,
+                test_timeout_ms / 1000,
+                cwd=str(EXAMPLE_DIR),
+            )
+            metadata = metadata_listener.wait_for_messages(5.0)
 
         assert result.returncode == 0, (
             f"main.py exited with code {result.returncode}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert metadata.success, (
+            f"tracking metadata was not received on all streams: {metadata.error}"
         )
 
         files = [

--- a/tests/utils/metadata_json_listener.py
+++ b/tests/utils/metadata_json_listener.py
@@ -1,0 +1,138 @@
+"""Test-only UDP listener for Insight metadata JSON."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import select
+import socket
+import time
+
+
+@dataclass(frozen=True)
+class MetadataJsonMessage:
+    port: int
+    payload: str
+    frame_id: str
+    timestamp_ms: int
+    object_count: int
+
+
+@dataclass(frozen=True)
+class MetadataJsonResult:
+    success: bool
+    ports_with_valid_json: set[int] = field(default_factory=set)
+    messages: list[MetadataJsonMessage] = field(default_factory=list)
+    error: str = ""
+
+
+class MetadataJsonListener:
+    """Receive metadata JSON emitted by e2e examples."""
+
+    def __init__(
+        self,
+        host: str,
+        base_port: int,
+        num_ports: int,
+        metadata_type: str = "object-detection",
+        data_array_key: str = "objects",
+        require_all_ports: bool = False,
+    ) -> None:
+        if num_ports <= 0:
+            raise ValueError("num_ports must be > 0")
+        if base_port <= 0:
+            raise ValueError("base_port must be > 0")
+
+        self._metadata_type = metadata_type
+        self._data_array_key = data_array_key
+        self._require_all_ports = require_all_ports
+        self._sockets: dict[socket.socket, int] = {}
+        try:
+            for offset in range(num_ports):
+                port = base_port + offset
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind((host, port))
+                sock.setblocking(False)
+                self._sockets[sock] = port
+        except Exception:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        for sock in self._sockets:
+            sock.close()
+        self._sockets.clear()
+
+    def __enter__(self) -> "MetadataJsonListener":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def wait_for_messages(self, timeout_s: float) -> MetadataJsonResult:
+        ports_with_valid_json: set[int] = set()
+        messages: list[MetadataJsonMessage] = []
+        last_error = "metadata timeout"
+        deadline = time.monotonic() + timeout_s
+
+        while time.monotonic() < deadline:
+            remaining = max(0.0, deadline - time.monotonic())
+            readable, _, _ = select.select(list(self._sockets.keys()), [], [], min(0.2, remaining))
+            for sock in readable:
+                payload, _ = sock.recvfrom(65536)
+                port = self._sockets[sock]
+                message, error = self._parse_message(port, payload)
+                if message is None:
+                    last_error = error
+                    continue
+                messages.append(message)
+                ports_with_valid_json.add(port)
+                if self._success_reached(ports_with_valid_json):
+                    return MetadataJsonResult(True, ports_with_valid_json, messages)
+
+        missing = sorted(set(self._sockets.values()) - ports_with_valid_json)
+        if missing:
+            last_error = f"missing metadata on ports {missing}; last_error={last_error}"
+        return MetadataJsonResult(False, ports_with_valid_json, messages, last_error)
+
+    def _success_reached(self, ports_with_valid_json: set[int]) -> bool:
+        if self._require_all_ports:
+            return len(ports_with_valid_json) == len(self._sockets)
+        return bool(ports_with_valid_json)
+
+    def _parse_message(
+        self, port: int, payload: bytes
+    ) -> tuple[MetadataJsonMessage | None, str]:
+        try:
+            parsed = json.loads(payload.decode("utf-8"))
+        except Exception as exc:
+            return None, f"json parse failed: {exc}"
+
+        if not isinstance(parsed, dict):
+            return None, "json root is not an object"
+        if parsed.get("type") != self._metadata_type:
+            return None, "missing or invalid type"
+        timestamp = parsed.get("timestamp")
+        if not isinstance(timestamp, int):
+            return None, "missing or invalid timestamp"
+        frame_id = parsed.get("frame_id")
+        if not isinstance(frame_id, str):
+            return None, "missing or invalid frame_id"
+        data = parsed.get("data")
+        if not isinstance(data, dict):
+            return None, "missing or invalid data"
+        objects = data.get(self._data_array_key)
+        if not isinstance(objects, list):
+            return None, f"missing or invalid data.{self._data_array_key}"
+
+        return (
+            MetadataJsonMessage(
+                port=port,
+                payload=payload.decode("utf-8", errors="replace"),
+                frame_id=frame_id,
+                timestamp_ms=timestamp,
+                object_count=len(objects),
+            ),
+            "",
+        )


### PR DESCRIPTION
## Summary
Forward `2.1.1-prep` into `develop` after the RTSP / VideoSender fixes landed on the prep branch.

This PR includes:
- Apps manifest prep for platform `2.1.2` while keeping core resolution on `policy=snap`
- public docs and portal link updates from #256
- RTSP decoded-output caps for examples that feed raw video into model and VideoSender paths
- `RealtimeLatestByStream` on live RTSP branch edges where stale frames should not backpressure the graph
- lossless/default links for strict debug-frame joins that must preserve matching PTS
- multi-stream object detector scheduling aligned with the tracker pattern: one graph/run and one consumer thread per stream
- Insight SDK port defaults for the affected configs/examples
- Python unit fixture updates for the multi-stream object detector runtime output name
- multistream E2E metadata checks for object detection and tracking on all configured streams

This PR intentionally does not include `sandbox/DEBUG`. The `sandbox/` tree remains ignored by `.gitignore`, so local debug probes stay local-only.

## Why
The prep branch contains the app-side pieces needed for the 2.1.2 RTSP validation work.

Core/runtime handles the VideoSender caps contract and codec service packaging. Apps still need to publish the correct RTSP caps, live branch policy, port defaults, and multistream scheduling pattern so examples behave consistently on Modalix/SDK + Insight.

The debug-save path uses strict `ByPts` combine. Branches feeding that join must keep default/lossless link behavior. Latest/drop link policy is correct for live video/model branches where stale frames are acceptable, but it can break strict frame/detection pairing.

The multistream E2E tests also need to run as board-local tests. The metadata listeners now bind to `127.0.0.1` and the test configs send metadata to that same local address. This avoids trying to bind listener sockets to the SDK/Insight host address from inside the board test process.

## Included PRs / Change Groups
- #256: public developer examples/docs link cleanup
- #257: RTSP decoded output caps, live branch scheduling, and multistream detector isolation
- #259: strict debug-frame join fix and Python unit fixture update
- latest branch commits: multistream metadata E2E alignment for C++ and Python

## Validation
Latest local/source checks:

```text
git diff --check
python3 -m py_compile examples/object-detection/single-stream-object-detector/src/python/main.py examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
python3 -m pytest examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py -q
# 7 passed, 1 warning
```

Manifest validation run earlier on the release-prep branch:

```text
python3 -m json.tool deps/manifest.json >/dev/null
python3 -m pytest tests/scripts/test_manifest_contract.py
```

Manual runtime validation performed on Modalix with the paired core/internals branch:

```text
multi-stream object detector runs with video + metadata visible in Insight
codec daemons owned by neat-runtime and restarted from the updated package
```

The latest E2E commit is intended to address the two observed test-harness failures:

```text
C++ multistream E2E: metadata listener bind failed on 192.168.2.1
Python tracker E2E: run_until_output_files was called with expected_files=0 and timed out
```

Full Python/C++ E2E should be rerun on the board after the branch update.

## Notes
This is a branch-forward PR from `2.1.1-prep` to `develop`. The branch history was kept clean of local sandbox debug scripts.
