### PR TITLE
fix(rtsp): preserve strict debug joins

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
@@ -180,6 +180,7 @@ class TestMetadata:
             frame_h=100,
             output_fps=30,
             video_port=9000,
+            output_name="detections",
         )
         boxes = [
             {

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -348,7 +348,11 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
   runtime.graph.connect(branch, video_graph, live_link_options);
-  runtime.graph.connect(branch, model_graph, live_link_options);
+  if (save_debug_frames) {
+    runtime.graph.connect(branch, model_graph);
+  } else {
+    runtime.graph.connect(branch, model_graph, live_link_options);
+  }
   runtime.graph.connect(model_graph, detections_graph);
   if (save_debug_frames) {
     simaai::neat::Graph frames("debug_frame");
@@ -356,7 +360,7 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
         simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
     auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
                                                     simaai::neat::CombinePolicy::ByPts);
-    runtime.graph.connect(branch, frames, live_link_options);
+    runtime.graph.connect(branch, frames);
     runtime.graph.connect(frames, debug_join);
     runtime.graph.connect(detections_graph, debug_join);
   }

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -413,7 +413,10 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
     graph.connect(branch, video_graph, live_link_options)
-    graph.connect(branch, model_graph, live_link_options)
+    if save_debug_frames:
+        graph.connect(branch, model_graph)
+    else:
+        graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
     if save_debug_frames:
         frames = pyneat.Graph("debug_frame")
@@ -421,7 +424,7 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
         debug_join = pyneat.graphs.combine(
             ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByPts
         )
-        graph.connect(branch, frames, live_link_options)
+        graph.connect(branch, frames)
         graph.connect(frames, debug_join)
         graph.connect(detections_graph, debug_join)
     if cfg.profile:


### PR DESCRIPTION
## Summary
Fix the RTSP debug-save path after adding `RealtimeLatestByStream` to live branches.

Changes:
- keep VideoSender on `RealtimeLatestByStream`
- keep branches feeding the strict debug-frame `Combine(ByPts)` on default/lossless links
- update the multi-stream object detector Python unit fixture to pass the new `output_name`

## Why
The single-stream object detector e2e debug-save path joins `debug_frame` and `detections` with strict `ByPts`. `RealtimeLatestByStream` can drop or replace stale samples, which can leave the join without a matching timestamp partner and fail with:

```text
JoinBundle: missing pts_ns for strict ByPts combine
```

Realtime latest is still correct for the terminal VideoSender branch. It is not correct for branches that must feed a strict frame/timestamp join.

## Validation
Run locally before pushing:

```text
clang-format -i examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
python3 -m py_compile examples/object-detection/single-stream-object-detector/src/python/main.py examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
python3 -m pytest examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py -q
# 7 passed, 1 warning
git diff --check
```

## Notes
This PR intentionally contains no `sandbox/` changes.
