### PR TITLE
Pin Apps to codec service core artifact

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,15 @@ sanitize_branch_key() {
   printf '%s' "$1" | tr '/ ' '--'
 }
 
+core_artifact_branch_key() {
+  python3 - "$1" <<'PY'
+import sys
+import urllib.parse
+
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+}
+
 git_short_sha() {
   if [[ -n "${NEAT_APPS_ARTIFACT_SHORT_SHA:-}" ]]; then
     printf '%.7s\n' "${NEAT_APPS_ARTIFACT_SHORT_SHA}"
@@ -416,7 +425,7 @@ core_artifact_version_exists() {
     return 1
   fi
 
-  branch_key="$(sanitize_branch_key "${branch}")"
+  branch_key="$(core_artifact_branch_key "${branch}")"
   download_text "${NEAT_ARTIFACTS_BASE_URL}/${branch_key}/${version}/metadata.json" >/dev/null 2>&1
 }
 
@@ -548,7 +557,7 @@ resolve_latest_version() {
   local branch_key cache_key cache_path missing_path latest_url
   local resolved=""
 
-  branch_key="$(sanitize_branch_key "${branch}")"
+  branch_key="$(core_artifact_branch_key "${branch}")"
   cache_key="$(printf '%s' "${branch_key}" | tr -c 'A-Za-z0-9._-' '_')"
   cache_path="${LATEST_TAG_CACHE_DIR}/${cache_key}.tag"
   missing_path="${LATEST_TAG_CACHE_DIR}/${cache_key}.missing"

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,8 @@ core_artifact_branch_key() {
 import sys
 import urllib.parse
 
-print(urllib.parse.quote(sys.argv[1], safe=""))
+ref_key = urllib.parse.quote(sys.argv[1], safe="")
+print(urllib.parse.quote(ref_key, safe=""))
 PY
 }
 

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,6 +1,7 @@
 {
   "neat-core": {
-    "policy": "snap"
+    "branch": "codex/internals-linux-codec-service",
+    "spec": "4d4688395032"
   },
   "sdk": {
     "channel": "develop"

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -178,7 +178,7 @@ def _run_build(
                 [
                     "develop=devsha1",
                     "main=mainsha1",
-                    "feature%2Fcore-artifact=featsha2",
+                    "feature%252Fcore-artifact=featsha2",
                     "zz-core-artifact-for-test=featsha1",
                     "scratch-core-for-test=scratchsha1",
                 ]
@@ -186,7 +186,7 @@ def _run_build(
             "NEAT_APPS_TEST_METADATA": "\n".join(
                 [
                     "main:mainsha1",
-                    "feature%2Fcore-artifact:pinnedsha2",
+                    "feature%252Fcore-artifact:pinnedsha2",
                     "zz-core-artifact-for-test:pinnedsha1",
                 ]
             ),
@@ -379,7 +379,7 @@ def test_dependency_object_manifest_url_encodes_slash_branch_for_artifact(tmp_pa
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert _installer_args(tmp_path) == "--minimum feature/core-artifact pinnedsha2"
     assert (
-        "https://core.test/feature%2Fcore-artifact/pinnedsha2/metadata.json"
+        "https://core.test/feature%252Fcore-artifact/pinnedsha2/metadata.json"
         in _curl_log(tmp_path)
     )
 
@@ -394,7 +394,7 @@ def test_dependency_object_manifest_url_encodes_slash_branch_for_latest(tmp_path
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert _installer_args(tmp_path) == "--minimum feature/core-artifact featsha2"
-    assert "https://core.test/feature%2Fcore-artifact/latest.tag" in _curl_log(tmp_path)
+    assert "https://core.test/feature%252Fcore-artifact/latest.tag" in _curl_log(tmp_path)
 
 
 def test_explicit_manifest_fails_when_artifact_is_invalid(tmp_path):

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -178,6 +178,7 @@ def _run_build(
                 [
                     "develop=devsha1",
                     "main=mainsha1",
+                    "feature%2Fcore-artifact=featsha2",
                     "zz-core-artifact-for-test=featsha1",
                     "scratch-core-for-test=scratchsha1",
                 ]
@@ -185,6 +186,7 @@ def _run_build(
             "NEAT_APPS_TEST_METADATA": "\n".join(
                 [
                     "main:mainsha1",
+                    "feature%2Fcore-artifact:pinnedsha2",
                     "zz-core-artifact-for-test:pinnedsha1",
                 ]
             ),
@@ -364,6 +366,35 @@ def test_dependency_object_manifest_uses_valid_artifact(tmp_path, ref_key):
         "https://core.test/zz-core-artifact-for-test/pinnedsha1/metadata.json"
         in _curl_log(tmp_path)
     )
+
+
+def test_dependency_object_manifest_url_encodes_slash_branch_for_artifact(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"branch": "feature/core-artifact", "spec": "pinnedsha2"},
+        args=["--only-install-neat-core"],
+        env=_installer_env(tmp_path),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == "--minimum feature/core-artifact pinnedsha2"
+    assert (
+        "https://core.test/feature%2Fcore-artifact/pinnedsha2/metadata.json"
+        in _curl_log(tmp_path)
+    )
+
+
+def test_dependency_object_manifest_url_encodes_slash_branch_for_latest(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"branch": "feature/core-artifact"},
+        args=["--only-install-neat-core"],
+        env=_installer_env(tmp_path),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == "--minimum feature/core-artifact featsha2"
+    assert "https://core.test/feature%2Fcore-artifact/latest.tag" in _curl_log(tmp_path)
 
 
 def test_explicit_manifest_fails_when_artifact_is_invalid(tmp_path):


### PR DESCRIPTION
## Summary
Pin Apps to the core artifact that packages the codec service changes needed for the 2.1.2 RTSP / VideoSender validation path.

```text
BRANCH=codex/internals-linux-codec-service
VERSION=4d4688395032
```

## Why
The merged Apps changes use the newer graph-link API and depend on the matching core/runtime artifact. Keeping `neat-core.policy=snap` lets the build resolve an older core that does not expose `GraphLinkOptions`, which breaks C++ builds.

## Validation
```text
python3 -m json.tool deps/manifest.json >/dev/null
python3 -m pytest tests/scripts/test_manifest_contract.py -q
# 17 passed
```
