### PR TITLE
docs: simplify example reproduction docs

### DIFF
--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,7 +1,6 @@
 {
   "neat-core": {
-    "branch": "codex/internals-linux-codec-service",
-    "spec": "4d4688395032"
+    "policy": "snap"
   },
   "sdk": {
     "channel": "develop"

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -60,63 +60,31 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- This example expects the model path to be provided explicitly at runtime.
-- Input and output paths are user-provided.
-- Update this section with any example-specific behavior that affects runtime results.
+## Configure
+Edit `examples/<category>/<name>/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/<category>/<name>/<binary> <args>`
-- Required arguments:
-  `<required_arg_1> <required_arg_2>`
-- Optional arguments:
-  `--flag <value>`
+```yaml
+model:
+  path: assets/models/<model-pack>.tar.gz # Model package to load.
 
-### Python
-- Invocation:
-  `python3 examples/<category>/<name>/src/python/main.py <args>`
-- Required arguments:
-  `<required_arg_1> <required_arg_2>`
-- Optional arguments:
-  `--flag <value>`
-
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/<category>/<name>/<binary>
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>
-cmake -S examples/<category>/<name>/src/cpp -B build/<name>
-cmake --build build/<name> -j
-```
-
-Binary output:
-```bash
-./build/<name>/<binary>
+io:
+  input_dir: assets/test_images           # Folder containing input images.
+  output_dir: sandbox/<name>              # Folder for generated outputs.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/<category>/<name>/<binary> <args>
+./build/examples/<category>/<name>/<binary> \
+  --config examples/<category>/<name>/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/<category>/<name>/src/python/requirements.txt
-python3 examples/<category>/<name>/src/python/main.py <args>
+python3 examples/<category>/<name>/src/python/main.py \
+  --config examples/<category>/<name>/src/common/config.yaml
 ```
 
 ## Debugging Notes

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -38,10 +38,11 @@ cd ../..
 ```
 
 For another supported model, replace `<default-model>` in the download command and config path.
+The command stores models under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
 
 ## Get The Apps Repo
@@ -62,7 +63,7 @@ Edit `examples/<category>/<name>/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/<model-pack>.tar.gz # Model package to load.
+  path: <model-path>             # Path to the model package.
 
 io:
   input_dir: assets/test_images           # Folder containing input images.
@@ -85,7 +86,7 @@ python3 examples/<category>/<name>/src/python/main.py \
 ```
 
 ## Debugging Notes
-- Confirm the model file exists under `assets/models/`.
+- Confirm `model.path` points to a readable model package.
 - Confirm input paths exist and are readable.
 - Confirm output directories are writable.
 

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -26,14 +26,26 @@ Use the platform version wherever `<platform-version>` appears.
 
 Also works with: `<model_variant_1>`, `<model_variant_2>`
 
-Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get <model_variant_1> && cd ../..`
+Download one model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+
+PLATFORM_VERSION="<platform-version>"
+MODEL=<modelzoo-name>
+
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get "${MODEL}"
+
+cd ../..
+```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with a supported modelzoo name.
 
 ## Prerequisites
 - Installed Neat Development Environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get <default_model_name> && cd ../..`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -22,7 +22,7 @@ Optional. If you have a demo screenshot for the portal detail page, place it her
 ```
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `<default-model>`.
 
@@ -32,7 +32,7 @@ Download the default model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli modelzoo -v 2.1.2 get <default-model>
+sima-cli modelzoo -v <platform-version> get <default-model>
 
 cd ../..
 ```

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -22,25 +22,22 @@ Optional. If you have a demo screenshot for the portal detail page, place it her
 ```
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
-Also works with: `<model_variant_1>`, `<model_variant_2>`
+Default model: `<default-model>`.
 
-Download one model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=<modelzoo-name>
-
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get "${MODEL}"
+sima-cli modelzoo -v 2.1.2 get <default-model>
 
 cd ../..
 ```
 
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with a supported modelzoo name.
+For another supported model, replace `<default-model>` in the download command and config path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
@@ -91,6 +88,9 @@ python3 examples/<category>/<name>/src/python/main.py \
 - Confirm the model file exists under `assets/models/`.
 - Confirm input paths exist and are readable.
 - Confirm output directories are writable.
+
+## Appendix: Additional Models
+This example can also run with `<model_variant_1>` or `<model_variant_2>`. Replace the default model name in the download command and config path.
 
 ## Source Files
 - Test scope: `tests/test-scope.yaml`

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -29,7 +29,7 @@ This example accepts any compiled model package supported by `pyneat.Model`.
 ## Prerequisites
 - Installed Neat Development Environment.
 - Activated `pyneat` environment.
-- A compiled model package available locally, usually under `assets/models/`.
+- A compiled model package available locally.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -49,7 +49,7 @@ Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or override
 
 ```yaml
 model:
-  path: assets/models/<model-pack>.tar.gz     # Model package to benchmark.
+  path: <model-path>                          # Path to the model package.
 
 benchmark:
   frames: 1000                                # Number of synthetic frames.
@@ -66,7 +66,7 @@ source ~/pyneat/bin/activate
 pip install -r examples/benchmarking/model-benchmark/src/python/requirements.txt
 
 python3 examples/benchmarking/model-benchmark/src/python/main.py \
-  --model assets/models/my_model.tar.gz \
+  --model <model-path> \
   --frames 1000 \
   --output-json sandbox/model-benchmark/my_model.json
 ```

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -66,7 +66,7 @@ source ~/pyneat/bin/activate
 pip install -r examples/benchmarking/model-benchmark/src/python/requirements.txt
 
 python3 examples/benchmarking/model-benchmark/src/python/main.py \
-  --model <model-path> \
+  --model assets/models/my_model.tar.gz \
   --frames 1000 \
   --output-json sandbox/model-benchmark/my_model.json
 ```

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -44,20 +44,19 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- `benchmark.frames` controls the measured synthetic frames passed to `Model.benchmark()`.
-- The default report path is `sandbox/model-benchmark/report.json`.
-- The JSON report is the stable output for comparing model packages.
+## Configure
+Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or override these values from the command line.
 
-## Command-Line Options
-### Python
-- Invocation:
-  `python3 examples/benchmarking/model-benchmark/src/python/main.py [--config <path>] [--model <path>] [--frames <n>] [--output-json <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
-  `--model <path>`: compiled model package path. Overrides `model.path`.
-  `--frames <n>`: measured synthetic frames. Overrides `benchmark.frames`.
-  `--output-json <path>`: report path. Overrides `output.report_json`.
+```yaml
+model:
+  path: assets/models/<model-pack>.tar.gz     # Model package to benchmark.
+
+benchmark:
+  frames: 1000                                # Number of synthetic frames.
+
+output:
+  report_json: sandbox/model-benchmark/report.json # JSON report path.
+```
 
 ## Run
 From the Apps repo root:

--- a/examples/benchmarking/model-benchmark/src/common/config.yaml
+++ b/examples/benchmarking/model-benchmark/src/common/config.yaml
@@ -1,8 +1,8 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Model package selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-benchmark:
-  frames: 1000
+benchmark:                   # Synthetic benchmark settings.
+  frames: 1000               # Number of synthetic frames to run.
 
-output:
-  report_json: sandbox/model-benchmark/report.json
+output:                      # Benchmark report output.
+  report_json: sandbox/model-benchmark/report.json # JSON report path.

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -20,7 +20,7 @@ The pipeline is trying to classify this goldfish image.
 ![Image classifier goldfish input](../../../assets/portal/classification/image-classifier/image.jpeg)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Primary model: `resnet_50`
 
@@ -29,7 +29,7 @@ Download the model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli modelzoo -v <platform-version> get resnet_50
+sima-cli modelzoo -v 2.1.2 get resnet_50
 cd ../..
 ```
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -33,9 +33,11 @@ sima-cli modelzoo -v <platform-version> get resnet_50
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -55,7 +57,7 @@ Edit `examples/classification/image-classifier/src/common/config.yaml` if you wa
 
 ```yaml
 model:
-  path: assets/models/resnet_50_mpk.tar.gz  # Model package to load.
+  path: <model-path>                        # Path to the model package.
 
 io:
   image: null                               # Input image. null uses the sample image.
@@ -80,7 +82,7 @@ python3 examples/classification/image-classifier/src/python/main.py \
 ```
 
 ## Debugging Notes
-- If you see a model load error, verify the model file exists at `assets/models/resnet_50_mpk.tar.gz`.
+- If you see a model load error, verify `model.path` points to a readable model package.
 - If image decode fails, set `io.image` in the config.
 - If top-1 validation fails, try lowering `validation.min_probability` for debug runs.
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -20,7 +20,7 @@ The pipeline is trying to classify this goldfish image.
 ![Image classifier goldfish input](../../../assets/portal/classification/image-classifier/image.jpeg)
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Primary model: `resnet_50`
 
@@ -29,7 +29,7 @@ Download the model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli modelzoo -v 2.1.2 get resnet_50
+sima-cli modelzoo -v <platform-version> get resnet_50
 cd ../..
 ```
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -50,50 +50,18 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- Runtime settings live in `src/common/config.yaml`.
-- If `io.image` is null, the example downloads a sample goldfish image automatically.
-- `validation.min_probability` controls the pass/fail threshold for the expected class probability.
+## Configure
+Edit `examples/classification/image-classifier/src/common/config.yaml` if you want to use a different image or threshold.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/classification/image-classifier/image-classifier [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+```yaml
+model:
+  path: assets/models/resnet_50_mpk.tar.gz  # Model package to load.
 
-### Python
-- Invocation:
-  `python examples/classification/image-classifier/src/python/main.py [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+io:
+  image: null                               # Input image. null uses the sample image.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/classification/image-classifier/image-classifier
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/classification/image-classifier
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/image-classifier
+validation:
+  min_probability: 0.50                     # Minimum expected-class probability.
 ```
 
 ## Run
@@ -107,7 +75,7 @@ Binary output:
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/classification/image-classifier/src/python/requirements.txt
-python examples/classification/image-classifier/src/python/main.py \
+python3 examples/classification/image-classifier/src/python/main.py \
   --config examples/classification/image-classifier/src/common/config.yaml
 ```
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -24,13 +24,18 @@ Use the platform version wherever `<platform-version>` appears.
 
 Primary model: `resnet_50`
 
-Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get resnet_50 && cd ../..`
+Download the model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli modelzoo -v <platform-version> get resnet_50
+cd ../..
+```
 
 ## Prerequisites
 - Installed Neat Development Environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get resnet_50 && cd ../..`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).

--- a/examples/classification/image-classifier/src/common/config.yaml
+++ b/examples/classification/image-classifier/src/common/config.yaml
@@ -1,15 +1,15 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Classifier model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  image: null
+io:                          # Input image settings.
+  image: null                # Optional local image path. null uses fallback_image_url.
   fallback_image_url: https://raw.githubusercontent.com/EliSchwartz/imagenet-sample-images/master/n01443537_goldfish.JPEG
 
-runtime:
-  input_width: 224
-  input_height: 224
-  timeout_ms: 20000
+runtime:                     # Runtime settings.
+  input_width: 224           # Model input width.
+  input_height: 224          # Model input height.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
 
-validation:
-  expected_class_id: 1
-  min_probability: 0.20
+validation:                  # Expected result check.
+  expected_class_id: 1       # Expected ImageNet class id.
+  min_probability: 0.20      # Minimum expected-class probability.

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -33,9 +33,11 @@ sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -55,7 +57,7 @@ Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/depth_anything_v2_vits_mpk.tar.gz # Model package to load.
+  path: <model-path>                         # Path to the model package.
 
 io:
   input_dir: assets/test_images                         # Folder containing input images.

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -50,61 +50,31 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- Runtime settings are read from `src/common/config.yaml` by default.
-- Input directory is scanned for common image extensions.
-- Output files are written to the configured output directory.
+## Configure
+Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/depth-estimation/depth-estimator/depth-estimator [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: assets/models/depth_anything_v2_vits_mpk.tar.gz # Model package to load.
 
-### Python
-- Invocation:
-  `python examples/depth-estimation/depth-estimator/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
-
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/depth-estimation/depth-estimator/depth-estimator
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/depth-estimation/depth-estimator
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/depth-estimator
+io:
+  input_dir: assets/test_images                         # Folder containing input images.
+  output_dir: sandbox/depth-estimator                   # Folder for depth visualizations.
 ```
 
 ## Run
-Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml` to point at the model and image folder.
-
 ### C++
 ```bash
-./build/examples/depth-estimation/depth-estimator/depth-estimator
+./build/examples/depth-estimation/depth-estimator/depth-estimator \
+  --config examples/depth-estimation/depth-estimator/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/depth-estimation/depth-estimator/src/python/requirements.txt
-python examples/depth-estimation/depth-estimator/src/python/main.py
+python3 examples/depth-estimation/depth-estimator/src/python/main.py \
+  --config examples/depth-estimation/depth-estimator/src/common/config.yaml
 ```
 
 ## Debugging Notes

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -20,7 +20,7 @@ Snippet from a pipeline run:
 ![Depth estimator preview](../../../assets/portal/depth-estimation/depth-estimator/image.png)
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Primary model: `depth_anything_v2_vits`
 
@@ -29,7 +29,7 @@ Download the model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli modelzoo -v 2.1.2 get depth_anything_v2_vits
+sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
 cd ../..
 ```
 

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -24,13 +24,18 @@ Use the platform version wherever `<platform-version>` appears.
 
 Primary model: `depth_anything_v2_vits`
 
-Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits && cd ../..`
+Download the model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
+cd ../..
+```
 
 ## Prerequisites
 - Installed Neat Development Environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits && cd ../..`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -20,7 +20,7 @@ Snippet from a pipeline run:
 ![Depth estimator preview](../../../assets/portal/depth-estimation/depth-estimator/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Primary model: `depth_anything_v2_vits`
 
@@ -29,7 +29,7 @@ Download the model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
+sima-cli modelzoo -v 2.1.2 get depth_anything_v2_vits
 cd ../..
 ```
 

--- a/examples/depth-estimation/depth-estimator/src/common/config.yaml
+++ b/examples/depth-estimation/depth-estimator/src/common/config.yaml
@@ -1,11 +1,11 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Depth model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/depth-estimator
+io:                          # Input and output paths.
+  input_dir: assets/test_images       # Folder containing input images.
+  output_dir: sandbox/depth-estimator # Folder for depth visualizations.
 
-runtime:
-  infer_size: 518
-  timeout_ms: 20000
-  queue_depth: 4
+runtime:                     # Runtime settings.
+  infer_size: 518            # Square model input size.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  queue_depth: 4             # Runtime queue depth.

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -33,15 +33,18 @@ Use the platform version wherever `<platform-version>` appears.
 
 Validated with: `retinaface_mobilenet25`
 
-Download into `assets/models/`:
-- `./scripts/download_models.sh retinaface_mobilenet25`
+Download the validated model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+cd ../..
+```
 
 ## Prerequisites
 - Installed Neat Development Environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Preferred download command: `./scripts/download_models.sh retinaface_mobilenet25`
-- Direct URL fallback:
-  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz && cd ../..`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -29,7 +29,7 @@ Snippet from a pipeline run:
 ![Face detector preview](../../../assets/portal/face-detection/face-detector/image.png)
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Validated with: `retinaface_mobilenet25`
 
@@ -38,7 +38,7 @@ Download the validated model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
 cd ../..
 ```
 

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -29,7 +29,7 @@ Snippet from a pipeline run:
 ![Face detector preview](../../../assets/portal/face-detection/face-detector/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Validated with: `retinaface_mobilenet25`
 
@@ -38,7 +38,7 @@ Download the validated model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
 cd ../..
 ```
 

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -42,9 +42,11 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -64,7 +66,7 @@ Edit `examples/face-detection/face-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz # Model package to load.
+  path: <model-path>                                  # Path to the model package.
 
 io:
   input_dir: assets/test_images                               # Folder containing input images.
@@ -146,7 +148,7 @@ Notes:
 - If `SIMANEAT_APPS_TEST_INPUT_DIR` is not set, both e2e tests fall back to `assets/test_images`.
 
 ## Debugging Notes
-- If the model fails to load, verify `assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz` exists and is readable.
+- If the model fails to load, verify `model.path` points to a readable model package.
 - If no detections appear, lower `decode.confidence_threshold` and confirm the input actually contains faces.
 - If too many duplicate boxes appear, reduce `decode.nms_iou` and/or lower `decode.top_k`.
 - If output writing fails, ensure `io.output_dir` exists or can be created.

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -59,59 +59,35 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- C++ and Python read runtime values from `src/common/config.yaml`.
-- Detection confidence and NMS IoU live under `decode`.
-- By default, detections include 5-point facial landmarks unless `decode.landmarks` is `false`.
+## Configure
+Edit `examples/face-detection/face-detector/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/face-detection/face-detector_cpp/face-detector [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz # Model package to load.
 
-### Python
-- Invocation:
-  `python3 examples/face-detection/face-detector/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+io:
+  input_dir: assets/test_images                               # Folder containing input images.
+  output_dir: sandbox/face-detector                           # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/face-detection/face-detector_cpp/face-detector
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/face-detection/face-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/face-detector
+decode:
+  confidence_threshold: 0.40                                  # Minimum face confidence.
+  landmarks: true                                             # Draw five facial landmarks.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/face-detection/face-detector_cpp/face-detector
+./build/examples/face-detection/face-detector_cpp/face-detector \
+  --config examples/face-detection/face-detector/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/face-detection/face-detector/src/python/requirements.txt
-python3 examples/face-detection/face-detector/src/python/main.py
+python3 examples/face-detection/face-detector/src/python/main.py \
+  --config examples/face-detection/face-detector/src/common/config.yaml
 ```
 
 ## Testing

--- a/examples/face-detection/face-detector/src/common/config.yaml
+++ b/examples/face-detection/face-detector/src/common/config.yaml
@@ -1,20 +1,20 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Face detector model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/face-detector
+io:                          # Input and output paths.
+  input_dir: assets/test_images      # Folder containing input images.
+  output_dir: sandbox/face-detector  # Folder for annotated images.
 
-decode:
-  confidence_threshold: 0.40
-  nms_iou: 0.90
-  top_k: 5000
-  keep_top_k: 750
-  max_draw: 50
-  landmarks: true
+decode:                      # RetinaFace decode settings.
+  confidence_threshold: 0.40 # Minimum face confidence.
+  nms_iou: 0.90              # Overlap threshold for NMS.
+  top_k: 5000                # Candidate boxes before NMS.
+  keep_top_k: 750            # Candidate boxes after NMS.
+  max_draw: 50               # Max faces to draw per image.
+  landmarks: true            # Draw five facial landmarks.
 
-runtime:
-  timeout_ms: 20000
-  profile: false
-  num_runs: 100
-  verbose: false
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  profile: false             # Print profiling summaries.
+  num_runs: 100              # Number of repeated runs for profiling.
+  verbose: false             # Print verbose runtime output.

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -19,6 +19,16 @@ Detection metadata visualized in Insight:
 
 ![Detection-to-VLM assistant preview](../../../assets/portal/genai/detection-to-vlm-assistant/image.png)
 
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+
+Run `neat` in the Neat Developer Environment and copy these values into your config:
+
+- `Insight Web UI`: browser URL for the viewer
+- `rtsp.tcp`: RTSP source port
+- `videoUDP`: UDP video port range
+- `metadataUDP`: UDP metadata port range
+
 ## Prerequisites
 - Installed Neat Development Environment.
 - YOLO26 detector model package available under `assets/models/`.
@@ -66,6 +76,25 @@ cd ../..
 ```
 
 Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
+
+## Configure
+Edit `examples/genai/detection-to-vlm-assistant/src/common/config.yaml`.
+
+```yaml
+source:
+  rtsp_url: rtsp://<insight-host-ip>:<rtsp.tcp>/<stream> # RTSP stream URL.
+
+model:
+  path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
+
+insight:
+  host: <insight-host-ip>                                  # Host running Insight.
+  video_port: <videoUDP start port from neat>              # UDP video port.
+  metadata_port: <metadataUDP start port from neat>        # UDP metadata port.
+
+openai:
+  enabled: false                                           # Disable for detection plus Insight only.
+```
 
 ## Run
 From the `apps` repository root:

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -52,7 +52,7 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
@@ -62,7 +62,7 @@ Download the default detector model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -51,16 +51,21 @@ Supported batch-1 YOLO26 detector models:
 - `yolo26m-det-bf16-b1.tar.gz`
 - `yolo26m-det-int8-b1.tar.gz`
 
-Download the default detector model:
+Download one detector model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
 
 cd ../..
 ```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Run
 From the `apps` repository root:

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -33,7 +33,7 @@ Use the same `neat` output to set `insight.host`, `video_port`, and `metadata_po
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Default YOLO26 detector model package available under `assets/models/`.
+- Default YOLO26 detector model downloaded, or `model.path` set to another readable model package.
 - RTSP source created in Insight or provided by your camera.
 - Insight receiver running at the configured host and ports.
 - OpenAI-compatible Gemma server running when `openai.enabled` is true.
@@ -67,6 +67,8 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Configure
 Edit `examples/genai/detection-to-vlm-assistant/src/common/config.yaml`.
 
@@ -75,7 +77,7 @@ source:
   rtsp_url: <rtsp-url-copied-from-insight>              # RTSP stream URL.
 
 model:
-  path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
+  path: <model-path>                                    # Path to the model package.
 
 insight:
   host: <insight-host-ip>                                  # Host running Insight.

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -22,17 +22,19 @@ Detection metadata visualized in Insight:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Run `neat` in the Neat Developer Environment and copy these values into your config:
+To create a reproducible RTSP input:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use a sample video or upload your own video.
+4. Start the stream and copy the RTSP URL.
+5. Put that RTSP URL into `source.rtsp_url`.
 
-- `Insight Web UI`: browser URL for the viewer
-- `rtsp.tcp`: RTSP source port
-- `videoUDP`: UDP video port range
-- `metadataUDP`: UDP metadata port range
+Use the same `neat` output to set `insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- YOLO26 detector model package available under `assets/models/`.
-- RTSP stream readable from the Neat Development Environment.
+- Default YOLO26 detector model package available under `assets/models/`.
+- RTSP source created in Insight or provided by your camera.
 - Insight receiver running at the configured host and ports.
 - OpenAI-compatible Gemma server running when `openai.enabled` is true.
 
@@ -50,39 +52,27 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
-Supported batch-1 YOLO26 detector models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
+Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
-Download one detector model:
+Download the default detector model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```
-
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Configure
 Edit `examples/genai/detection-to-vlm-assistant/src/common/config.yaml`.
 
 ```yaml
 source:
-  rtsp_url: rtsp://<insight-host-ip>:<rtsp.tcp>/<stream> # RTSP stream URL.
+  rtsp_url: <rtsp-url-copied-from-insight>              # RTSP stream URL.
 
 model:
   path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
@@ -110,6 +100,17 @@ For local model comparison, example configs are available under
 `sandbox/configs/detection-to-vlm-assistant/<model-name>/config.yaml`.
 
 The OpenAI path checks `/v1/models` before sending a crop, waits at least `openai.interval_seconds` between attempts, and keeps at most `openai.max_pending_requests` queued or in-flight requests.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detector models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+- `yolo26m-det-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - Python source: `src/python/main.py`, `src/python/utils/helpers.py`, `src/python/utils/openai_commenter.py`

--- a/examples/genai/detection-to-vlm-assistant/src/common/config.yaml
+++ b/examples/genai/detection-to-vlm-assistant/src/common/config.yaml
@@ -1,38 +1,38 @@
-source:
-  rtsp_url: <rtsp-url-1>  # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
+source:                      # RTSP input source.
+  rtsp_url: <rtsp-url-1>     # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
 
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Detector model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
   labels: examples/genai/detection-to-vlm-assistant/src/common/coco_label.txt
 
-inference:
-  frames: 0
-  min_score: 0.55
-  nms_iou: 0.60
-  max_detections: 50
+inference:                   # Detection controls.
+  frames: 0                  # Frame limit. 0 means run continuously.
+  min_score: 0.55            # Detection score threshold.
+  nms_iou: 0.60              # NMS IoU threshold.
+  max_detections: 50         # Max detections to keep per frame.
   # classes:
   #   - person
   #   - car
   #   - truck
 
-runtime:
-  timeout_ms: 50000
+runtime:                     # Runtime settings.
+  timeout_ms: 50000          # Inference timeout in milliseconds.
 
-insight:
-  host: <insight-host-ip>  # Host running the Insight receiver/viewer.
-  video_port: 9000
-  metadata_port: 9100
-  channel: 0
+insight:                     # Live video and metadata destination.
+  host: <insight-host-ip>    # Host running the Insight receiver/viewer.
+  video_port: 9000           # UDP video port.
+  metadata_port: 9100        # UDP metadata port.
+  channel: 0                 # Insight channel index.
 
-openai:
-  enabled: true
-  host: 127.0.0.1
-  port: 9998
-  model: gemma4
-  max_tokens: 128
-  interval_seconds: 3
-  timeout_seconds: 30
-  max_pending_requests: 1
+openai:                      # Optional OpenAI-compatible captioner.
+  enabled: true              # Enable crop-to-VLM requests.
+  host: 127.0.0.1            # OpenAI-compatible server host.
+  port: 9998                 # OpenAI-compatible server port.
+  model: gemma4              # Model name passed to the server.
+  max_tokens: 128            # Max generated tokens per request.
+  interval_seconds: 3        # Minimum seconds between VLM requests.
+  timeout_seconds: 30        # Request timeout in seconds.
+  max_pending_requests: 1    # Max queued or in-flight VLM requests.
   system_prompt: >-
     Write one sarcastic scene caption. Comment on the visible situation,
     not identity or appearance. Use 10 words or fewer. Avoid: darling,

--- a/examples/genai/multimodal-assistant/src/common/config.yaml
+++ b/examples/genai/multimodal-assistant/src/common/config.yaml
@@ -1,34 +1,34 @@
-server:
-  openai:
-    host: 0.0.0.0
-    port: 9998
+server:                      # Local OpenAI-compatible model server.
+  openai:                    # Server bind address.
+    host: 0.0.0.0            # Host interface to bind.
+    port: 9998               # Server port.
 
-  models:
-    chat:
+  models:                    # Models served by the local server.
+    chat:                    # Chat or vision-language models.
       # The first chat model is selected by default in the UI.
       - name: <primary-chat-model-name>
         path: <path-to-primary-chat-model-dir>
       - name: <secondary-chat-model-name>
         path: <path-to-secondary-chat-model-dir>
-    asr:
-      name: <asr-model-name>
-      path: <path-to-asr-model-dir>
+    asr:                     # Speech-to-text model.
+      name: <asr-model-name>        # Model name shown to the app.
+      path: <path-to-asr-model-dir> # Local model directory.
 
-app:
-  openai:
-    client_host: 127.0.0.1
-    port: 9998
+app:                         # Assistant web app settings.
+  openai:                    # OpenAI-compatible client endpoint.
+    client_host: 127.0.0.1   # Host used by the app client.
+    port: 9998               # Port used by the app client.
 
-  request:
-    max_tokens: 128
+  request:                   # Default generation settings.
+    max_tokens: 128          # Max generated tokens per response.
     system_prompt: >-
       Answer clearly and concisely.
 
-  web:
-    host: 0.0.0.0
-    port: 5000
-    https: true
+  web:                       # Browser UI settings.
+    host: 0.0.0.0            # Host interface to bind.
+    port: 5000               # Web UI port.
+    https: true              # Serve the UI over HTTPS.
 
-  rag:
-    enabled: false
-    embedding_model_dir: <path-to-embedding-model-dir>
+  rag:                       # Retrieval-augmented generation settings.
+    enabled: false                             # Enable document retrieval.
+    embedding_model_dir: <path-to-embedding-model-dir> # Embedding model directory.

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -35,11 +35,11 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be placed under `assets/models/`.
-- Default model path:
-  `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz`
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -59,7 +59,7 @@ Edit `examples/object-detection/detr-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz # Model package to load.
+  path: <model-path>                                  # Path to the model package.
 
 io:
   input_dir: assets/test_images                                                # Folder containing input images.
@@ -136,7 +136,7 @@ pytest -c tests/pytest.ini --rootdir="$PWD" -m e2e \
 ```
 
 ## Debugging Notes
-- If the model fails to load, verify `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` exists and is readable.
+- If the model fails to load, verify `model.path` points to a readable model package.
 - First-run model initialization can exceed 60 seconds on some setups. Increase `SIMANEAT_APPS_TEST_TIMEOUT_MS` (for example `180000`) for e2e runs.
 - If no detections appear, lower `decode.confidence_threshold` and confirm the input images contain supported COCO objects.
 - If detections are visibly offset, verify the model frame assumptions (`1333x800`) still match the compiled package.

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -22,7 +22,7 @@ Snippet from a pipeline run:
 ![DETR object detector preview](../../../assets/portal/object-detection/detr-object-detector/image.png)
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Validated with: `detr_resnet50_modified_class_embed_bbox_embed`
 
@@ -31,7 +31,7 @@ Download the validated model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
 cd ../..
 ```
 

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -22,7 +22,7 @@ Snippet from a pipeline run:
 ![DETR object detector preview](../../../assets/portal/object-detection/detr-object-detector/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Validated with: `detr_resnet50_modified_class_embed_bbox_embed`
 
@@ -31,7 +31,7 @@ Download the validated model:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
 cd ../..
 ```
 

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -26,15 +26,18 @@ Use the platform version wherever `<platform-version>` appears.
 
 Validated with: `detr_resnet50_modified_class_embed_bbox_embed`
 
-Download into `assets/models/`:
-- `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
+Download the validated model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+cd ../..
+```
 
 ## Prerequisites
 - Installed Neat Development Environment.
 - Model artifacts are user-managed and should be placed under `assets/models/`.
-- Preferred download command: `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
-- Direct URL fallback:
-  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz && cd ../..`
 - Default model path:
   `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz`
 

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -54,62 +54,35 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- The example expects an input folder with image files.
-- Input preprocessing preserves aspect ratio and center-pads into an `1333x800` model frame.
-- Output boxes are mapped back to the original image resolution before drawing.
-- By default all DETR foreground classes are considered. Set `decode.person_only: true` in `src/common/config.yaml` to keep only the DETR `person` class.
-- Overlay text uses built-in DETR COCO labels and class-colored boxes.
-- `runtime.profile` runs repeated inference and reports session, postprocessing, and overall timing statistics.
+## Configure
+Edit `examples/object-detection/detr-object-detector/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/object-detection/detr-object-detector/detr-object-detector [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz # Model package to load.
 
-### Python
-- Invocation:
-  `python3 examples/object-detection/detr-object-detector/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+io:
+  input_dir: assets/test_images                                                # Folder containing input images.
+  output_dir: sandbox/detr-object-detector                                     # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/object-detection/detr-object-detector/detr-object-detector
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/object-detection/detr-object-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/detr-object-detector
+decode:
+  confidence_threshold: 0.70                                                   # Minimum object confidence.
+  person_only: false                                                           # Keep only COCO person detections when true.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/object-detection/detr-object-detector/detr-object-detector
+./build/examples/object-detection/detr-object-detector/detr-object-detector \
+  --config examples/object-detection/detr-object-detector/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/detr-object-detector/src/python/requirements.txt
-python3 examples/object-detection/detr-object-detector/src/python/main.py
+python3 examples/object-detection/detr-object-detector/src/python/main.py \
+  --config examples/object-detection/detr-object-detector/src/common/config.yaml
 ```
 
 ## Testing

--- a/examples/object-detection/detr-object-detector/src/common/config.yaml
+++ b/examples/object-detection/detr-object-detector/src/common/config.yaml
@@ -1,17 +1,17 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # DETR model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/detr-object-detector
+io:                          # Input and output paths.
+  input_dir: assets/test_images              # Folder containing input images.
+  output_dir: sandbox/detr-object-detector   # Folder for annotated images.
 
-decode:
-  confidence_threshold: 0.70
-  max_draw: 50
-  person_only: false
+decode:                      # DETR decode settings.
+  confidence_threshold: 0.70 # Minimum object confidence.
+  max_draw: 50               # Max detections to draw per image.
+  person_only: false         # Keep only COCO person detections when true.
 
-runtime:
-  timeout_ms: 20000
-  profile: false
-  num_runs: 100
-  verbose: false
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  profile: false             # Print profiling summaries.
+  num_runs: 100              # Number of repeated runs for profiling.
+  verbose: false             # Print verbose runtime output.

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -22,17 +22,19 @@ Snippet from a pipeline run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Run `neat` in the Neat Developer Environment and copy these values into your config:
+To create reproducible RTSP inputs:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use sample videos or upload your own videos.
+4. Start each stream and copy the RTSP URLs.
+5. Put those RTSP URLs into `streams`.
 
-- `Insight Web UI`: browser URL for the viewer
-- `rtsp.tcp`: RTSP source port
-- `videoUDP`: UDP video port range
-- `metadataUDP`: UDP metadata port range
+Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- One or more reachable RTSP camera URLs.
-- A YOLO26 model pack downloaded into `assets/models/`.
+- RTSP sources created in Insight or provided by your cameras.
+- Default YOLO26 model pack downloaded into `assets/models/`.
 - Edit `src/common/config.yaml` before running with real streams.
 - On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the example if the runtime has been used by earlier ML/video apps.
 
@@ -50,34 +52,20 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 The default model is `yolo26m-det-int8-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download one model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-det-int8-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```
-
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Configure
 Edit `examples/object-detection/multi-stream-object-detector/src/common/config.yaml`.
@@ -87,8 +75,8 @@ model:
   path: assets/models/yolo26m-det-int8-b1.tar.gz       # Model package to load.
 
 streams:
-  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-1>     # First RTSP stream.
-  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-2>     # Second RTSP stream.
+  - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
+  - <second-rtsp-url-copied-from-insight>              # Second RTSP stream.
 
 inference:
   frames: 0                                            # Frame limit per stream. 0 runs continuously.
@@ -131,6 +119,17 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-str
 - On Modalix DevKit, start with `bash /usr/bin/fix_devkit_runtime.sh`. If the runtime still behaves inconsistently, a full board reboot has been a more reliable reset than service restarts alone.
 - `output.debug_dir` and `output.save_every` let you save periodic aligned debug frames locally without changing the Insight output contract.
 - Profiling prints per-stream pull, metadata, output FPS, and detection-count summaries.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++: `src/cpp/main.cpp`

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -71,22 +71,21 @@ Supported batch-1 YOLO26 detection models:
 - `yolo26m-det-bf16-b1.tar.gz`
 - `yolo26m-det-int8-b1.tar.gz`
 
-Download all supported batch-1 variants:
+Download one model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-det-int8-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
 
 cd ../..
 ```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Build
 ### Build From The Apps Repo

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -34,7 +34,7 @@ Use the same `neat` output to set `output.insight.host`, `video_port_base`, and 
 ## Prerequisites
 - Installed Neat Development Environment.
 - RTSP sources created in Insight or provided by your cameras.
-- Default YOLO26 model pack downloaded into `assets/models/`.
+- Default YOLO26 model downloaded, or `model.path` set to another readable model package.
 - Edit `src/common/config.yaml` before running with real streams.
 - On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the example if the runtime has been used by earlier ML/video apps.
 
@@ -67,12 +67,14 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Configure
 Edit `examples/object-detection/multi-stream-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/yolo26m-det-int8-b1.tar.gz       # Model package to load.
+  path: <model-path>                                   # Path to the model package.
 
 streams:
   - <first-rtsp-url-copied-from-insight>               # First RTSP stream.

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -52,7 +52,7 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 The default model is `yolo26m-det-int8-b1.tar.gz`.
 
@@ -62,7 +62,7 @@ Download the default model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -19,18 +19,15 @@ Snippet from a pipeline run:
 
 ![Multi-stream object detector preview](../../../assets/portal/object-detection/multi-stream-object-detector/image.png)
 
-Architecture:
-- one complete graph per RTSP stream
-- each stream branches decoded NV12 frames into video and model paths
-- clean Insight video is sent through `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output
-- YOLO26 detections are sent as metadata for Insight overlay
-- optional debug output joins decoded frames and detections by frame id before saving
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Per-stream graph:
-- `RtspDecodedInput -> Branch(video, model[, debug_frame])`
-- `video -> VideoSender(H.264 RTP/UDP)`
-- `model -> YOLO26 model.graph() -> detections`
-- debug only: `Combine(debug_frame, detections, ByFrame) -> debug_output`
+Run `neat` in the Neat Developer Environment and copy these values into your config:
+
+- `Insight Web UI`: browser URL for the viewer
+- `rtsp.tcp`: RTSP source port
+- `videoUDP`: UDP video port range
+- `metadataUDP`: UDP metadata port range
 
 ## Prerequisites
 - Installed Neat Development Environment.
@@ -51,11 +48,6 @@ cd apps
 ```
 
 After this setup, follow the example-specific commands below.
-
-## Command-Line Options
-- `--config <path>`: path to the YAML configuration file
-- `--validate-config-only`: validate the config and exit without opening RTSP streams
-- `--help`: print the CLI help text
 
 ## Download Models
 Use the platform version wherever `<platform-version>` appears.
@@ -87,18 +79,26 @@ cd ../..
 
 Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
+## Configure
+Edit `examples/object-detection/multi-stream-object-detector/src/common/config.yaml`.
 
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>
-cmake -S examples/object-detection/multi-stream-object-detector/src/cpp -B build/multi-stream-object-detector
-cmake --build build/multi-stream-object-detector -j
+```yaml
+model:
+  path: assets/models/yolo26m-det-int8-b1.tar.gz       # Model package to load.
+
+streams:
+  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-1>     # First RTSP stream.
+  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-2>     # Second RTSP stream.
+
+inference:
+  frames: 0                                            # Frame limit per stream. 0 runs continuously.
+  min_score: 0.30                                      # Minimum object confidence.
+
+output:
+  insight:
+    host: <insight-host-ip>                            # Host running Insight.
+    video_port_base: <videoUDP start port from neat>   # First UDP video port.
+    metadata_port_base: <metadataUDP start port from neat> # First UDP metadata port.
 ```
 
 ## Run
@@ -131,13 +131,6 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-str
 - On Modalix DevKit, start with `bash /usr/bin/fix_devkit_runtime.sh`. If the runtime still behaves inconsistently, a full board reboot has been a more reliable reset than service restarts alone.
 - `output.debug_dir` and `output.save_every` let you save periodic aligned debug frames locally without changing the Insight output contract.
 - Profiling prints per-stream pull, metadata, output FPS, and detection-count summaries.
-
-## Notes
-- Point `model.path` at a YOLO26 detection pack. This example does not use a `model.family` config key.
-- Both C++ and Python use the same public graph shape: `RtspDecodedInput`, `graphs::Branch`, `model.graph()`, `graphs::Combine` for debug saves, and `VideoSender`.
-- The app does not add lower-level video conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes around `VideoSender`.
-- The live path keeps video and metadata separate. Insight overlays metadata on the clean video stream.
-- `output.video_enabled: false` disables per-stream H.264 video output. Metadata still runs.
 
 ## Source Files
 - C++: `src/cpp/main.cpp`

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -29,17 +29,19 @@ Snippet from a pipeline run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Run `neat` in the Neat Developer Environment and copy these values into your config:
+To create a reproducible RTSP input:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use a sample video or upload your own video.
+4. Start the stream and copy the RTSP URL.
+5. Put that RTSP URL into `source.rtsp_url`.
 
-- `Insight Web UI`: browser URL for the viewer
-- `rtsp.tcp`: RTSP source port
-- `videoUDP`: UDP video port range
-- `metadataUDP`: UDP metadata port range
+Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit
-- RTSP camera source or use Insight to start RTSP source
-- Model artifacts are user-managed. Download the model variant you want to run into `assets/models/`.
+- RTSP source created in Insight or provided by your camera
+- Default model downloaded into `assets/models/`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -55,34 +57,20 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download one model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```
-
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Configure
 Edit `examples/object-detection/single-stream-object-detector/src/common/config.yaml`.
@@ -92,7 +80,7 @@ model:
   path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
 
 source:
-  rtsp_url: rtsp://<insight-host-ip>:<rtsp.tcp>/<stream>  # RTSP stream URL.
+  rtsp_url: <rtsp-url-copied-from-insight>                # RTSP stream URL.
   tcp: true                                               # Use TCP transport for RTSP.
 
 inference:
@@ -126,6 +114,17 @@ python3 examples/object-detection/single-stream-object-detector/src/python/main.
 - If the RTSP source resolution changes, the startup probe is expected to adapt the decode path automatically.
 - If detections are missing but video is flowing, focus on the YOLO session and bbox extraction/parse path.
 - If video and detections are both missing in Insight, verify the host and UDP ports first.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+- `yolo26m-det-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -99,22 +99,21 @@ Supported batch-1 YOLO26 detection models:
 - `yolo26m-det-bf16-b1.tar.gz`
 - `yolo26m-det-int8-b1.tar.gz`
 
-Download all supported batch-1 variants:
+Download one model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
 
 cd ../..
 ```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Important Behavior
 - The sample always publishes to Insight.
@@ -243,7 +242,12 @@ Download the default YOLO26 detector model if it is not already available:
 ```bash
 mkdir -p assets/models
 cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
+
 cd ../..
 ```
 

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -26,46 +26,15 @@ Snippet from a pipeline run:
 
 ![Single-stream object detector preview](../../../assets/portal/object-detection/single-stream-object-detector/image.png)
 
-## What Is Insight?
-Insight is SiMa.ai's lightweight, cross-platform development and visualization tool for vision pipelines on DevKits:
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-- a media source manager that can host test media and stream it as RTSP
-- a zero-install web viewer for real-time video and metadata visualization
+Run `neat` in the Neat Developer Environment and copy these values into your config:
 
-For this sample, the most important part is the viewer/output contract: the application sends video on the Insight video channel and sends detection metadata as JSON on the Insight side channel. That allows the browser UI to display the live stream together with object detections without relying on external tools such as `ffplay`, VLC, or ad hoc debug viewers.
-
-For more information regarding Insight, please refer to this [page](https://developer.sima.ai/software/tools/insight).
-
-## Architecture
-The sample is split into three independent runtime stages:
-
-1. `RTSP ingest and decode`
-   The application first probes the RTSP source to learn the decoded frame size, then builds a decode graph that outputs NV12 frames. This avoids hardcoding `640x480` and makes the example more robust when the source changes resolution.
-
-2. `YOLO inference`
-   Decoded NV12 frames are pushed into a dedicated YOLO pipeline:
-   `Input -> model.graph() -> Output`
-
-   The model stage is isolated from transport logic so detection behavior can be debugged separately from RTSP or Insight issues.
-
-3. `Insight output`
-   The original decoded frame is pushed into `VideoSender`. The nodegroup owns the raw-frame video transport path, including conversion, raw NV12 caps, H.264 encoding, RTP packetization, and UDP output. Detection results from the YOLO path are converted into Insight metadata and sent on the metadata side channel.
-
-## Neat Library API Usage
-
-- RTSP ingest: `RtspDecodedInputOptions` -> `Graph.add(rtsp_decoded_input)` -> `Graph.build(...)`
-- YOLO path:
-  C++ and Python use `Input -> model.graph() -> Output`
-- Insight output:
-  C++ and Python build a dedicated `VideoSender` runtime plus `MetadataSender`.
-
-## Lifecycle
-The example uses a producer/consumer design:
-
-- the producer thread pulls decoded frames from the RTSP graph and places them into a bounded queue
-- the consumer thread pulls frames from that queue, submits them to YOLO, converts detection results to Insight objects, and publishes both video and metadata
-
-This separation keeps the RTSP graph from being tightly coupled to the inference latency of each frame and makes profile output easier to interpret.
+- `Insight Web UI`: browser URL for the viewer
+- `rtsp.tcp`: RTSP source port
+- `videoUDP`: UDP video port range
+- `metadataUDP`: UDP metadata port range
 
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit
@@ -115,154 +84,42 @@ cd ../..
 
 Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
-## Important Behavior
-- The sample always publishes to Insight.
-- Video is sent to the configured Insight video UDP port.
-- Detection metadata is sent to the configured Insight metadata UDP port.
-- The app adds only the `VideoSender` nodegroup for video output. It does not manually add lower-level color conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes.
-- This example feeds raw decoded frames to `VideoSender` with the raw-frame option. If an upstream pipeline already produces H.264, `VideoSender` also supports the encoded-input option, where it parses, packetizes, and sends without re-encoding.
-- `model.path` must point to a valid YOLO compiled model package file.
-- `source.rtsp_url` must be set before running.
-- If `inference.frames` is zero, the sample runs continuously.
-- If `runtime.profile` is true, the sample prints aggregate profile summaries every `runtime.profile_interval` published frames.
+## Configure
+Edit `examples/object-detection/single-stream-object-detector/src/common/config.yaml`.
 
-## Command-Line Options
-- `--config <path>`
-  Optional. YAML config path. Defaults to `src/common/config.yaml`.
-- `--validate-config-only`
-  Validate YAML config and exit without opening the RTSP stream.
+```yaml
+model:
+  path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
 
-## Build
-This example can be built in either of these environments:
+source:
+  rtsp_url: rtsp://<insight-host-ip>:<rtsp.tcp>/<stream>  # RTSP stream URL.
+  tcp: true                                               # Use TCP transport for RTSP.
 
-- from a Neat Development Environment
-- directly on a `DevKit`
+inference:
+  frames: 0                                               # Frame limit. 0 runs continuously.
+  min_score: 0.30                                         # Minimum object confidence.
 
-Within either environment, the C++ implementation can be built in two ways. The Python implementation does not require a compile step.
-
-### Build From The Apps Repo
-Build all C++ examples from the `apps` repo root:
-
-```bash
-cd <apps-repo-root>
-./build.sh
+output:
+  insight:
+    host: <insight-host-ip>                               # Host running Insight.
+    video_port: <videoUDP start port from neat>           # UDP video port.
+    metadata_port: <metadataUDP start port from neat>     # UDP metadata port.
 ```
-
-The resulting binary is:
-
-```bash
-./build/examples/object-detection/single-stream-object-detector/single-stream-object-detector
-```
-
-### Build This Example Directly With CMake
-Configure and build only this example from its own directory:
-
-```bash
-cd <apps-repo-root>/examples/object-detection/single-stream-object-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-The resulting binary is:
-
-```bash
-./build/single-stream-object-detector
-```
-
-Direct CMake builds use the shared example module support in the `apps` repo and link against the available Neat Library installation or local core build.
-
-In practice:
-
-- in the Neat Development Environment, this is typically done after activating the environment and then building from the repo or the example folder
-- on `DevKit`, this can be done directly on the target device as long as the required Neat Library dependencies are installed
-
-## RTSP Source
-
-If you want a quick RTSP source for testing, [`tool-mediasources`](https://github.com/SiMa-ai/tool-mediasources) on the host is one option:
-
-```bash
-sima-cli install gh:sima-ai/tool-mediasources
-./mediasrc.sh <video-dir>
-open preview.html
-```
-
-If you use host-streamed sources from a board/devkit, use the host IP in the RTSP URL instead of `127.0.0.1`. Any other RTSP source also works.
 
 ## Run
-### Binary Built From The Apps Repo
+### C++
 ```bash
 ./build/examples/object-detection/single-stream-object-detector/single-stream-object-detector \
   --config examples/object-detection/single-stream-object-detector/src/common/config.yaml
 ```
 
-### Binary Built Directly In The Example Folder
-```bash
-./build/single-stream-object-detector \
-  --config src/common/config.yaml
-```
-
-Set the RTSP source and Insight destination in the config:
-
-```yaml
-source:
-  rtsp_url: rtsp://<host>:8554/<stream>
-  tcp: true
-model:
-  path: <model-path>
-inference:
-  frames: 0
-  min_score: 0.55
-  nms_iou: 0.50
-  max_detections: 100
-runtime:
-  profile: false
-  profile_interval: 100
-output:
-  save_dir: ""
-  save_every: 0
-  insight:
-    host: <insight-host-ip>
-    video_port: 9000
-    metadata_port: 9100
-```
-
-### Python Implementation
-Run the Python sample directly from the example folder:
-
-```bash
-cd <apps-repo-root>/examples/object-detection/single-stream-object-detector
-pip install -r src/python/requirements.txt
-python3 src/python/main.py --config src/common/config.yaml
-```
-
-Example workflow:
-
-Download the default YOLO26 detector model if it is not already available:
-
-```bash
-mkdir -p assets/models
-cd assets/models
-
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
-
-cd ../..
-```
-
-Then start the Python app:
-
+### Python
 ```bash
 source ~/pyneat/bin/activate
-pip install -r src/python/requirements.txt
-python3 src/python/main.py --config src/common/config.yaml
+pip install -r examples/object-detection/single-stream-object-detector/src/python/requirements.txt
+python3 examples/object-detection/single-stream-object-detector/src/python/main.py \
+  --config examples/object-detection/single-stream-object-detector/src/common/config.yaml
 ```
-
-Python-specific notes:
-
-- `model.path` must point to a downloaded YOLO26 detector package
-- it sends Insight metadata directly over UDP and streams video through `VideoSender`
 
 ## Debugging Notes
 - If the sample times out waiting for the first RTSP frame, the problem is usually upstream stream delivery or device connectivity, not YOLO itself.

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -41,7 +41,7 @@ Use the same `neat` output to set `output.insight.host`, `video_port`, and `meta
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit
 - RTSP source created in Insight or provided by your camera
-- Default model downloaded into `assets/models/`
+- Default model downloaded, or `model.path` set to another readable model package
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -72,12 +72,14 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Configure
 Edit `examples/object-detection/single-stream-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
+  path: <model-path>                                      # Path to the model package.
 
 source:
   rtsp_url: <rtsp-url-copied-from-insight>                # RTSP stream URL.

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -57,7 +57,7 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
@@ -67,7 +67,7 @@ Download the default model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -35,9 +35,11 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 - Labels file: `examples/object-detection/yolo26-object-detector/src/common/coco_label.txt`
 
 ## Get The Apps Repo
@@ -58,7 +60,7 @@ Edit `examples/object-detection/yolo26-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
+  path: <model-path>                         # Path to the model package.
   labels: examples/object-detection/yolo26-object-detector/src/common/coco_label.txt
 
 io:
@@ -129,7 +131,7 @@ pytest examples/object-detection/yolo26-object-detector/tests/python/test_e2e.py
 
 ## Debugging Notes
 - If detections are missing, validate label file ordering and score thresholds.
-- If model load fails, verify `assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz` exists.
+- If model load fails, verify `model.path` points to a readable model package.
 - Ensure input folder contains supported image extensions (`.jpg`, `.jpeg`, `.png`, `.bmp`).
 - Use `--profile` to identify bottlenecks in the pipeline.
 - Use `decode.score_threshold` and `decode.nms_iou` to tune detection sensitivity.

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -67,62 +67,36 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- C++ and Python read runtime values from `src/common/config.yaml`.
-- Labels file is configured under `model.labels`.
-- Output images are written as `.png` files.
-- Use `runtime.profile` to print per-image and aggregate timing plus FPS.
-- Use `runtime.num_runs` to repeat the image set for benchmarking.
-- Use `output.overlay: false` to skip drawing bounding boxes and writing output images.
+## Configure
+Edit `examples/object-detection/yolo26-object-detector/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz # Model package to load.
+  labels: examples/object-detection/yolo26-object-detector/src/common/coco_label.txt
 
-### Python
-- Invocation:
-  `python examples/object-detection/yolo26-object-detector/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+io:
+  input_dir: assets/test_images                           # Folder containing input images.
+  output_dir: sandbox/yolo26-object-detector              # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/object-detection/yolo26-object-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/yolo26-object-detector
+decode:
+  score_threshold: 0.40                                   # Minimum object confidence.
+  nms_iou: 0.60                                           # Overlap threshold for NMS.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector
+./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector \
+  --config examples/object-detection/yolo26-object-detector/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/yolo26-object-detector/src/python/requirements.txt
-python examples/object-detection/yolo26-object-detector/src/python/main.py
+python3 examples/object-detection/yolo26-object-detector/src/python/main.py \
+  --config examples/object-detection/yolo26-object-detector/src/common/config.yaml
 ```
 
 ## Testing

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -20,34 +20,20 @@ Snippet from a pipeline run:
 ![YOLO26 object detector preview](../../../assets/portal/object-detection/yolo26-object-detector/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download one model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```
-
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Prerequisites
 - Installed Neat Development Environment.
@@ -147,6 +133,17 @@ pytest examples/object-detection/yolo26-object-detector/tests/python/test_e2e.py
 - Ensure input folder contains supported image extensions (`.jpg`, `.jpeg`, `.png`, `.bmp`).
 - Use `--profile` to identify bottlenecks in the pipeline.
 - Use `decode.score_threshold` and `decode.nms_iou` to tune detection sensitivity.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+- `yolo26m-det-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -33,16 +33,21 @@ Supported batch-1 YOLO26 detection models:
 - `yolo26m-det-bf16-b1.tar.gz`
 - `yolo26m-det-int8-b1.tar.gz`
 
-Download the default model:
+Download one model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-det-bf16-mla_tess-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
 
 cd ../..
 ```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Prerequisites
 - Installed Neat Development Environment.

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -20,7 +20,7 @@ Snippet from a pipeline run:
 ![YOLO26 object detector preview](../../../assets/portal/object-detection/yolo26-object-detector/image.png)
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
@@ -30,7 +30,7 @@ Download the default model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/object-detection/yolo26-object-detector/src/common/config.yaml
+++ b/examples/object-detection/yolo26-object-detector/src/common/config.yaml
@@ -1,20 +1,20 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Detector model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
   labels: examples/object-detection/yolo26-object-detector/src/common/coco_label.txt
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/yolo26-object-detector
+io:                          # Input and output paths.
+  input_dir: assets/test_images                 # Folder containing input images.
+  output_dir: sandbox/yolo26-object-detector    # Folder for annotated images.
 
-decode:
-  score_threshold: 0.40
-  nms_iou: 0.60
-  max_detections: 50
+decode:                      # YOLO decode settings.
+  score_threshold: 0.40      # Minimum object confidence.
+  nms_iou: 0.60              # Overlap threshold for NMS.
+  max_detections: 50         # Max detections to keep per image.
 
-runtime:
-  timeout_ms: 20000
-  num_runs: 1
-  profile: false
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  num_runs: 1                # Number of repeated runs.
+  profile: false             # Print profiling summaries.
 
-output:
-  overlay: true
+output:                      # Output rendering settings.
+  overlay: true              # Draw boxes and labels on output images.

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -56,10 +56,12 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit.
 - RTSP source created in Insight or provided by your camera.
-- Default YOLO26 segmentation model package downloaded locally.
+- Default YOLO26 segmentation model downloaded, or `model.path` set to another readable model package.
 - `model.path`, `model.labels`, `source.rtsp_url`, and `output.insight.host` set in `src/common/config.yaml`.
 
 ## Get The Apps Repo
@@ -80,7 +82,7 @@ Edit `examples/segmentation/single-stream-instance-segmenter/src/common/config.y
 
 ```yaml
 model:
-  path: assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-b1.tar.gz # Model package to load.
+  path: <model-path>                                                # Path to the model package.
 
 source:
   rtsp_url: <rtsp-url-copied-from-insight>                          # RTSP stream URL.

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -41,7 +41,7 @@ To create a reproducible RTSP input:
 Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-seg-bf16-b1.tar.gz`.
 
@@ -51,7 +51,7 @@ Download the default model:
 mkdir -p assets/models/YOLO26-SEGMENTATION
 cd assets/models/YOLO26-SEGMENTATION
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
 
 cd ../../..
 ```

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -42,24 +42,21 @@ Supported YOLO26 segmentation models:
 - `yolo26m-seg-bf16-mla_tess-b1.tar.gz`
 - `yolo26m-seg-int8-b1.tar.gz`
 
-Download the supported variants:
+Download one model:
 
 ```bash
-PLATFORM_VERSION=<platform-version>
 mkdir -p assets/models/YOLO26-SEGMENTATION
 cd assets/models/YOLO26-SEGMENTATION
 
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz"
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-seg-bf16-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/${MODEL}"
 
 cd ../../..
 ```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit.

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -31,47 +31,35 @@ Snippet from a pipeline run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive segmentation metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Run `neat` in the Neat Developer Environment and copy these values into your config:
+To create a reproducible RTSP input:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use a sample video or upload your own video.
+4. Start the stream and copy the RTSP URL.
+5. Put that RTSP URL into `source.rtsp_url`.
 
-- `Insight Web UI`: browser URL for the viewer
-- `rtsp.tcp`: RTSP source port
-- `videoUDP`: UDP video port range
-- `metadataUDP`: UDP metadata port range
+Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
-Supported YOLO26 segmentation models:
+Default model: `yolo26m-seg-bf16-b1.tar.gz`.
 
-- `yolo26n-seg-bf16-mla_tess.tar.gz`
-- `yolo26s-seg-bf16-mla_tess.tar.gz`
-- `yolo26m-seg-bf16-mla_tess.tar.gz`
-- `yolo26l-seg-bf16-mla_tess.tar.gz`
-- `yolo26x-seg-bf16-mla_tess.tar.gz`
-- `yolo26m-seg-bf16-b1.tar.gz`
-- `yolo26m-seg-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-seg-int8-b1.tar.gz`
-
-Download one model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models/YOLO26-SEGMENTATION
 cd assets/models/YOLO26-SEGMENTATION
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-seg-bf16-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/${MODEL}"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
 
 cd ../../..
 ```
 
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
-
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit.
-- RTSP camera source, or an Insight/tool-mediasources RTSP stream.
-- A YOLO26 segmentation model package downloaded locally.
+- RTSP source created in Insight or provided by your camera.
+- Default YOLO26 segmentation model package downloaded locally.
 - `model.path`, `model.labels`, `source.rtsp_url`, and `output.insight.host` set in `src/common/config.yaml`.
 
 ## Get The Apps Repo
@@ -95,7 +83,7 @@ model:
   path: assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-b1.tar.gz # Model package to load.
 
 source:
-  rtsp_url: rtsp://<insight-host-ip>:<rtsp.tcp>/<stream>             # RTSP stream URL.
+  rtsp_url: <rtsp-url-copied-from-insight>                          # RTSP stream URL.
   tcp: true                                                          # Use TCP transport for RTSP.
 
 inference:
@@ -129,6 +117,18 @@ python3 examples/segmentation/single-stream-instance-segmenter/src/python/main.p
 - If the app times out waiting for RTSP, verify source reachability first.
 - If Insight receives no video, verify `output.insight.host` and UDP ports.
 - If saved frames are needed for inspection, set `output.save_dir` and `output.save_every`.
+
+## Appendix: Additional Models
+Other supported YOLO26 segmentation models:
+- `yolo26n-seg-bf16-mla_tess.tar.gz`
+- `yolo26s-seg-bf16-mla_tess.tar.gz`
+- `yolo26m-seg-bf16-mla_tess.tar.gz`
+- `yolo26l-seg-bf16-mla_tess.tar.gz`
+- `yolo26x-seg-bf16-mla_tess.tar.gz`
+- `yolo26m-seg-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-seg-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -28,6 +28,16 @@ Snippet from a pipeline run:
 
 ![Single stream instance segmenter preview](../../../assets/portal/segmentation/single-stream-instance-segmenter/image.png)
 
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive segmentation metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+
+Run `neat` in the Neat Developer Environment and copy these values into your config:
+
+- `Insight Web UI`: browser URL for the viewer
+- `rtsp.tcp`: RTSP source port
+- `videoUDP`: UDP video port range
+- `metadataUDP`: UDP metadata port range
+
 ## Supported Models
 Use the platform version wherever `<platform-version>` appears.
 
@@ -77,46 +87,26 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- C++ and Python read runtime values from `src/common/config.yaml`.
-- `model.path` must point to a valid YOLO26 segmentation model package.
-- `model.labels` points to the COCO labels file used for overlays and metadata.
-- `source.rtsp_url` must point to a live RTSP stream.
-- `output.insight.host` must point to the host running the Insight receiver/viewer.
-- If `inference.frames` is zero, the sample runs continuously.
-- Masks are rendered into the video stream. Metadata contains object labels, confidences, and boxes.
-- `output.save_dir` and `output.save_every` can be used to save sampled annotated frames.
-- The model path uses model-managed preprocessing with `COCO_YOLO` normalization and `YoloV26Seg` decode.
-- Insight video is sent through `VideoSender`; the app passes raw frames plus stream geometry, and the nodegroup owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output.
+## Configure
+Edit `examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml`.
 
-## Command-Line Options
-- `--config <path>`
-  Optional. YAML config path. Defaults to `src/common/config.yaml`.
-- `--validate-config-only`
-  Validate YAML config and exit without opening the RTSP stream.
+```yaml
+model:
+  path: assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-b1.tar.gz # Model package to load.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
+source:
+  rtsp_url: rtsp://<insight-host-ip>:<rtsp.tcp>/<stream>             # RTSP stream URL.
+  tcp: true                                                          # Use TCP transport for RTSP.
 
-Binary output:
-```bash
-./build/examples/segmentation/single-stream-instance-segmenter/single-stream-instance-segmenter
-```
+inference:
+  frames: 0                                                          # Frame limit. 0 runs continuously.
+  min_score: 0.55                                                    # Minimum instance confidence.
 
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/segmentation/single-stream-instance-segmenter
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/single-stream-instance-segmenter
+output:
+  insight:
+    host: <insight-host-ip>                                          # Host running Insight.
+    video_port: <videoUDP start port from neat>                      # UDP video port.
+    metadata_port: <metadataUDP start port from neat>                # UDP metadata port.
 ```
 
 ## Run
@@ -132,40 +122,6 @@ source ~/pyneat/bin/activate
 pip install -r examples/segmentation/single-stream-instance-segmenter/src/python/requirements.txt
 python3 examples/segmentation/single-stream-instance-segmenter/src/python/main.py \
   --config examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
-```
-
-Example config:
-
-```yaml
-model:
-  path: assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-b1.tar.gz
-  labels: examples/segmentation/single-stream-instance-segmenter/src/common/coco_label.txt
-
-source:
-  rtsp_url: rtsp://<host>:8554/<stream>
-  tcp: true
-  latency_ms: 100
-
-inference:
-  frames: 0
-  min_score: 0.55
-  nms_iou: 0.60
-  max_detections: 50
-
-runtime:
-  profile: false
-  profile_interval: 100
-
-output:
-  save_dir: ""
-  save_every: 0
-  mask_alpha: 0.55
-  mask_threshold: 0.50
-  draw_boxes: true
-  insight:
-    host: <insight-host-ip>
-    video_port: 9000
-    metadata_port: 9100
 ```
 
 ## Debugging Notes

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -20,7 +20,7 @@ Snippet from a pipeline run:
 ![Instance segmenter preview](../../../assets/portal/segmentation/yolov8-instance-segmenter/image.jpg)
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo_v8n_seg`.
 
@@ -30,7 +30,7 @@ Download the default model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli modelzoo -v 2.1.2 get yolo_v8n_seg
+sima-cli modelzoo -v <platform-version> get yolo_v8n_seg
 
 cd ../..
 ```

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -57,54 +57,19 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- Model path is positional and required.
-- Input directory is scanned for common image extensions.
-- Output images include per-instance mask overlays plus bounding boxes/class labels.
-- Runtime and decode settings live in `src/common/config.yaml`.
-- Inference runs on a resized model input, but saved overlays preserve the original image resolution.
-- Uses YOLOv8-seg tensors for box regression/class scores, mask coefficients, and prototype masks.
-- Masks, mask contours, and bounding boxes share the same vivid class-color palette.
+## Configure
+Edit `examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/segmentation/yolov8-instance-segmenter/yolov8-instance-segmenter [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+```yaml
+model:
+  path: assets/models/yolo_v8n_seg_mpk.tar.gz  # Model package to load.
 
-### Python
-- Invocation:
-  `python3 examples/segmentation/yolov8-instance-segmenter/src/python/main.py [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+io:
+  input_dir: assets/test_images                 # Folder containing input images.
+  output_dir: sandbox/yolov8-instance-segmenter # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/segmentation/yolov8-instance-segmenter/yolov8-instance-segmenter
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/segmentation/yolov8-instance-segmenter
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/yolov8-instance-segmenter
+decode:
+  score_threshold: 0.25                         # Minimum instance confidence.
 ```
 
 ## Run

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -24,13 +24,25 @@ Use the platform version wherever `<platform-version>` appears.
 
 Also works with: `yolo_v8s_seg`, `yolo_v8m_seg`, `yolo_v8l_seg`
 
-Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get yolo_v8n_seg && cd ../..`
+Download one model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo_v8n_seg
+
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get "${MODEL}"
+
+cd ../..
+```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with a supported modelzoo name.
 
 ## Prerequisites
 - Installed Neat Development Environment.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get yolo_v8n_seg && cd ../..`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -35,9 +35,11 @@ sima-cli modelzoo -v <platform-version> get yolo_v8n_seg
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -57,7 +59,7 @@ Edit `examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/yolo_v8n_seg_mpk.tar.gz  # Model package to load.
+  path: <model-path>                   # Path to the model package.
 
 io:
   input_dir: assets/test_images                 # Folder containing input images.

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -20,25 +20,20 @@ Snippet from a pipeline run:
 ![Instance segmenter preview](../../../assets/portal/segmentation/yolov8-instance-segmenter/image.jpg)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
-Also works with: `yolo_v8s_seg`, `yolo_v8m_seg`, `yolo_v8l_seg`
+Default model: `yolo_v8n_seg`.
 
-Download one model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo_v8n_seg
-
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get "${MODEL}"
+sima-cli modelzoo -v 2.1.2 get yolo_v8n_seg
 
 cd ../..
 ```
-
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with a supported modelzoo name.
 
 ## Prerequisites
 - Installed Neat Development Environment.
@@ -91,6 +86,10 @@ python3 examples/segmentation/yolov8-instance-segmenter/src/python/main.py \
 - If startup fails, verify model file path and filename.
 - If output is empty, check `decode.score_threshold` and `runtime.infer_size`.
 - Ensure output directory is writable.
+
+## Appendix: Additional Models
+This example also works with `yolo_v8s_seg`, `yolo_v8m_seg`, and `yolo_v8l_seg`.
+Replace `yolo_v8n_seg` in the download command and update `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml
+++ b/examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml
@@ -1,19 +1,19 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Segmenter model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/yolov8-instance-segmenter
+io:                          # Input and output paths.
+  input_dir: assets/test_images                    # Folder containing input images.
+  output_dir: sandbox/yolov8-instance-segmenter    # Folder for annotated images.
 
-runtime:
-  infer_size: 640
-  timeout_ms: 20000
-  queue_depth: 8
+runtime:                     # Runtime settings.
+  infer_size: 640            # Square model input size.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  queue_depth: 8             # Runtime queue depth.
 
-decode:
-  score_threshold: 0.60
-  nms_iou: 0.45
-  max_detections: 200
+decode:                      # YOLOv8 segmentation decode settings.
+  score_threshold: 0.60      # Minimum instance confidence.
+  nms_iou: 0.45              # Overlap threshold for NMS.
+  max_detections: 200        # Max instances to keep per image.
 
-visualization:
-  mask_alpha: 0.65
+visualization:               # Overlay rendering settings.
+  mask_alpha: 0.65           # Mask overlay opacity.

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -32,7 +32,7 @@ To create reproducible RTSP inputs:
 Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Supported Models
-This README is written for SDK `2.1.2`.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-int8-b1.tar.gz`.
 
@@ -42,7 +42,7 @@ Download the default model:
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -22,47 +22,35 @@ Preview image from a live run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive tracking metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Run `neat` in the Neat Developer Environment and copy these values into your config:
+To create reproducible RTSP inputs:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use sample videos or upload your own videos.
+4. Start each stream and copy the RTSP URLs.
+5. Put those RTSP URLs into `streams`.
 
-- `Insight Web UI`: browser URL for the viewer
-- `rtsp.tcp`: RTSP source port
-- `videoUDP`: UDP video port range
-- `metadataUDP`: UDP metadata port range
+Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+This README is written for SDK `2.1.2`.
 
 Default model: `yolo26m-det-int8-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download a supported model:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-PLATFORM_VERSION="<platform-version>"
-MODEL=yolo26m-det-int8-b1.tar.gz
-
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```
 
-Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
-
 ## Prerequisites
 - A Neat Python environment with `pyneat`, `numpy`, and OpenCV available.
-- One or more reachable RTSP camera URLs.
-- A YOLO26 detector model pack downloaded into `assets/models/`.
+- RTSP sources created in Insight or provided by your cameras.
+- Default YOLO26 detector model pack downloaded into `assets/models/`.
 - An Insight viewer instance reachable from the board/host running this example.
 
 ## Get The Apps Repo
@@ -86,8 +74,8 @@ model:
   path: assets/models/yolo26m-det-int8-b1.tar.gz       # Model package to load.
 
 streams:
-  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-1>     # First RTSP stream.
-  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-2>     # Second RTSP stream.
+  - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
+  - <second-rtsp-url-copied-from-insight>              # Second RTSP stream.
 
 inference:
   frames: 0                                            # Frame limit per stream. 0 runs continuously.
@@ -124,6 +112,17 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
 - Confirm each RTSP URL is reachable from the board or host running the example.
 - If Insight appears idle, verify `output.insight.host`, `video_port_base`, and `metadata_port_base`.
 - If you want saved overlay frames, set both `output.debug_dir` and `output.save_every`.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -47,10 +47,12 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - A Neat Python environment with `pyneat`, `numpy`, and OpenCV available.
 - RTSP sources created in Insight or provided by your cameras.
-- Default YOLO26 detector model pack downloaded into `assets/models/`.
+- Default YOLO26 detector model downloaded, or `model.path` set to another readable model package.
 - An Insight viewer instance reachable from the board/host running this example.
 
 ## Get The Apps Repo
@@ -71,7 +73,7 @@ Edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: assets/models/yolo26m-det-int8-b1.tar.gz       # Model package to load.
+  path: <model-path>                                   # Path to the model package.
 
 streams:
   - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
@@ -108,7 +110,7 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
 
 ## Debugging Notes
 - Start with one RTSP stream and confirm the config before scaling to multiple cameras.
-- Confirm the model file exists under `assets/models/`.
+- Confirm `model.path` points to a readable model package.
 - Confirm each RTSP URL is reachable from the board or host running the example.
 - If Insight appears idle, verify `output.insight.host`, `video_port_base`, and `metadata_port_base`.
 - If you want saved overlay frames, set both `output.debug_dir` and `output.save_every`.

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -45,22 +45,21 @@ Supported batch-1 YOLO26 detection models:
 - `yolo26m-det-bf16-b1.tar.gz`
 - `yolo26m-det-int8-b1.tar.gz`
 
-Download all supported batch-1 variants:
+Download a supported model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+PLATFORM_VERSION="<platform-version>"
+MODEL=yolo26m-det-int8-b1.tar.gz
+
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/${MODEL}"
 
 cd ../..
 ```
+
+Set `PLATFORM_VERSION` to your installed SDK platform version, and replace `MODEL` with any supported model listed above.
 
 ## Prerequisites
 - A Neat Python environment with `pyneat`, `numpy`, and OpenCV available.

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -14,22 +14,20 @@
 ## Concept
 Multi-stream people tracking example with RTSP inputs, mixed-resolution support, Insight live video plus metadata output, and optional sampled overlay saves. The pipeline filters detector output to the configured person class and assigns stable track IDs per stream.
 
-Both the Python and C++ entrypoints use one complete graph per RTSP stream:
-
-```text
-RtspDecodedInput
-  -> Branch(video, model[, debug_frame])
-    -> video: VideoSender(raw caps + H.264 RTP/UDP)
-    -> model: YOLO26 model.graph() -> Output(detections)
-    -> debug only: Combine(debug_frame, detections, ByFrame) -> debug_output
-```
-
-Each stream has one lightweight consumer that pulls detections, updates that stream's `PeopleTracker`, and sends Insight tracking metadata. There is no shared detector pool, mailbox queue, worker scheduler, or cross-camera identity tracking.
-
 ## Preview
 Preview image from a live run:
 
 ![Multi-stream people tracker preview](../../../assets/portal/tracking/multi-stream-people-tracker/image.png)
+
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive tracking metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+
+Run `neat` in the Neat Developer Environment and copy these values into your config:
+
+- `Insight Web UI`: browser URL for the viewer
+- `rtsp.tcp`: RTSP source port
+- `videoUDP`: UDP video port range
+- `metadataUDP`: UDP metadata port range
 
 ## Supported Models
 Use the platform version wherever `<platform-version>` appears.
@@ -80,119 +78,45 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- The Python and C++ implementations follow the same per-stream graph structure.
-- The `streams:` list in `src/common/config.yaml` controls the number of cameras dynamically. This phase supports up to four streams.
-- The checked-in `src/common/config.yaml` uses placeholder RTSP and Insight values; fill them with your own camera URLs and receiver host before running.
-- Stream `i` publishes video to `output.insight.video_port_base + i`.
-- Stream `i` publishes tracking metadata to `output.insight.metadata_port_base + i` for Insight-side overlay.
-- `inference.frames: 0` runs indefinitely.
-- `output.debug_dir: null` and `output.save_every: 0` disable saved overlay frames while keeping live Insight output enabled.
-- `inference.min_score`, `inference.nms_iou`, and `inference.max_detections` are explicit detector decode parameters in the checked-in config.
-- The example defaults to person class id `0`, and tracker behavior is configurable from the config file.
-- Both C++ and Python add the `VideoSender` nodegroup for video transport and use `model.graph()` for model-owned preprocessing, inference, and YOLO26 decode.
-- `VideoSender` owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. The app does not add those lower-level nodes itself.
-- Debug saves use `Combine(ByFrame)` so saved frames and tracks stay aligned.
+## Configure
+Edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  ```bash
-  ./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker \
-    --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
-  ```
-- Required arguments:
-  None.
-- Optional arguments:
-  `--config <path>` to load a different YAML configuration file.
+```yaml
+model:
+  path: assets/models/yolo26m-det-int8-b1.tar.gz       # Model package to load.
 
-### Python
-- Invocation:
-  ```bash
-  python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
-    --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
-  ```
-- Required arguments:
-  None.
-- Optional arguments:
-  `--config <path>` to load a different YAML configuration file.
+streams:
+  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-1>     # First RTSP stream.
+  - rtsp://<insight-host-ip>:<rtsp.tcp>/<stream-2>     # Second RTSP stream.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
+inference:
+  frames: 0                                            # Frame limit per stream. 0 runs continuously.
+  min_score: 0.30                                      # Minimum person confidence.
 
-Binary output:
-```bash
-./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker
-```
+tracking:
+  max_missing_frames: 15                               # Frames to keep a missing track alive.
 
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>
-cmake -S examples/tracking/multi-stream-people-tracker/src/cpp -B build/multi-stream-people-tracker
-cmake --build build/multi-stream-people-tracker -j
-```
-
-Binary output:
-```bash
-./build/multi-stream-people-tracker/multi-stream-people-tracker
+output:
+  insight:
+    host: <insight-host-ip>                            # Host running Insight.
+    video_port_base: <videoUDP start port from neat>   # First UDP video port.
+    metadata_port_base: <metadataUDP start port from neat> # First UDP metadata port.
 ```
 
 ## Run
-Before running either entrypoint, edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml` and replace the placeholder values in:
-
-- `streams`
-- `output.insight.host`
-
 ### C++
 ```bash
 ./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker \
   --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
 ```
 
-The C++ binary follows the same config contract and per-stream graph topology as the Python example.
-
 ### Python
-Install the small Python-side dependencies:
-
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/tracking/multi-stream-people-tracker/src/python/requirements.txt
-```
-
-Edit the example config in `src/common/config.yaml`, especially the placeholder values in:
-
-- `streams`
-- `output.insight.host`
-
-The `streams:` list controls the number of cameras dynamically.
-
-Run the Python example with that config:
-
-```bash
 python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
   --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
 ```
-
-Notes:
-
-- stream `i` feeds clean frames into `VideoSender` at
-  `output.insight.video_port_base + i`
-- stream `i` sends object-detection metadata with track IDs to `output.insight.metadata_port_base + i`
-- the default config runs indefinitely and does not save frames because
-  `output.debug_dir` is `null` and `output.save_every` is `0`
-- set `inference.frames` for a bounded smoke run
-- set `output.debug_dir` and `output.save_every` if you want sampled overlay frames
-  written as `stream_<index>_frame_<frame>.jpg`; the live Insight video stays clean
-- if the app runs on a DevKit, set `output.insight.host` to the Insight host IP,
-  not `127.0.0.1`
-- `pyneat.Model(...)` is still used, but the detector runtime composes the
-  model-owned graph fragment instead of a black-box one-call inference path
-- live metadata is emitted separately from video in Insight object-detection
-  format, with one channel per stream
 
 ## Debugging Notes
 - Start with one RTSP stream and confirm the config before scaling to multiple cameras.


### PR DESCRIPTION
## Summary
- simplify example READMEs around apps-root reproduction steps
- add concise Insight setup guidance for RTSP, VideoSender, MetadataSender, and metrics examples
- remove direct local CMake build instructions from portal-facing docs
- add short commented config snippets and align user-facing config YAML comments

## Validation
- python3 scripts/validate_readmes.py --root .
- python3 scripts/generate_catalog.py >/tmp/apps-catalog-readme-cleanup.json
- python3 -m json.tool /tmp/apps-catalog-readme-cleanup.json >/dev/null
- python3 -m pytest -c tests/pytest.ini --rootdir="$PWD" tests/scripts/test_portal_asset_contract.py tests/scripts/test_modelzoo_version_pin.py tests/scripts/test_scope_contract.py -q
- python3 scripts/check_cmake_style.py
- python3 scripts/check_duplicate_includes.py
- git diff --check

## CI
- CodeQL: passed
- Build Apps on Vulcan: passed
- Test Apps Runtime: passed
- Build/Publish SysDoc Examples Route: passed
- Publish Apps Algolia Index: passed

Note: `bash scripts/check_all.sh` could not run end-to-end on macOS because `/bin/bash` is Bash 3.2 and the shell scripts use `mapfile`; the individual checks available on this host were run above.