### PR TITLE
Point Apps issue Jira sync to NEAT project

### DIFF
--- a/.github/workflows/issues-jira-sync.yml
+++ b/.github/workflows/issues-jira-sync.yml
@@ -92,9 +92,9 @@ jobs:
       comment_url: '${{ github.event_name == ''workflow_dispatch'' && inputs.comment_url || github.event.comment.html_url || '''' }}'
       dry_run: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
       github_repository: '${{ github.repository }}'
-      jira_project_key: '${{ vars.JIRA_PROJECT_KEY || ''AUTO'' }}'
+      jira_project_key: '${{ vars.JIRA_PROJECT_KEY || ''NEAT'' }}'
       jira_issue_type_name: '${{ vars.JIRA_ISSUE_TYPE_NAME || ''Task'' }}'
-      jira_epic_key: '${{ vars.JIRA_NEAT_APPS_EPIC_KEY || ''AUTO-1881'' }}'
+      jira_epic_key: '${{ vars.JIRA_NEAT_APPS_EPIC_KEY || ''NEAT-62'' }}'
       jira_epic_link_field_id: '${{ vars.JIRA_EPIC_LINK_FIELD_ID || '''' }}'
       jira_gh_user_map_json: '${{ vars.JIRA_GH_USER_MAP_JSON || ''{}'' }}'
       jira_backlog_enforce: ${{ vars.JIRA_BACKLOG_ENFORCE == 'true' }}


### PR DESCRIPTION
## Summary

Update the Apps issue-to-Jira sync workflow defaults so GitHub issues are created in the NEAT Jira project by default.

## Changes

- Change the default Jira project key from `AUTO` to `NEAT`.
- Change the default Apps epic from `AUTO-1881` to `NEAT-62`.
- Keep repository/org variable overrides intact:
  - `JIRA_PROJECT_KEY` can still override the project.
  - `JIRA_NEAT_APPS_EPIC_KEY` can still override the epic.

## Impact

Apps GitHub issue sync will now route to the NEAT Jira project and default to epic `NEAT-62` when no override variables are configured.

## Validation

```bash
git diff --check
```
