### PR TITLE
docs: update apps portal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Examples are organized under `examples/<category>/<example>`. Each example is so
 | `examples/<category>/<example>/src/common/` | Files shared by the example implementations |
 
 > **IMPORTANT:** Use this structure when reading, extending, or adding examples, and follow each example README for any example-specific entrypoints.
-> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
+> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://developer.sima.ai/examples>).
 
 ### Contributor Guidelines
 

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -34,7 +34,7 @@ Insight is SiMa.ai's lightweight, cross-platform development and visualization t
 
 For this sample, the most important part is the viewer/output contract: the application sends video on the Insight video channel and sends detection metadata as JSON on the Insight side channel. That allows the browser UI to display the live stream together with object detections without relying on external tools such as `ffplay`, VLC, or ad hoc debug viewers.
 
-For more information regarding Insight, please refer to this [page](https://docs.sima.ai/pages/insight/main.html#).
+For more information regarding Insight, please refer to this [page](https://developer.sima.ai/software/tools/insight).
 
 ## Architecture
 The sample is split into three independent runtime stages:
@@ -271,4 +271,4 @@ Python-specific notes:
 - C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
 - Python source: `src/python/main.py`
 - Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Insight documentation: <https://docs.sima.ai/pages/insight/main.html>
+- Insight documentation: <https://developer.sima.ai/software/tools/insight>


### PR DESCRIPTION
## Summary

Update apps documentation links that pointed at legacy public documentation hosts:

- Root apps README now points to `https://developer.sima.ai/examples`.
- The single-stream object detector Insight docs references now point to `https://developer.sima.ai/software/tools/insight`.

Installer, artifact, and model package download URLs are intentionally unchanged.

## Self-review

No merge-blocking issues found. The diff is limited to public documentation links in README files. It does not change runtime behavior, portal build output, installer URLs, download tooling, CI publishing, test-scope model acquisition, or generated catalog data.

`docs.sima.ai` was scanned in the apps repo. After this update, the remaining `docs.sima.ai` references are all `/pkg_downloads/...` model package URLs used by README download commands and `tests/test-scope.yaml`; those should not be replaced with Developer Center page URLs without a confirmed artifact-host migration path.

Stale portal links found in core docs live in the separate `core` repository and need a separate PR there.

## Validation

- `git diff --check`
- `python3 scripts/validate_readmes.py --root .`
- `python3 scripts/generate_catalog.py >/tmp/apps-catalog.json`
- `rg -n "docs\.sima\.ai" . | rg -v "/pkg_downloads/"` returned no non-package-download hits

## CI

Vulcan CI restarted after the follow-up commit. Resolve jobs had previously passed; latest status should be checked before merge.

## Merge readiness

Safe with CI pending. No board/runtime validation needed for this docs-only change.