### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/.github/workflows/issues-jira-sync.yml
+++ b/.github/workflows/issues-jira-sync.yml
@@ -92,9 +92,9 @@ jobs:
       comment_url: '${{ github.event_name == ''workflow_dispatch'' && inputs.comment_url || github.event.comment.html_url || '''' }}'
       dry_run: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
       github_repository: '${{ github.repository }}'
-      jira_project_key: '${{ vars.JIRA_PROJECT_KEY || ''AUTO'' }}'
+      jira_project_key: '${{ vars.JIRA_PROJECT_KEY || ''NEAT'' }}'
       jira_issue_type_name: '${{ vars.JIRA_ISSUE_TYPE_NAME || ''Task'' }}'
-      jira_epic_key: '${{ vars.JIRA_NEAT_APPS_EPIC_KEY || ''AUTO-1881'' }}'
+      jira_epic_key: '${{ vars.JIRA_NEAT_APPS_EPIC_KEY || ''NEAT-62'' }}'
       jira_epic_link_field_id: '${{ vars.JIRA_EPIC_LINK_FIELD_ID || '''' }}'
       jira_gh_user_map_json: '${{ vars.JIRA_GH_USER_MAP_JSON || ''{}'' }}'
       jira_backlog_enforce: ${{ vars.JIRA_BACKLOG_ENFORCE == 'true' }}

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -108,6 +108,21 @@ jobs:
             fi
 
             cd /workspace
+            echo "SDK release:"
+            cat /etc/sdk-release || true
+            echo "Build compiler environment:"
+            echo "  CC=${CC:-}"
+            echo "  CXX=${CXX:-}"
+            if [[ -n "${CC:-}" ]]; then
+              command -v "${CC}" || true
+              "${CC}" --version | head -n 1 || true
+            fi
+            if [[ -n "${CXX:-}" ]]; then
+              command -v "${CXX}" || true
+              "${CXX}" --version | head -n 1 || true
+            fi
+            echo "Cross compiler symlinks:"
+            ls -l /usr/bin/aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-g++ || true
             chmod +x build.sh scripts/ci/check_public_includes.sh scripts/install-vulcan-apps-package.sh
             ./build.sh --all --clean
             ./scripts/ci/check_public_includes.sh

--- a/README.md
+++ b/README.md
@@ -1,58 +1,64 @@
 # SiMa Neat Apps
 
-![Standard Build & Archive](https://img.shields.io/badge/Standard%20Build%20%26%20Archive-TBA-lightgrey)
-![Fuzz Nightly](https://img.shields.io/badge/Fuzz%20Nightly-TBA-lightgrey)
-![Crash Correctness Nightly](https://img.shields.io/badge/Crash%20Correctness%20Nightly-TBA-lightgrey)
-![Neat Development Environment](https://img.shields.io/badge/Neat%20Development%20Environment-2.0-green)
+![Vulcan CI](https://github.com/sima-neat/apps/actions/workflows/vulcan-ci.yml/badge.svg)
+![Apps Nightly E2E](https://github.com/sima-neat/apps/actions/workflows/nightly-e2e.yml/badge.svg)
+![Neat Development Environment](https://img.shields.io/badge/Neat%20Development%20Environment-2.1.2-green)
 ![Language](https://img.shields.io/badge/C%2B%2B-20-informational)
 
-Neat Apps contains editable Neat applications and reference examples built around real workflows such as detection, segmentation, and streaming pipelines. The goal is to make the apps easy to run, easy to modify, and easy to learn from.
+SiMa Neat Apps is a source-first collection of editable applications and reference
+examples for real Modalix workflows: detection, segmentation, streaming,
+tracking, benchmarking, and GenAI.
 
-The core idea is simple: the Neat Library provides the C++ and Python runtime APIs, while `apps` shows how to use them in customer-facing examples where the important Neat Library API calls stay visible in the source.
+Use this repo when you want runnable examples that keep the important Neat
+Library C++ and Python API calls visible in the source. Use the Neat Library
+docs for the runtime API contract, and use this repo for working application
+patterns.
 
-This repo is intentionally separate from `core`:
-- `core` owns the Neat Library runtime and tooling
-- `apps` holds customer-facing applications and sample code
+`core` owns the Neat Library runtime and tooling. `apps` owns customer-facing
+examples and sample application code.
 
-## Customer Workflow (Early Release)
+## Start
 
-1. Install the Neat Library by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Install the Neat Development Environment and Neat Library first:
 
-2. Clone this repo:
+- [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/install-the-environment)
+- [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/install-or-update)
+- [sima-cli](https://developer.sima.ai/software/tools/sima-cli/)
 
-   ```bash
-   git clone https://github.com/sima-neat/apps.git
-   cd apps
-   ```
+For Neat Development Environment 2.1.2:
 
-3. `sima-cli` is used by some examples and tools in this repo. Install it by following the official [sima-cli guide](https://developer.sima.ai/software/tools/sima-cli/).
+```bash
+sima-cli install ghcr:sima-neat/sdk:v2.1.2
+sima-cli sdk neat
+```
 
-4. For first-time setup, run:
+Clone and build this repo from the SDK shell:
 
-   ```bash
-   sudo apt update
-   sudo apt-get install -y nlohmann-json3-dev nodejs npm
-   ./build.sh --clean
-   ```
+```bash
+git clone https://github.com/sima-neat/apps.git
+cd apps
+./build.sh --clean
+```
 
-   This configures and builds the apps from the local checkout. Follow each example README for model downloads and run commands.
+Python examples use the PyNeat environment installed with the Neat Library:
 
-   **Note:** If the Neat Library was installed into the default `pyneat` virtual environment, activate it with `source ~/pyneat/bin/activate` to run Python examples.
+```bash
+source ~/pyneat/bin/activate
+```
 
-5. For broader Neat Library concepts and platform documentation, see:
-   https://developer.sima.ai/
+For the public examples index, use the
+[Neat Apps Portal](https://developer.sima.ai/examples). For broader application
+development docs, use [Develop Apps](https://developer.sima.ai/software/develop-apps/).
 
-This keeps examples editable and easy to customize.
+## Fetch One Example
 
-### Fetch A Single Example
-
-Users who only need one example can fetch it with the helper script:
+To fetch one example without cloning the full repo:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-example.sh | bash -s -- <example>
 ```
 
-For example:
+Example:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-example.sh | bash -s -- multimodal-assistant
@@ -61,172 +67,84 @@ cd multimodal-assistant
 ./run.sh
 ```
 
-The helper fetches the apps archive and leaves only the requested example
-directory in the current working directory.
-
 ## Repo Layout
-
-- `examples/`: application examples organized by task/category. Each example owns its README, runtime config, source entrypoints, and tests.
-- `support/`: shared C++ helper code used by multiple examples.
-- `assets/`: user-managed runtime assets, including models under `assets/models/` and test media under `assets/test_images/`.
-- `tests/`: centralized test infrastructure, including the runner, environment setup, pytest config, and docs.
-- `deps/manifest.json`: Neat Library and platform-version dependency declaration
-
-## Example Structure
-
-Examples are organized under `examples/<category>/<example>`. Each example is source-first and meant to be readable from its entrypoints. Most runtime examples provide both C++ and Python entrypoints; Python-only examples document their supported scripts in their own README.
-
-### Common Layout
 
 | Path | Purpose |
 | --- | --- |
-| `examples/<category>/<example>/README.md` | Example-specific usage and setup instructions |
-| `examples/<category>/<example>/tests/test-scope.yaml` | Internal test selection and e2e model source metadata |
-| `examples/<category>/<example>/src/cpp/CMakeLists.txt` | C++ example build configuration, when the example has a C++ implementation |
-| `examples/<category>/<example>/src/cpp/main.cpp` | C++ entrypoint with visible Neat Library API flow, when present |
-| `examples/<category>/<example>/tests/cpp/test_unit.cpp` | C++ unit tests, when C++ unit coverage is enabled |
-| `examples/<category>/<example>/tests/cpp/test_e2e.cpp` | C++ end-to-end tests, when C++ e2e coverage is enabled |
-| `examples/<category>/<example>/src/python/main.py` | Python entrypoint with visible Neat Library API flow, when the example uses a single Python entrypoint |
-| `examples/<category>/<example>/src/python/requirements.txt` | Python example dependencies |
-| `examples/<category>/<example>/tests/python/test_unit.py` | Python unit tests, when Python unit coverage is enabled |
-| `examples/<category>/<example>/tests/python/test_e2e.py` | Python end-to-end tests, when Python e2e coverage is enabled |
-| `examples/<category>/<example>/src/common/` | Files shared by the example implementations |
+| `examples/` | Application examples organized by category |
+| `assets/` | Runtime assets, including models and test media |
+| `tests/` | Test runner, fixtures, and test documentation |
+| `deps/manifest.json` | Neat Library and platform dependency declaration |
+| `portal/` | Source for the examples portal |
 
-> **IMPORTANT:** Use this structure when reading, extending, or adding examples, and follow each example README for any example-specific entrypoints.
-> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://developer.sima.ai/examples>).
+## Examples
 
-### Contributor Guidelines
+Examples live under `examples/<category>/<example>/`.
 
-For the contributor workflow, example contract, and review checklist, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+The common shape is:
 
-## Build (`build.sh`)
+| Path | Purpose |
+| --- | --- |
+| `README.md` | Example-specific setup and run instructions |
+| `src/common/` | Shared config, labels, and assets |
+| `src/cpp/main.cpp` | C++ entrypoint, when present |
+| `src/python/main.py` | Python entrypoint, when present |
+| `tests/` | Example-specific unit and e2e tests |
 
-`build.sh` has three main modes:
+Start with the example README. It is the source for model downloads, runtime
+inputs, config edits, and run commands for that example.
 
-- build/configure the apps locally
-- install the Neat Library dependency only
-- run the full release/package flow with `--all`, which installs the Neat Library dependency, builds the apps, builds the portal, and packages `neat-apps-runtime`
+Contributor details live in [CONTRIBUTING.md](./CONTRIBUTING.md). The README
+template lives at [examples/TEMPLATE_README.md](./examples/TEMPLATE_README.md).
 
-It does not run tests.
+## Build
+
+`build.sh` builds the repo. It does not run tests.
 
 Common commands:
 
 ```bash
-# Full release/package flow
-./build.sh --all --clean
-
-# Build only (default)
-./build.sh
-
-# Clean build directory then build
-./build.sh --clean
-
-# Install Neat Library dependency, build apps, build portal, then package
-./build.sh --all
-
-# Install Neat Library dependency only, no build
-./build.sh --only-install-neat-core
-
-# Override deps/manifest.json for one run (branch-version)
-./build.sh --all --neat-core-version main-latest
-
-# Debug build
-./build.sh --debug
-
-# Build to a custom directory
-./build.sh --build-dir out/build
+./build.sh          # configure and build
+./build.sh --clean  # clean build directory first
 ```
 
-Main `build.sh` args:
-
-- `--all`: install Neat Library dependency, build apps, build portal, then package
-- `--only-install-neat-core`: install Neat Library dependency and exit
-- `--neat-core-version <branch-version>`: override `deps/manifest.json`
-- `--clean`: remove build dir before configure
-- `--debug` / `--release`: build type
-- `--build-dir <dir>`: build directory
-- `--no-cpp`: skip C++ example build (layout/metadata only)
-
-When `--all` is used, the script also:
-
-- builds `portal/` with `npm` for local testing
-- stages a distributable `neat-apps-runtime/` tree
-- writes a packaged `neat-core.json` into that staged runtime
-- creates `neat-apps-<branch>-<sha>.tar.gz` at the repo root
-
-If Neat is installed in a custom location and CMake cannot find it automatically, set `CMAKE_PREFIX_PATH`:
-
-```bash
-CMAKE_PREFIX_PATH=/path/to/neat/install ./build.sh
-```
-
-### Cross Compilation
-
-`build.sh` auto-selects `cmake/toolchains/aarch64-modalix.cmake` when cross
-environment variables are present (`SYSROOT`, `CROSS_COMPILE`, `CC`, `CXX`).
-Set `CMAKE_TOOLCHAIN_FILE` explicitly if you want to override that default.
-
-Typical usage:
-
-```bash
-./build.sh
-```
-
-## Test (`tests/test.sh` only)
-
-Testing is documented in [tests/README.md](./tests/README.md).
-
-Summary:
-
-- `build.sh` does not run tests.
-- `tests/test.sh` is test-only.
-- For RTSP e2e tests, make sure RTSP stream source(s) are running before invoking `tests/test.sh`.
+Compile C++ examples in the Neat Development Environment. Run Neat runtime and
+e2e checks on SiMa hardware such as Modalix or DevKit.
 
 ## RTSP Streams
 
-If you want a quick RTSP source for testing, [`tool-mediasources`](https://github.com/SiMa-ai/tool-mediasources) on the host is one option:
+For quick RTSP sources, use
+[`tool-mediasources`](https://github.com/SiMa-ai/tool-mediasources):
 
 ```bash
 sima-cli install gh:sima-ai/tool-mediasources
 ./mediasrc.sh <video-dir>
 ```
 
-If you use [`tool-mediasources`](https://github.com/SiMa-ai/tool-mediasources), you can check the streams with:
-
-```bash
-open preview.html
-```
-
-If you use host-streamed sources from a board/devkit, use the host IP in the RTSP URL instead of `127.0.0.1`. Any other RTSP source also works.
+If a board or DevKit consumes host-streamed RTSP sources, use the host IP in the
+RTSP URL instead of `127.0.0.1`.
 
 ## Neat Library Dependency
 
-`deps/manifest.json` declares the Neat Library dependency and the platform version.
-The normal value is `"neat-core": {"policy": "snap"}`. Snap resolves from the
-dependency branch: `main` uses `main-latest`, `develop` uses `develop-latest`,
-and custom branches use a matching core branch when available or fall back to
-`develop-latest`. Explicit manifest pins can use `{"branch": "...", "spec": "..."}`
-or `{"ref": "...", "spec": "..."}`. Legacy string pins and the
-`--neat-core-version <branch-version>` override remain supported.
+`deps/manifest.json` declares the Neat Library dependency and platform version.
+
+The normal branch value is:
+
+```json
+{
+  "neat-core": {
+    "policy": "snap"
+  }
+}
+```
+
+`snap` resolves from the dependency branch: `main` uses `main-latest`, `develop`
+uses `develop-latest`, and custom branches use a matching core branch when one
+exists or fall back to `develop-latest`.
 
 ## Support
 
-Use the GitHub issue templates on the repo's `New issue` page and keep reports detailed.
+Use GitHub issues for bug reports and feature requests. Include the exact
+example, command, inputs, environment, and logs needed to reproduce the issue.
 
-For bug reports, include:
-
-- a clear explanation of the bug
-- the exact example, script, or command that was run
-- steps to reproduce
-- expected behavior and actual behavior
-- the full error message, traceback, or relevant logs
-- environment details such as platform, OS, Neat Development Environment version, and input assets
-
-For feature requests, include:
-
-- exactly what needs to be added, removed, or changed
-- why the change is necessary
-- the examples, docs, scripts, or workflows that should change
-- the expected outcome or acceptance criteria
-
-If you are blocked or need help triaging an issue, contact us at `support@sima.ai`.
+For direct help, contact `support@sima.ai`.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Examples are organized under `examples/<category>/<example>`. Each example is so
 | `examples/<category>/<example>/src/common/` | Files shared by the example implementations |
 
 > **IMPORTANT:** Use this structure when reading, extending, or adding examples, and follow each example README for any example-specific entrypoints.
-> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://apps.sima-neat.com/portal/index.html>).
+> Follow the instructions inside each example `README.md`, or visit the [SiMa.ai Neat Apps Portal](<https://developer.sima.ai/examples>).
 
 ### Contributor Guidelines
 

--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,16 @@ sanitize_branch_key() {
   printf '%s' "$1" | tr '/ ' '--'
 }
 
+core_artifact_branch_key() {
+  python3 - "$1" <<'PY'
+import sys
+import urllib.parse
+
+ref_key = urllib.parse.quote(sys.argv[1], safe="")
+print(urllib.parse.quote(ref_key, safe=""))
+PY
+}
+
 git_short_sha() {
   if [[ -n "${NEAT_APPS_ARTIFACT_SHORT_SHA:-}" ]]; then
     printf '%.7s\n' "${NEAT_APPS_ARTIFACT_SHORT_SHA}"
@@ -416,7 +426,7 @@ core_artifact_version_exists() {
     return 1
   fi
 
-  branch_key="$(sanitize_branch_key "${branch}")"
+  branch_key="$(core_artifact_branch_key "${branch}")"
   download_text "${NEAT_ARTIFACTS_BASE_URL}/${branch_key}/${version}/metadata.json" >/dev/null 2>&1
 }
 
@@ -548,7 +558,7 @@ resolve_latest_version() {
   local branch_key cache_key cache_path missing_path latest_url
   local resolved=""
 
-  branch_key="$(sanitize_branch_key "${branch}")"
+  branch_key="$(core_artifact_branch_key "${branch}")"
   cache_key="$(printf '%s' "${branch_key}" | tr -c 'A-Za-z0-9._-' '_')"
   cache_path="${LATEST_TAG_CACHE_DIR}/${cache_key}.tag"
   missing_path="${LATEST_TAG_CACHE_DIR}/${cache_key}.missing"

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,6 +1,7 @@
 {
   "neat-core": {
-    "policy": "snap"
+    "branch": "codex/internals-linux-codec-service",
+    "spec": "4d4688395032"
   },
   "sdk": {
     "channel": "develop"

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,7 +1,6 @@
 {
   "neat-core": {
-    "branch": "codex/internals-linux-codec-service",
-    "spec": "4d4688395032"
+    "policy": "snap"
   },
   "sdk": {
     "channel": "develop"

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -3,7 +3,7 @@
     "policy": "snap"
   },
   "sdk": {
-    "channel": "main"
+    "channel": "develop"
   },
-  "platform-version": "2.0.0"
+  "platform-version": "2.1.2"
 }

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -41,14 +41,14 @@ For another supported model, replace `<default-model>` in the download command a
 The command stores models under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -56,7 +56,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/<category>/<name>/src/common/config.yaml`.

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -22,18 +22,28 @@ Optional. If you have a demo screenshot for the portal detail page, place it her
 ```
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
-Also works with: `<model_variant_1>`, `<model_variant_2>`
+Default model: `<default-model>`.
 
-Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get <model_variant_1> && cd ../..`
+Download the default model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+
+sima-cli modelzoo -v <platform-version> get <default-model>
+
+cd ../..
+```
+
+For another supported model, replace `<default-model>` in the download command and config path.
+The command stores models under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 - If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get <default_model_name> && cd ../..`
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -48,69 +58,40 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- This example expects the model path to be provided explicitly at runtime.
-- Input and output paths are user-provided.
-- Update this section with any example-specific behavior that affects runtime results.
+## Configure
+Edit `examples/<category>/<name>/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/<category>/<name>/<binary> <args>`
-- Required arguments:
-  `<required_arg_1> <required_arg_2>`
-- Optional arguments:
-  `--flag <value>`
+```yaml
+model:
+  path: <model-path>             # Path to the model package.
 
-### Python
-- Invocation:
-  `python3 examples/<category>/<name>/src/python/main.py <args>`
-- Required arguments:
-  `<required_arg_1> <required_arg_2>`
-- Optional arguments:
-  `--flag <value>`
-
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/<category>/<name>/<binary>
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>
-cmake -S examples/<category>/<name>/src/cpp -B build/<name>
-cmake --build build/<name> -j
-```
-
-Binary output:
-```bash
-./build/<name>/<binary>
+io:
+  input_dir: assets/test_images           # Folder containing input images.
+  output_dir: sandbox/<name>              # Folder for generated outputs.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/<category>/<name>/<binary> <args>
+./build/examples/<category>/<name>/<binary> \
+  --config examples/<category>/<name>/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/<category>/<name>/src/python/requirements.txt
-python3 examples/<category>/<name>/src/python/main.py <args>
+python3 examples/<category>/<name>/src/python/main.py \
+  --config examples/<category>/<name>/src/common/config.yaml
 ```
 
 ## Debugging Notes
-- Confirm the model file exists under `assets/models/`.
+- Confirm `model.path` points to a readable model package.
 - Confirm input paths exist and are readable.
 - Confirm output directories are writable.
+
+## Appendix: Additional Models
+This example can also run with `<model_variant_1>` or `<model_variant_2>`. Replace the default model name in the download command and config path.
 
 ## Source Files
 - Test scope: `tests/test-scope.yaml`

--- a/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
+++ b/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
@@ -10,10 +10,11 @@ These results measure the compiled model package only. They do not include camer
 | Field | Value |
 | --- | --- |
 | Target | Modalix (`aarch64`) |
-| SDK | 2.0.0 |
+| SDK | 2.1.2 |
 | Date | 2026-06-12 |
 | Frames | 1000 |
 | Command | `python3 examples/benchmarking/model-benchmark/src/python/main.py --model <model-package>` |
+| Refresh Script | `python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py --run` |
 | JSON Reports | `sandbox/model-benchmark/runs/<model-id>.json` |
 | Power Columns | Omitted |
 

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -27,14 +27,14 @@ This example accepts any compiled model package supported by `pyneat.Model`.
 `tests/test-scope.yaml` lists the compiled model packages already used by Apps examples. `BENCHMARK_RESULTS.md` is the manually maintained table for reference benchmark results.
 
 ## Prerequisites
-- Installed Neat Development Environment.
+- Installed Neat Development Environment + Neat Library.
 - Activated `pyneat` environment.
-- A compiled model package available locally.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -42,7 +42,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or override these values from the command line.
@@ -59,7 +59,7 @@ output:
 ```
 
 ## Run
-From the Apps repo root:
+On the Modalix/DevKit board, from the Apps repo root:
 
 ```bash
 source ~/pyneat/bin/activate

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -29,7 +29,7 @@ This example accepts any compiled model package supported by `pyneat.Model`.
 ## Prerequisites
 - Installed Neat Development Environment.
 - Activated `pyneat` environment.
-- A compiled model package available locally, usually under `assets/models/`.
+- A compiled model package available locally.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -44,20 +44,19 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- `benchmark.frames` controls the measured synthetic frames passed to `Model.benchmark()`.
-- The default report path is `sandbox/model-benchmark/report.json`.
-- The JSON report is the stable output for comparing model packages.
+## Configure
+Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or override these values from the command line.
 
-## Command-Line Options
-### Python
-- Invocation:
-  `python3 examples/benchmarking/model-benchmark/src/python/main.py [--config <path>] [--model <path>] [--frames <n>] [--output-json <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
-  `--model <path>`: compiled model package path. Overrides `model.path`.
-  `--frames <n>`: measured synthetic frames. Overrides `benchmark.frames`.
-  `--output-json <path>`: report path. Overrides `output.report_json`.
+```yaml
+model:
+  path: <model-path>                          # Path to the model package.
+
+benchmark:
+  frames: 1000                                # Number of synthetic frames.
+
+output:
+  report_json: sandbox/model-benchmark/report.json # JSON report path.
+```
 
 ## Run
 From the Apps repo root:

--- a/examples/benchmarking/model-benchmark/scripts/refresh_results.py
+++ b/examples/benchmarking/model-benchmark/scripts/refresh_results.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Run all model benchmarks and refresh BENCHMARK_RESULTS.md."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+
+EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+APPS_ROOT = Path(__file__).resolve().parents[4]
+MAIN_PY = EXAMPLE_ROOT / "src" / "python" / "main.py"
+RESULTS_MD = EXAMPLE_ROOT / "BENCHMARK_RESULTS.md"
+REPORTS_DIR = APPS_ROOT / "sandbox" / "model-benchmark" / "runs"
+
+
+@dataclass(frozen=True)
+class ModelRow:
+    model_id: str
+    package: str
+    used_by: str
+    preferred_path: str
+
+
+@dataclass(frozen=True)
+class BenchmarkFailure:
+    model_id: str
+    reason: str
+
+
+GROUPS: tuple[tuple[str, tuple[ModelRow, ...]], ...] = (
+    (
+        "General Models",
+        (
+            ModelRow("resnet_50", "resnet_50_mpk.tar.gz", "image-classifier",
+                     "assets/models/resnet_50_mpk.tar.gz"),
+            ModelRow("depth_anything_v2_vits", "depth_anything_v2_vits_mpk.tar.gz",
+                     "depth-estimator", "assets/models/depth_anything_v2_vits_mpk.tar.gz"),
+            ModelRow("retinaface_mobilenet25", "retinaface_mobilenet25_mod_0_mpk.tar.gz",
+                     "face-detector", "assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz"),
+            ModelRow("detr_resnet50_modified_class_embed_bbox_embed",
+                     "detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz",
+                     "detr-object-detector",
+                     "assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz"),
+            ModelRow("yolo_v8n_seg", "yolo_v8n_seg_mpk.tar.gz",
+                     "yolov8-instance-segmenter", "assets/models/yolo_v8n_seg_mpk.tar.gz"),
+        ),
+    ),
+    (
+        "YOLO26 Detection",
+        (
+            ModelRow("yolo26n-det-bf16-mla_tess-b1",
+                     "yolo26n-det-bf16-mla_tess-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "multi-stream-people-tracker",
+                     "assets/models/YOLO26-DETECTION/yolo26n-det-bf16-mla_tess-b1.tar.gz"),
+            ModelRow("yolo26s-det-bf16-mla_tess-b1",
+                     "yolo26s-det-bf16-mla_tess-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "multi-stream-people-tracker",
+                     "assets/models/YOLO26-DETECTION/yolo26s-det-bf16-mla_tess-b1.tar.gz"),
+            ModelRow("yolo26m-det-bf16-mla_tess-b1",
+                     "yolo26m-det-bf16-mla_tess-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "yolo26-object-detector, detection-to-vlm-assistant, "
+                     "multi-stream-people-tracker",
+                     "assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz"),
+            ModelRow("yolo26l-det-bf16-mla_tess-b1",
+                     "yolo26l-det-bf16-mla_tess-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "multi-stream-people-tracker",
+                     "assets/models/YOLO26-DETECTION/yolo26l-det-bf16-mla_tess-b1.tar.gz"),
+            ModelRow("yolo26x-det-bf16-mla_tess-b1",
+                     "yolo26x-det-bf16-mla_tess-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "multi-stream-people-tracker",
+                     "assets/models/YOLO26-DETECTION/yolo26x-det-bf16-mla_tess-b1.tar.gz"),
+            ModelRow("yolo26m-det-bf16-b1", "yolo26m-det-bf16-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "detection-to-vlm-assistant, multi-stream-people-tracker",
+                     "assets/models/YOLO26-DETECTION/yolo26m-det-bf16-b1.tar.gz"),
+            ModelRow("yolo26m-det-int8-b1", "yolo26m-det-int8-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "detection-to-vlm-assistant, multi-stream-people-tracker",
+                     "assets/models/YOLO26-DETECTION/yolo26m-det-int8-b1.tar.gz"),
+        ),
+    ),
+    (
+        "YOLO26 Segmentation",
+        (
+            ModelRow("yolo26n-seg-bf16-mla_tess", "yolo26n-seg-bf16-mla_tess.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26n-seg-bf16-mla_tess.tar.gz"),
+            ModelRow("yolo26s-seg-bf16-mla_tess", "yolo26s-seg-bf16-mla_tess.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26s-seg-bf16-mla_tess.tar.gz"),
+            ModelRow("yolo26m-seg-bf16-mla_tess", "yolo26m-seg-bf16-mla_tess.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-mla_tess.tar.gz"),
+            ModelRow("yolo26l-seg-bf16-mla_tess", "yolo26l-seg-bf16-mla_tess.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26l-seg-bf16-mla_tess.tar.gz"),
+            ModelRow("yolo26x-seg-bf16-mla_tess", "yolo26x-seg-bf16-mla_tess.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26x-seg-bf16-mla_tess.tar.gz"),
+            ModelRow("yolo26m-seg-bf16-b1", "yolo26m-seg-bf16-b1.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/yolo26m-seg-bf16-b1.tar.gz"),
+            ModelRow("yolo26m-seg-bf16-mla_tess-b1",
+                     "yolo26m-seg-bf16-mla_tess-b1.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-mla_tess-b1.tar.gz"),
+            ModelRow("yolo26m-seg-int8-b1", "yolo26m-seg-int8-b1.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "assets/models/YOLO26-SEGMENTATION/yolo26m-seg-int8-b1.tar.gz"),
+        ),
+    ),
+)
+
+
+def all_rows() -> tuple[ModelRow, ...]:
+    return tuple(row for _, rows in GROUPS for row in rows)
+
+
+def selected_rows(model_ids: list[str] | None) -> tuple[ModelRow, ...]:
+    rows = all_rows()
+    if not model_ids:
+        return rows
+    known = {row.model_id: row for row in rows}
+    missing = sorted(set(model_ids) - set(known))
+    if missing:
+        raise ValueError(f"unknown model id(s): {', '.join(missing)}")
+    return tuple(known[model_id] for model_id in model_ids)
+
+
+def existing_context_value(name: str, default: str) -> str:
+    if not RESULTS_MD.exists():
+        return default
+    match = re.search(rf"^\| {re.escape(name)} \| (.*?) \|$", RESULTS_MD.read_text(), re.M)
+    return match.group(1) if match else default
+
+
+def detect_sdk() -> str:
+    try:
+        result = subprocess.run(["neat", "--offline"], cwd=APPS_ROOT, check=False,
+                                text=True, capture_output=True)
+    except FileNotFoundError:
+        return existing_context_value("SDK", "unknown")
+    match = re.search(r"^\s*SDK Version\s+(.+)$", result.stdout, re.M)
+    return match.group(1).strip() if match else existing_context_value("SDK", "unknown")
+
+
+def resolve_model_path(row: ModelRow) -> Path:
+    preferred = APPS_ROOT / row.preferred_path
+    if preferred.exists():
+        return preferred
+    matches = sorted((APPS_ROOT / "assets" / "models").rglob(row.package))
+    if not matches:
+        raise FileNotFoundError(f"model package not found: {row.package}")
+    return matches[0]
+
+
+def run_benchmarks(frames: int, reports_dir: Path, rows: tuple[ModelRow, ...]) -> list[BenchmarkFailure]:
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    failures: list[BenchmarkFailure] = []
+    for row in rows:
+        try:
+            model_path = resolve_model_path(row)
+        except FileNotFoundError as exc:
+            failures.append(BenchmarkFailure(row.model_id, str(exc)))
+            print(f"[failed] {row.model_id}: {exc}", file=sys.stderr, flush=True)
+            continue
+        out_path = reports_dir / f"{row.model_id}.json"
+        print(f"[benchmark] {row.model_id}: {model_path}", flush=True)
+        result = subprocess.run([
+            sys.executable,
+            str(MAIN_PY),
+            "--model",
+            str(model_path),
+            "--frames",
+            str(frames),
+            "--output-json",
+            str(out_path),
+        ], cwd=APPS_ROOT, check=False)
+        if result.returncode != 0:
+            failures.append(BenchmarkFailure(row.model_id, f"exit {result.returncode}"))
+            print(f"[failed] {row.model_id}: exit {result.returncode}", file=sys.stderr,
+                  flush=True)
+    return failures
+
+
+def report_metrics(reports_dir: Path, row: ModelRow) -> tuple[float, float]:
+    report_path = reports_dir / f"{row.model_id}.json"
+    if not report_path.exists():
+        raise FileNotFoundError(f"missing benchmark report: {report_path}")
+    data = json.loads(report_path.read_text())
+    metrics = data["metrics"]
+    return float(metrics["latency_ms"]), float(metrics["fps"])
+
+
+def report_date(reports_dir: Path) -> str:
+    dates: list[str] = []
+    for row in all_rows():
+        report_path = reports_dir / f"{row.model_id}.json"
+        if not report_path.exists():
+            continue
+        timestamp = json.loads(report_path.read_text()).get("benchmark", {}).get("timestamp_utc")
+        if timestamp:
+            dates.append(datetime.fromisoformat(timestamp).date().isoformat())
+    return max(dates) if dates else date.today().isoformat()
+
+
+def render_markdown(frames: int, sdk: str, run_date: str, reports_dir: Path) -> str:
+    lines = [
+        "# Model Benchmark Results",
+        "",
+        "This file is a manually maintained reference table for Apps-supported compiled model packages.",
+        "The numbers come from `pyneat.Model.benchmark()` through `src/python/main.py`.",
+        "",
+        "These results measure the compiled model package only. They do not include camera ingest, RTSP decode, Insight output, metadata conversion, overlays, or application postprocessing.",
+        "",
+        "## Run Context",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        "| Target | Modalix (`aarch64`) |",
+        f"| SDK | {sdk} |",
+        f"| Date | {run_date} |",
+        f"| Frames | {frames} |",
+        "| Command | `python3 examples/benchmarking/model-benchmark/src/python/main.py --model <model-package>` |",
+        "| Refresh Script | `python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py --run` |",
+        "| JSON Reports | `sandbox/model-benchmark/runs/<model-id>.json` |",
+        "| Power Columns | Omitted |",
+        "",
+    ]
+    for title, rows in GROUPS:
+        lines.extend([
+            f"## {title}",
+            "",
+            "| Model ID | Package | Used By | Latency / FPS |",
+            "| --- | --- | --- | ---: |",
+        ])
+        for row in rows:
+            latency_ms, fps = report_metrics(reports_dir, row)
+            lines.append(
+                f"| `{row.model_id}` | `{row.package}` | {row.used_by} | "
+                f"{latency_ms:.3f} / {fps:.2f} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run", action="store_true", help="run benchmarks before refreshing")
+    parser.add_argument("--frames", type=int, default=1000)
+    parser.add_argument("--reports-dir", type=Path, default=REPORTS_DIR)
+    parser.add_argument("--sdk", default=None)
+    parser.add_argument("--date", default=None)
+    parser.add_argument("--models", nargs="*", help="optional model IDs to rerun")
+    parser.add_argument("--allow-partial-update", action="store_true",
+                        help="refresh Markdown even when a requested benchmark fails")
+    args = parser.parse_args()
+
+    if args.frames <= 0:
+        parser.error("--frames must be > 0")
+
+    rows = selected_rows(args.models)
+    failures: list[BenchmarkFailure] = []
+    if args.run:
+        failures = run_benchmarks(args.frames, args.reports_dir, rows)
+
+    if failures and not args.allow_partial_update:
+        print("\nBenchmark failures:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure.model_id}: {failure.reason}", file=sys.stderr)
+        failed_ids = " ".join(failure.model_id for failure in failures)
+        print("\nRerun only failed model(s):", file=sys.stderr)
+        print("  python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py "
+              f"--run --frames {args.frames} --models {failed_ids}", file=sys.stderr)
+        print("BENCHMARK_RESULTS.md was not updated.", file=sys.stderr)
+        return 1
+
+    sdk = args.sdk or detect_sdk()
+    run_date = args.date or (date.today().isoformat() if args.run else report_date(args.reports_dir))
+    RESULTS_MD.write_text(render_markdown(args.frames, sdk, run_date, args.reports_dir),
+                          encoding="utf-8")
+    print(f"updated {RESULTS_MD}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmarking/model-benchmark/src/common/config.yaml
+++ b/examples/benchmarking/model-benchmark/src/common/config.yaml
@@ -1,8 +1,8 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Model package selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-benchmark:
-  frames: 1000
+benchmark:                   # Synthetic benchmark settings.
+  frames: 1000               # Number of synthetic frames to run.
 
-output:
-  report_json: sandbox/model-benchmark/report.json
+output:                      # Benchmark report output.
+  report_json: sandbox/model-benchmark/report.json # JSON report path.

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -20,17 +20,24 @@ The pipeline is trying to classify this goldfish image.
 ![Image classifier goldfish input](../../../assets/portal/classification/image-classifier/image.jpeg)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Primary model: `resnet_50`
 
-Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get resnet_50 && cd ../..`
+Download the model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli modelzoo -v <platform-version> get resnet_50
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get resnet_50 && cd ../..`
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -45,50 +52,18 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- Runtime settings live in `src/common/config.yaml`.
-- If `io.image` is null, the example downloads a sample goldfish image automatically.
-- `validation.min_probability` controls the pass/fail threshold for the expected class probability.
+## Configure
+Edit `examples/classification/image-classifier/src/common/config.yaml` if you want to use a different image or threshold.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/classification/image-classifier/image-classifier [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+```yaml
+model:
+  path: <model-path>                        # Path to the model package.
 
-### Python
-- Invocation:
-  `python examples/classification/image-classifier/src/python/main.py [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+io:
+  image: null                               # Input image. null uses the sample image.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/classification/image-classifier/image-classifier
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/classification/image-classifier
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/image-classifier
+validation:
+  min_probability: 0.50                     # Minimum expected-class probability.
 ```
 
 ## Run
@@ -102,12 +77,12 @@ Binary output:
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/classification/image-classifier/src/python/requirements.txt
-python examples/classification/image-classifier/src/python/main.py \
+python3 examples/classification/image-classifier/src/python/main.py \
   --config examples/classification/image-classifier/src/common/config.yaml
 ```
 
 ## Debugging Notes
-- If you see a model load error, verify the model file exists at `assets/models/resnet_50_mpk.tar.gz`.
+- If you see a model load error, verify `model.path` points to a readable model package.
 - If image decode fails, set `io.image` in the config.
 - If top-1 validation fails, try lowering `validation.min_probability` for debug runs.
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -36,13 +36,13 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -50,7 +50,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/classification/image-classifier/src/common/config.yaml` if you want to use a different image or threshold.

--- a/examples/classification/image-classifier/src/common/config.yaml
+++ b/examples/classification/image-classifier/src/common/config.yaml
@@ -1,15 +1,15 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Classifier model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  image: null
+io:                          # Input image settings.
+  image: null                # Optional local image path. null uses fallback_image_url.
   fallback_image_url: https://raw.githubusercontent.com/EliSchwartz/imagenet-sample-images/master/n01443537_goldfish.JPEG
 
-runtime:
-  input_width: 224
-  input_height: 224
-  timeout_ms: 20000
+runtime:                     # Runtime settings.
+  input_width: 224           # Model input width.
+  input_height: 224          # Model input height.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
 
-validation:
-  expected_class_id: 1
-  min_probability: 0.20
+validation:                  # Expected result check.
+  expected_class_id: 1       # Expected ImageNet class id.
+  min_probability: 0.20      # Minimum expected-class probability.

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -20,17 +20,24 @@ Snippet from a pipeline run:
 ![Depth estimator preview](../../../assets/portal/depth-estimation/depth-estimator/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Primary model: `depth_anything_v2_vits`
 
-Download into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits && cd ../..`
+Download the model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits && cd ../..`
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -45,61 +52,31 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- Runtime settings are read from `src/common/config.yaml` by default.
-- Input directory is scanned for common image extensions.
-- Output files are written to the configured output directory.
+## Configure
+Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/depth-estimation/depth-estimator/depth-estimator [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: <model-path>                         # Path to the model package.
 
-### Python
-- Invocation:
-  `python examples/depth-estimation/depth-estimator/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
-
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/depth-estimation/depth-estimator/depth-estimator
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/depth-estimation/depth-estimator
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/depth-estimator
+io:
+  input_dir: assets/test_images                         # Folder containing input images.
+  output_dir: sandbox/depth-estimator                   # Folder for depth visualizations.
 ```
 
 ## Run
-Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml` to point at the model and image folder.
-
 ### C++
 ```bash
-./build/examples/depth-estimation/depth-estimator/depth-estimator
+./build/examples/depth-estimation/depth-estimator/depth-estimator \
+  --config examples/depth-estimation/depth-estimator/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/depth-estimation/depth-estimator/src/python/requirements.txt
-python examples/depth-estimation/depth-estimator/src/python/main.py
+python3 examples/depth-estimation/depth-estimator/src/python/main.py \
+  --config examples/depth-estimation/depth-estimator/src/common/config.yaml
 ```
 
 ## Debugging Notes

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -36,13 +36,13 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -50,7 +50,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml`.

--- a/examples/depth-estimation/depth-estimator/src/common/config.yaml
+++ b/examples/depth-estimation/depth-estimator/src/common/config.yaml
@@ -1,11 +1,11 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Depth model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/depth-estimator
+io:                          # Input and output paths.
+  input_dir: assets/test_images       # Folder containing input images.
+  output_dir: sandbox/depth-estimator # Folder for depth visualizations.
 
-runtime:
-  infer_size: 518
-  timeout_ms: 20000
-  queue_depth: 4
+runtime:                     # Runtime settings.
+  infer_size: 518            # Square model input size.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  queue_depth: 4             # Runtime queue depth.

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -29,19 +29,24 @@ Snippet from a pipeline run:
 ![Face detector preview](../../../assets/portal/face-detection/face-detector/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Validated with: `retinaface_mobilenet25`
 
-Download into `assets/models/`:
-- `./scripts/download_models.sh retinaface_mobilenet25`
+Download the validated model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Preferred download command: `./scripts/download_models.sh retinaface_mobilenet25`
-- Direct URL fallback:
-  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz && cd ../..`
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -56,59 +61,35 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- C++ and Python read runtime values from `src/common/config.yaml`.
-- Detection confidence and NMS IoU live under `decode`.
-- By default, detections include 5-point facial landmarks unless `decode.landmarks` is `false`.
+## Configure
+Edit `examples/face-detection/face-detector/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/face-detection/face-detector_cpp/face-detector [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: <model-path>                                  # Path to the model package.
 
-### Python
-- Invocation:
-  `python3 examples/face-detection/face-detector/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+io:
+  input_dir: assets/test_images                               # Folder containing input images.
+  output_dir: sandbox/face-detector                           # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/face-detection/face-detector_cpp/face-detector
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/face-detection/face-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/face-detector
+decode:
+  confidence_threshold: 0.40                                  # Minimum face confidence.
+  landmarks: true                                             # Draw five facial landmarks.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/face-detection/face-detector_cpp/face-detector
+./build/examples/face-detection/face-detector_cpp/face-detector \
+  --config examples/face-detection/face-detector/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/face-detection/face-detector/src/python/requirements.txt
-python3 examples/face-detection/face-detector/src/python/main.py
+python3 examples/face-detection/face-detector/src/python/main.py \
+  --config examples/face-detection/face-detector/src/common/config.yaml
 ```
 
 ## Testing
@@ -167,7 +148,7 @@ Notes:
 - If `SIMANEAT_APPS_TEST_INPUT_DIR` is not set, both e2e tests fall back to `assets/test_images`.
 
 ## Debugging Notes
-- If the model fails to load, verify `assets/models/retinaface_mobilenet25_mod_0_mpk.tar.gz` exists and is readable.
+- If the model fails to load, verify `model.path` points to a readable model package.
 - If no detections appear, lower `decode.confidence_threshold` and confirm the input actually contains faces.
 - If too many duplicate boxes appear, reduce `decode.nms_iou` and/or lower `decode.top_k`.
 - If output writing fails, ensure `io.output_dir` exists or can be created.

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -45,13 +45,13 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -59,7 +59,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/face-detection/face-detector/src/common/config.yaml`.
@@ -93,7 +93,7 @@ python3 examples/face-detection/face-detector/src/python/main.py \
 ```
 
 ## Testing
-Run from the apps repository root:
+On the Modalix/DevKit board, run from the apps repository root:
 
 ```bash
 cd <apps-repo-root>

--- a/examples/face-detection/face-detector/src/common/config.yaml
+++ b/examples/face-detection/face-detector/src/common/config.yaml
@@ -1,20 +1,20 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Face detector model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/face-detector
+io:                          # Input and output paths.
+  input_dir: assets/test_images      # Folder containing input images.
+  output_dir: sandbox/face-detector  # Folder for annotated images.
 
-decode:
-  confidence_threshold: 0.40
-  nms_iou: 0.90
-  top_k: 5000
-  keep_top_k: 750
-  max_draw: 50
-  landmarks: true
+decode:                      # RetinaFace decode settings.
+  confidence_threshold: 0.40 # Minimum face confidence.
+  nms_iou: 0.90              # Overlap threshold for NMS.
+  top_k: 5000                # Candidate boxes before NMS.
+  keep_top_k: 750            # Candidate boxes after NMS.
+  max_draw: 50               # Max faces to draw per image.
+  landmarks: true            # Draw five facial landmarks.
 
-runtime:
-  timeout_ms: 20000
-  profile: false
-  num_runs: 100
-  verbose: false
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  profile: false             # Print profiling summaries.
+  num_runs: 100              # Number of repeated runs for profiling.
+  verbose: false             # Print verbose runtime output.

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -12,7 +12,7 @@
 | Model | yolo26m-det-bf16-mla_tess-b1 |
 
 ## Concept
-This example decodes an RTSP stream, runs YOLO26 detection with internal box decode, and sends video plus object-detection metadata to Insight. When OpenAI is enabled, the highest-score detected person is cropped and sent to the configured OpenAI-compatible Gemma server from a bounded background worker, so the detection and Insight loop keeps running.
+This example decodes an RTSP stream, runs YOLO26 detection with internal box decode, and sends video plus object-detection metadata to Insight. Insight video uses `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. When OpenAI is enabled, the highest-score detected person is cropped and sent to the configured OpenAI-compatible Gemma server from a bounded background worker, so the detection and Insight loop keeps running.
 
 ## Preview
 Detection metadata visualized in Insight:

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -22,8 +22,16 @@ Detection metadata visualized in Insight:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
+In the Neat Development Environment, install the sample video assets:
+
+```bash
+sima-cli install assets/multi-video-sources
+```
+
+This provides 720p and 480p videos that Insight can stream as RTSP sources.
+
 To create a reproducible RTSP input:
-1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
 2. In Insight, open `RTSP Source`.
 3. Use a sample video or upload your own video.
 4. Start the stream and copy the RTSP URL.
@@ -32,16 +40,16 @@ To create a reproducible RTSP input:
 Use the same `neat` output to set `insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Default YOLO26 detector model downloaded, or `model.path` set to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default YOLO26 detector model, or set `model.path` to another readable model package.
 - RTSP source created in Insight or provided by your camera.
 - Insight receiver running at the configured host and ports.
 - OpenAI-compatible Gemma server running when `openai.enabled` is true.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -49,7 +57,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Download Models
 Use the SDK platform version wherever `<platform-version>` appears.

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -19,10 +19,22 @@ Detection metadata visualized in Insight:
 
 ![Detection-to-VLM assistant preview](../../../assets/portal/genai/detection-to-vlm-assistant/image.png)
 
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+
+To create a reproducible RTSP input:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use a sample video or upload your own video.
+4. Start the stream and copy the RTSP URL.
+5. Put that RTSP URL into `source.rtsp_url`.
+
+Use the same `neat` output to set `insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- YOLO26 detector model package available under `assets/models/`.
-- RTSP stream readable from the Neat Development Environment.
+- Default YOLO26 detector model downloaded, or `model.path` set to another readable model package.
+- RTSP source created in Insight or provided by your camera.
 - Insight receiver running at the configured host and ports.
 - OpenAI-compatible Gemma server running when `openai.enabled` is true.
 
@@ -40,16 +52,9 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
-Supported batch-1 YOLO26 detector models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
+Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
 Download the default detector model:
 
@@ -60,6 +65,27 @@ cd assets/models
 sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
 
 cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
+## Configure
+Edit `examples/genai/detection-to-vlm-assistant/src/common/config.yaml`.
+
+```yaml
+source:
+  rtsp_url: <rtsp-url-copied-from-insight>              # RTSP stream URL.
+
+model:
+  path: <model-path>                                    # Path to the model package.
+
+insight:
+  host: <insight-host-ip>                                  # Host running Insight.
+  video_port: <videoUDP start port from neat>              # UDP video port.
+  metadata_port: <metadataUDP start port from neat>        # UDP metadata port.
+
+openai:
+  enabled: false                                           # Disable for detection plus Insight only.
 ```
 
 ## Run
@@ -76,6 +102,17 @@ For local model comparison, example configs are available under
 `sandbox/configs/detection-to-vlm-assistant/<model-name>/config.yaml`.
 
 The OpenAI path checks `/v1/models` before sending a crop, waits at least `openai.interval_seconds` between attempts, and keeps at most `openai.max_pending_requests` queued or in-flight requests.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detector models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+- `yolo26m-det-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - Python source: `src/python/main.py`, `src/python/utils/helpers.py`, `src/python/utils/openai_commenter.py`

--- a/examples/genai/detection-to-vlm-assistant/src/common/config.yaml
+++ b/examples/genai/detection-to-vlm-assistant/src/common/config.yaml
@@ -1,38 +1,38 @@
-source:
-  rtsp_url: <rtsp-url-1>  # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
+source:                      # RTSP input source.
+  rtsp_url: <rtsp-url-1>     # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
 
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Detector model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
   labels: examples/genai/detection-to-vlm-assistant/src/common/coco_label.txt
 
-inference:
-  frames: 0
-  min_score: 0.55
-  nms_iou: 0.60
-  max_detections: 50
+inference:                   # Detection controls.
+  frames: 0                  # Frame limit. 0 means run continuously.
+  min_score: 0.55            # Detection score threshold.
+  nms_iou: 0.60              # NMS IoU threshold.
+  max_detections: 50         # Max detections to keep per frame.
   # classes:
   #   - person
   #   - car
   #   - truck
 
-runtime:
-  timeout_ms: 50000
+runtime:                     # Runtime settings.
+  timeout_ms: 50000          # Inference timeout in milliseconds.
 
-insight:
-  host: <insight-host-ip>  # Host running the Insight receiver/viewer.
-  video_port: 9000
-  metadata_port: 9100
-  channel: 0
+insight:                     # Live video and metadata destination.
+  host: <insight-host-ip>    # Host running the Insight receiver/viewer.
+  video_port: 9000           # UDP video port.
+  metadata_port: 9100        # UDP metadata port.
+  channel: 0                 # Insight channel index.
 
-openai:
-  enabled: true
-  host: 127.0.0.1
-  port: 9998
-  model: gemma4
-  max_tokens: 128
-  interval_seconds: 3
-  timeout_seconds: 30
-  max_pending_requests: 1
+openai:                      # Optional OpenAI-compatible captioner.
+  enabled: true              # Enable crop-to-VLM requests.
+  host: 127.0.0.1            # OpenAI-compatible server host.
+  port: 9998                 # OpenAI-compatible server port.
+  model: gemma4              # Model name passed to the server.
+  max_tokens: 128            # Max generated tokens per request.
+  interval_seconds: 3        # Minimum seconds between VLM requests.
+  timeout_seconds: 30        # Request timeout in seconds.
+  max_pending_requests: 1    # Max queued or in-flight VLM requests.
   system_prompt: >-
     Write one sarcastic scene caption. Comment on the visible situation,
     not identity or appearance. Use 10 words or fewer. Avoid: darling,

--- a/examples/genai/detection-to-vlm-assistant/src/python/main.py
+++ b/examples/genai/detection-to-vlm-assistant/src/python/main.py
@@ -200,6 +200,8 @@ def main() -> int:
             if cfg.debug:
                 print(f"frame={frame_id} detections={len(boxes)}")
         return 0 if frame_id > 0 else 3
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -40,20 +40,20 @@ Multimodal assistant UI:
 ![Multimodal Assistant preview](../../../assets/portal/genai/multimodal-assistant/image.png)
 
 ## Prerequisites
-Install Neat before running the demo. The model server uses the Python
-environment where `pyneat` is available. The default scripts assume:
+- Installed Neat Development Environment + Neat Library.
+- The model server uses the Python environment where `pyneat` is available. The default scripts assume:
 
 ```text
 ~/pyneat/bin/python
 ```
 
-Set `PYNEAT_PYTHON=/path/to/python-with-pyneat` if your Neat environment is
+Set `PYNEAT_PYTHON=/path/to/python-with-pyneat` if your Neat Library environment is
 somewhere else.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -61,7 +61,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Install
 Fetch only this example:

--- a/examples/genai/multimodal-assistant/src/common/config.yaml
+++ b/examples/genai/multimodal-assistant/src/common/config.yaml
@@ -1,34 +1,34 @@
-server:
-  openai:
-    host: 0.0.0.0
-    port: 9998
+server:                      # Local OpenAI-compatible model server.
+  openai:                    # Server bind address.
+    host: 0.0.0.0            # Host interface to bind.
+    port: 9998               # Server port.
 
-  models:
-    chat:
+  models:                    # Models served by the local server.
+    chat:                    # Chat or vision-language models.
       # The first chat model is selected by default in the UI.
       - name: <primary-chat-model-name>
         path: <path-to-primary-chat-model-dir>
       - name: <secondary-chat-model-name>
         path: <path-to-secondary-chat-model-dir>
-    asr:
-      name: <asr-model-name>
-      path: <path-to-asr-model-dir>
+    asr:                     # Speech-to-text model.
+      name: <asr-model-name>        # Model name shown to the app.
+      path: <path-to-asr-model-dir> # Local model directory.
 
-app:
-  openai:
-    client_host: 127.0.0.1
-    port: 9998
+app:                         # Assistant web app settings.
+  openai:                    # OpenAI-compatible client endpoint.
+    client_host: 127.0.0.1   # Host used by the app client.
+    port: 9998               # Port used by the app client.
 
-  request:
-    max_tokens: 128
+  request:                   # Default generation settings.
+    max_tokens: 128          # Max generated tokens per response.
     system_prompt: >-
       Answer clearly and concisely.
 
-  web:
-    host: 0.0.0.0
-    port: 5000
-    https: true
+  web:                       # Browser UI settings.
+    host: 0.0.0.0            # Host interface to bind.
+    port: 5000               # Web UI port.
+    https: true              # Serve the UI over HTTPS.
 
-  rag:
-    enabled: false
-    embedding_model_dir: <path-to-embedding-model-dir>
+  rag:                       # Retrieval-augmented generation settings.
+    enabled: false                             # Enable document retrieval.
+    embedding_model_dir: <path-to-embedding-model-dir> # Embedding model directory.

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -22,21 +22,24 @@ Snippet from a pipeline run:
 ![DETR object detector preview](../../../assets/portal/object-detection/detr-object-detector/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Validated with: `detr_resnet50_modified_class_embed_bbox_embed`
 
-Download into `assets/models/`:
-- `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
+Download the validated model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be placed under `assets/models/`.
-- Preferred download command: `./scripts/download_models.sh detr_resnet50_modified_class_embed_bbox_embed`
-- Direct URL fallback:
-  `mkdir -p assets/models && cd assets/models && sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz && cd ../..`
-- Default model path:
-  `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz`
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -51,62 +54,35 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- The example expects an input folder with image files.
-- Input preprocessing preserves aspect ratio and center-pads into an `1333x800` model frame.
-- Output boxes are mapped back to the original image resolution before drawing.
-- By default all DETR foreground classes are considered. Set `decode.person_only: true` in `src/common/config.yaml` to keep only the DETR `person` class.
-- Overlay text uses built-in DETR COCO labels and class-colored boxes.
-- `runtime.profile` runs repeated inference and reports session, postprocessing, and overall timing statistics.
+## Configure
+Edit `examples/object-detection/detr-object-detector/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/object-detection/detr-object-detector/detr-object-detector [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: <model-path>                                  # Path to the model package.
 
-### Python
-- Invocation:
-  `python3 examples/object-detection/detr-object-detector/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+io:
+  input_dir: assets/test_images                                                # Folder containing input images.
+  output_dir: sandbox/detr-object-detector                                     # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/object-detection/detr-object-detector/detr-object-detector
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/object-detection/detr-object-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/detr-object-detector
+decode:
+  confidence_threshold: 0.70                                                   # Minimum object confidence.
+  person_only: false                                                           # Keep only COCO person detections when true.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/object-detection/detr-object-detector/detr-object-detector
+./build/examples/object-detection/detr-object-detector/detr-object-detector \
+  --config examples/object-detection/detr-object-detector/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/detr-object-detector/src/python/requirements.txt
-python3 examples/object-detection/detr-object-detector/src/python/main.py
+python3 examples/object-detection/detr-object-detector/src/python/main.py \
+  --config examples/object-detection/detr-object-detector/src/common/config.yaml
 ```
 
 ## Testing
@@ -160,7 +136,7 @@ pytest -c tests/pytest.ini --rootdir="$PWD" -m e2e \
 ```
 
 ## Debugging Notes
-- If the model fails to load, verify `assets/models/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` exists and is readable.
+- If the model fails to load, verify `model.path` points to a readable model package.
 - First-run model initialization can exceed 60 seconds on some setups. Increase `SIMANEAT_APPS_TEST_TIMEOUT_MS` (for example `180000`) for e2e runs.
 - If no detections appear, lower `decode.confidence_threshold` and confirm the input images contain supported COCO objects.
 - If detections are visibly offset, verify the model frame assumptions (`1333x800`) still match the compiled package.

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -38,13 +38,13 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -52,7 +52,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/object-detection/detr-object-detector/src/common/config.yaml`.
@@ -86,7 +86,7 @@ python3 examples/object-detection/detr-object-detector/src/python/main.py \
 ```
 
 ## Testing
-Run from the apps repository root:
+On the Modalix/DevKit board, run from the apps repository root:
 
 ```bash
 cd <apps-repo-root>

--- a/examples/object-detection/detr-object-detector/src/common/config.yaml
+++ b/examples/object-detection/detr-object-detector/src/common/config.yaml
@@ -1,17 +1,17 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # DETR model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/detr-object-detector
+io:                          # Input and output paths.
+  input_dir: assets/test_images              # Folder containing input images.
+  output_dir: sandbox/detr-object-detector   # Folder for annotated images.
 
-decode:
-  confidence_threshold: 0.70
-  max_draw: 50
-  person_only: false
+decode:                      # DETR decode settings.
+  confidence_threshold: 0.70 # Minimum object confidence.
+  max_draw: 50               # Max detections to draw per image.
+  person_only: false         # Keep only COCO person detections when true.
 
-runtime:
-  timeout_ms: 20000
-  profile: false
-  num_runs: 100
-  verbose: false
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  profile: false             # Print profiling summaries.
+  num_runs: 100              # Number of repeated runs for profiling.
+  verbose: false             # Print verbose runtime output.

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -22,8 +22,16 @@ Snippet from a pipeline run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
+In the Neat Development Environment, install the sample video assets:
+
+```bash
+sima-cli install assets/multi-video-sources
+```
+
+This provides 720p and 480p videos that Insight can stream as RTSP sources.
+
 To create reproducible RTSP inputs:
-1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
 2. In Insight, open `RTSP Source`.
 3. Use sample videos or upload your own videos.
 4. Start each stream and copy the RTSP URLs.
@@ -32,16 +40,16 @@ To create reproducible RTSP inputs:
 Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
-- Installed Neat Development Environment.
+- Installed Neat Development Environment + Neat Library.
 - RTSP sources created in Insight or provided by your cameras.
-- Default YOLO26 model downloaded, or `model.path` set to another readable model package.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default YOLO26 model, or set `model.path` to another readable model package.
 - Edit `src/common/config.yaml` before running with real streams.
 - On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the example if the runtime has been used by earlier ML/video apps.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -49,7 +57,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Download Models
 Use the SDK platform version wherever `<platform-version>` appears.

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -22,7 +22,7 @@ Snippet from a pipeline run:
 Architecture:
 - one complete graph per RTSP stream
 - each stream branches decoded NV12 frames into video and model paths
-- clean Insight video is sent through `VideoSender`
+- clean Insight video is sent through `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output
 - YOLO26 detections are sent as metadata for Insight overlay
 - optional debug output joins decoded frames and detections by frame id before saving
 
@@ -136,6 +136,7 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-str
 ## Notes
 - Point `model.path` at a YOLO26 detection pack. This example does not use a `model.family` config key.
 - Both C++ and Python use the same public graph shape: `RtspDecodedInput`, `graphs::Branch`, `model.graph()`, `graphs::Combine` for debug saves, and `VideoSender`.
+- The app does not add lower-level video conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes around `VideoSender`.
 - The live path keeps video and metadata separate. Insight overlays metadata on the clean video stream.
 - `output.video_enabled: false` disables per-stream H.264 video output. Metadata still runs.
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -19,23 +19,22 @@ Snippet from a pipeline run:
 
 ![Multi-stream object detector preview](../../../assets/portal/object-detection/multi-stream-object-detector/image.png)
 
-Architecture:
-- one complete graph per RTSP stream
-- each stream branches decoded NV12 frames into video and model paths
-- clean Insight video is sent through `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output
-- YOLO26 detections are sent as metadata for Insight overlay
-- optional debug output joins decoded frames and detections by frame id before saving
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-Per-stream graph:
-- `RtspDecodedInput -> Branch(video, model[, debug_frame])`
-- `video -> VideoSender(H.264 RTP/UDP)`
-- `model -> YOLO26 model.graph() -> detections`
-- debug only: `Combine(debug_frame, detections, ByFrame) -> debug_output`
+To create reproducible RTSP inputs:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use sample videos or upload your own videos.
+4. Start each stream and copy the RTSP URLs.
+5. Put those RTSP URLs into `streams`.
+
+Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- One or more reachable RTSP camera URLs.
-- A YOLO26 model pack downloaded into `assets/models/`.
+- RTSP sources created in Insight or provided by your cameras.
+- Default YOLO26 model downloaded, or `model.path` set to another readable model package.
 - Edit `src/common/config.yaml` before running with real streams.
 - On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the example if the runtime has been used by earlier ML/video apps.
 
@@ -52,54 +51,44 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Command-Line Options
-- `--config <path>`: path to the YAML configuration file
-- `--validate-config-only`: validate the config and exit without opening RTSP streams
-- `--help`: print the CLI help text
-
 ## Download Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 The default model is `yolo26m-det-int8-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download all supported batch-1 variants:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
 sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>
-cmake -S examples/object-detection/multi-stream-object-detector/src/cpp -B build/multi-stream-object-detector
-cmake --build build/multi-stream-object-detector -j
+## Configure
+Edit `examples/object-detection/multi-stream-object-detector/src/common/config.yaml`.
+
+```yaml
+model:
+  path: <model-path>                                   # Path to the model package.
+
+streams:
+  - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
+  - <second-rtsp-url-copied-from-insight>              # Second RTSP stream.
+
+inference:
+  frames: 0                                            # Frame limit per stream. 0 runs continuously.
+  min_score: 0.30                                      # Minimum object confidence.
+
+output:
+  insight:
+    host: <insight-host-ip>                            # Host running Insight.
+    video_port_base: <videoUDP start port from neat>   # First UDP video port.
+    metadata_port_base: <metadataUDP start port from neat> # First UDP metadata port.
 ```
 
 ## Run
@@ -133,12 +122,16 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-str
 - `output.debug_dir` and `output.save_every` let you save periodic aligned debug frames locally without changing the Insight output contract.
 - Profiling prints per-stream pull, metadata, output FPS, and detection-count summaries.
 
-## Notes
-- Point `model.path` at a YOLO26 detection pack. This example does not use a `model.family` config key.
-- Both C++ and Python use the same public graph shape: `RtspDecodedInput`, `graphs::Branch`, `model.graph()`, `graphs::Combine` for debug saves, and `VideoSender`.
-- The app does not add lower-level video conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes around `VideoSender`.
-- The live path keeps video and metadata separate. Insight overlays metadata on the clean video stream.
-- `output.video_enabled: false` disables per-stream H.264 video output. Metadata still runs.
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++: `src/cpp/main.cpp`

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -128,6 +128,7 @@ struct StreamRuntime {
   simaai::neat::Run run;
   std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
   std::vector<std::string> labels;
+  std::string output_name;
   ProfileWindow profile;
   int frame_w = 0;
   int frame_h = 0;
@@ -387,6 +388,14 @@ make_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, 
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 
@@ -422,17 +431,27 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   runtime.profile.enabled = cfg.profile;
   runtime.profile.stream_index = stream_index;
 
-  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
+  const std::string model_name = "model";
+  const std::string video_name = "video";
+  const std::string debug_frame_name = "debug_frame";
+  const std::string detections_name = "detections";
+  const std::string debug_output_name = "debug_output";
+  runtime.output_name =
+      (!cfg.save_dir.empty() && cfg.save_every > 0) ? debug_output_name : detections_name;
+
   const bool save_debug_frames = !cfg.save_dir.empty() && cfg.save_every > 0;
-  std::vector<std::string> outputs = {"model"};
+  std::vector<std::string> outputs = {model_name};
   if (cfg.video_enabled) {
-    outputs.push_back("video");
+    outputs.push_back(video_name);
   }
   if (save_debug_frames) {
-    outputs.push_back("debug_frame");
+    outputs.push_back(debug_frame_name);
   }
+  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
   auto branch = simaai::neat::graphs::Branch("source", outputs);
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
   if (cfg.video_enabled) {
     auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
@@ -442,30 +461,32 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     video_options.video_port_base = cfg.video_port_base;
     video_options.encoder.bitrate_kbps = 1000;
     runtime.video_port = video_options.video_port();
-    simaai::neat::Graph video_graph("video");
-    video_graph.connect(simaai::neat::nodes::Input("video"),
+    simaai::neat::Graph video_graph(video_name);
+    video_graph.connect(simaai::neat::nodes::Input(video_name),
                         simaai::neat::nodes::groups::VideoSender(video_options));
-    runtime.graph.connect(branch, video_graph);
+    runtime.graph.connect(branch, video_graph, live_link_options);
   }
 
-  simaai::neat::Graph model_graph("model");
-  model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
-  simaai::neat::Graph detections_graph("detections");
+  simaai::neat::Graph model_graph(model_name);
+  model_graph.connect(simaai::neat::nodes::Input(model_name), *runtime.model);
+  simaai::neat::Graph detections_graph(detections_name);
   detections_graph.add(
-      simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
-  runtime.graph.connect(branch, model_graph);
+      simaai::neat::nodes::Output(detections_name, simaai::neat::OutputOptions::EveryFrame(4)));
+  runtime.graph.connect(branch, model_graph, live_link_options);
   runtime.graph.connect(model_graph, detections_graph);
 
   if (save_debug_frames) {
-    simaai::neat::Graph frames("debug_frame");
+    simaai::neat::Graph frames(debug_frame_name);
     frames.add(
-        simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
-    auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
-                                                    simaai::neat::CombinePolicy::ByFrame);
-    runtime.graph.connect(branch, frames);
+        simaai::neat::nodes::Output(debug_frame_name, simaai::neat::OutputOptions::EveryFrame(4)));
+    auto debug_join =
+        simaai::neat::graphs::Combine({debug_frame_name, detections_name}, debug_output_name,
+                                      simaai::neat::CombinePolicy::ByFrame);
+    runtime.graph.connect(branch, frames, live_link_options);
     runtime.graph.connect(frames, debug_join);
     runtime.graph.connect(detections_graph, debug_join);
   }
+
   if (cfg.profile) {
     std::cout << "Backend stream=" << stream_index << ":\n"
               << runtime.graph.describe_backend() << "\n";
@@ -540,13 +561,12 @@ void maybe_save_debug_frame(const AppConfig& cfg, const StreamRuntime& stream,
   }
 }
 
-bool process_stream_once(StreamRuntime& stream, const AppConfig& cfg,
-                         const std::string& output_name) {
+bool process_stream_once(StreamRuntime& stream, const AppConfig& cfg) {
   constexpr int kPullTimeoutMs = 50;
   simaai::neat::Sample sample;
   simaai::neat::PullError pull_error;
   const double pull_start = sima_examples::time_ms();
-  const auto status = stream.run.pull(output_name, kPullTimeoutMs, sample, &pull_error);
+  const auto status = stream.run.pull(stream.output_name, kPullTimeoutMs, sample, &pull_error);
   const double pull_end = sima_examples::time_ms();
   if (status == simaai::neat::PullStatus::Timeout) {
     return false;
@@ -582,13 +602,12 @@ bool process_stream_once(StreamRuntime& stream, const AppConfig& cfg,
   return true;
 }
 
-void consume_stream(StreamRuntime& stream, const AppConfig& cfg, const std::string& output_name,
-                    std::atomic_bool& stop_requested, std::exception_ptr& first_error,
-                    std::mutex& error_mutex) {
+void consume_stream(StreamRuntime& stream, const AppConfig& cfg, std::atomic_bool& stop_requested,
+                    std::exception_ptr& first_error, std::mutex& error_mutex) {
   try {
     while (!stop_requested.load() && g_stop_requested == 0 && !stream.closed &&
            (cfg.frames <= 0 || stream.processed < cfg.frames)) {
-      (void)process_stream_once(stream, cfg, output_name);
+      (void)process_stream_once(stream, cfg);
     }
   } catch (...) {
     {
@@ -620,21 +639,20 @@ void run_app(const AppConfig& cfg) {
         build_stream_runtime(cfg, static_cast<int>(index), cfg.rtsp_urls[index], labels));
   }
 
-  const std::string output_name =
-      (!cfg.save_dir.empty() && cfg.save_every > 0) ? "debug_output" : "detections";
   std::atomic_bool stop_requested{false};
   std::exception_ptr first_error;
   std::mutex error_mutex;
   std::vector<std::thread> consumers;
   consumers.reserve(streams.size());
   for (auto& stream : streams) {
-    consumers.emplace_back(consume_stream, std::ref(stream), std::cref(cfg), std::cref(output_name),
+    consumers.emplace_back(consume_stream, std::ref(stream), std::cref(cfg),
                            std::ref(stop_requested), std::ref(first_error), std::ref(error_mutex));
   }
 
   for (auto& consumer : consumers) {
-    if (consumer.joinable())
+    if (consumer.joinable()) {
       consumer.join();
+    }
   }
 
   for (auto& stream : streams) {
@@ -642,10 +660,10 @@ void run_app(const AppConfig& cfg) {
     stream.run.close();
     std::cout << "[stream " << stream.index << "] processed=" << stream.processed << "\n";
   }
-
   std::signal(SIGINT, previous_sigint);
-  if (first_error)
+  if (first_error) {
     std::rethrow_exception(first_error);
+  }
 }
 
 } // namespace

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -58,6 +58,7 @@ class StreamRuntime:
     frame_h: int
     output_fps: int
     video_port: int
+    output_name: str
     processed: int = 0
     closed: bool = False
 
@@ -379,6 +380,12 @@ def make_source_options(cfg: AppConfig, url: str, fps: int, width: int, height: 
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 
@@ -402,16 +409,25 @@ def build_stream_runtime(
     output_fps = cfg.fps if cfg.fps > 0 else fps
     model = make_model(cfg)
 
+    model_name = "model"
+    video_name = "video"
+    debug_frame_name = "debug_frame"
+    detections_name = "detections"
+    debug_output_name = "debug_output"
+    output_name = debug_output_name if cfg.save_dir and cfg.save_every > 0 else detections_name
+
     source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, url, fps, frame_w, frame_h))
     save_debug_frames = bool(cfg.save_dir and cfg.save_every > 0)
-    outputs = ["model"]
+    outputs = [model_name]
     if cfg.video_enabled:
-        outputs.append("video")
+        outputs.append(video_name)
     if save_debug_frames:
-        outputs.append("debug_frame")
+        outputs.append(debug_frame_name)
     branch = pyneat.graphs.branch("source", outputs)
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
     video_port = 0
     if cfg.video_enabled:
@@ -422,24 +438,24 @@ def build_stream_runtime(
         video_options.encoder.bitrate_kbps = 1000
         video_port = video_options.video_port
 
-        video_graph = pyneat.Graph("video")
-        video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
-        graph.connect(branch, video_graph)
+        video_graph = pyneat.Graph(video_name)
+        video_graph.connect(pyneat.nodes.input(video_name), pyneat.groups.video_sender(video_options))
+        graph.connect(branch, video_graph, live_link_options)
 
-    model_graph = pyneat.Graph("model")
-    model_graph.connect(pyneat.nodes.input("model"), model)
-    detections_graph = pyneat.Graph("detections")
-    detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
-    graph.connect(branch, model_graph)
+    model_graph = pyneat.Graph(model_name)
+    model_graph.connect(pyneat.nodes.input(model_name), model)
+    detections_graph = pyneat.Graph(detections_name)
+    detections_graph.add(pyneat.nodes.output(detections_name, pyneat.OutputOptions.every_frame(4)))
+    graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
 
     if save_debug_frames:
-        frames = pyneat.Graph("debug_frame")
-        frames.add(pyneat.nodes.output("debug_frame", pyneat.OutputOptions.every_frame(4)))
+        frames = pyneat.Graph(debug_frame_name)
+        frames.add(pyneat.nodes.output(debug_frame_name, pyneat.OutputOptions.every_frame(4)))
         debug_join = pyneat.graphs.combine(
-            ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByFrame
+            [debug_frame_name, detections_name], debug_output_name, pyneat.CombinePolicy.ByFrame
         )
-        graph.connect(branch, frames)
+        graph.connect(branch, frames, live_link_options)
         graph.connect(frames, debug_join)
         graph.connect(detections_graph, debug_join)
     if cfg.profile:
@@ -477,6 +493,7 @@ def build_stream_runtime(
         frame_h=frame_h,
         output_fps=output_fps,
         video_port=video_port,
+        output_name=output_name,
     )
 
 
@@ -576,12 +593,17 @@ def maybe_save_debug_frame(cfg: AppConfig, stream: StreamRuntime, sample, boxes:
         print(f"[warn] failed to write output frame: {out_path}", file=sys.stderr)
 
 
-def process_stream_once(stream: StreamRuntime, cfg: AppConfig, output_name: str) -> bool:
+def process_stream_once(stream: StreamRuntime, cfg: AppConfig) -> bool:
     pull_start = time_ms()
-    sample = stream.run.pull(output_name, 50)
+    sample = stream.run.pull(stream.output_name, 50)
     pull_end = time_ms()
     if sample is None:
-        if hasattr(stream.run, "can_pull") and not stream.run.can_pull():
+        last_error_fn = getattr(stream.run, "last_error", None)
+        last_error = last_error_fn() if callable(last_error_fn) else ""
+        if last_error:
+            raise RuntimeError(f"stream {stream.index} runtime error: {last_error}")
+        running_fn = getattr(stream.run, "running", None)
+        if callable(running_fn) and not running_fn():
             stream.closed = True
         return False
 
@@ -602,7 +624,6 @@ def process_stream_once(stream: StreamRuntime, cfg: AppConfig, output_name: str)
 def consume_stream(
     stream: StreamRuntime,
     cfg: AppConfig,
-    output_name: str,
     stop_event: threading.Event,
     errors: list[Exception],
 ) -> None:
@@ -612,7 +633,7 @@ def consume_stream(
             and not stream.closed
             and (cfg.frames <= 0 or stream.processed < cfg.frames)
         ):
-            process_stream_once(stream, cfg, output_name)
+            process_stream_once(stream, cfg)
     except Exception as exc:
         errors.append(exc)
         stop_event.set()
@@ -628,15 +649,15 @@ def run_app(cfg: AppConfig) -> None:
 
     labels = load_labels(cfg.labels_path)
     streams = [
-        build_stream_runtime(cfg, index, url, labels) for index, url in enumerate(cfg.rtsp_urls)
+        build_stream_runtime(cfg, index, url, labels)
+        for index, url in enumerate(cfg.rtsp_urls)
     ]
-    output_name = "debug_output" if cfg.save_dir and cfg.save_every > 0 else "detections"
     stop_event = threading.Event()
     errors: list[Exception] = []
     consumers = [
         threading.Thread(
             target=consume_stream,
-            args=(stream, cfg, output_name, stop_event, errors),
+            args=(stream, cfg, stop_event, errors),
             name=f"stream-{stream.index}-consumer",
         )
         for stream in streams
@@ -649,6 +670,7 @@ def run_app(cfg: AppConfig) -> None:
             consumer.join()
     except KeyboardInterrupt:
         stop_event.set()
+        raise
     finally:
         stop_event.set()
         for stream in streams:
@@ -677,6 +699,8 @@ def main(argv: list[str] | None = None) -> int:
         load_runtime_dependencies()
         run_app(cfg)
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
@@ -12,6 +12,10 @@
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
 
+namespace {
+constexpr const char* kE2eInsightHost = "127.0.0.1";
+} // namespace
+
 int main(int argc, char** argv) {
   if (argc < 2) {
     std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
@@ -39,9 +43,6 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       : "127.0.0.1";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
@@ -50,7 +51,7 @@ int main(int argc, char** argv) {
   write_e2e_config("multi-stream-object-detector", config_path,
                    {{"model.path", model_path},
                     {"output.debug_dir", output_dir},
-                    {"output.insight.host", insight_host},
+                    {"output.insight.host", kE2eInsightHost},
                     {"output.insight.video_port_base", std::to_string(video_port_base)},
                     {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
                     {"inference.frames", "140"}},
@@ -58,7 +59,7 @@ int main(int argc, char** argv) {
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   MetadataJsonListenerOptions metadata_options;
-  metadata_options.host = insight_host;
+  metadata_options.host = kE2eInsightHost;
   metadata_options.base_port = metadata_port_base;
   metadata_options.num_ports = 2;
   metadata_options.timeout_ms = 5000;
@@ -70,8 +71,8 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const ProcessResult result =
-      spawn_and_wait(binary, {"--config", config_path.string()}, timeout_ms);
+  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
+                                                        output_dir, total_saved_frames, timeout_ms);
 
   int rc = 0;
   if (result.exit_code != 0) {

--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_e2e.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_e2e.py
@@ -9,9 +9,12 @@ import sys
 
 import pytest
 
+from tests.utils.metadata_json_listener import MetadataJsonListener
+
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+E2E_INSIGHT_HOST = "127.0.0.1"
 
 
 def _runtime_deps_ready() -> bool:
@@ -21,10 +24,6 @@ def _runtime_deps_ready() -> bool:
 def _env_int_or_default(name: str, default: int) -> int:
     raw = os.environ.get(name, "").strip()
     return int(raw) if raw else default
-
-
-def _env_str_or_default(name: str, default: str) -> str:
-    return os.environ.get(name, "").strip() or default
 
 
 @pytest.mark.e2e
@@ -47,21 +46,18 @@ class TestE2E:
         skip_unless_e2e_ready(len(rtsp_urls) >= 2, "need at least two RTSP URLs for multistream e2e")
         output_cfg = e2e_config_section("multi-stream-object-detector", "testing.e2e.output")
         total_saved_frames = int(output_cfg["total_saved_frames"])
+        metadata_port_base = _env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100)
 
         config_path = e2e_config_writer(
             {
                 "streams": rtsp_urls[:2],
                 "output": {
                     "insight": {
-                        "host": _env_str_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_HOST", "127.0.0.1"
-                        ),
+                        "host": E2E_INSIGHT_HOST,
                         "video_port_base": _env_int_or_default(
                             "SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000
                         ),
-                        "metadata_port_base": _env_int_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100
-                        ),
+                        "metadata_port_base": metadata_port_base,
                     },
                     "debug_dir": str(tmp_output_dir),
                 },
@@ -74,17 +70,28 @@ class TestE2E:
             "--config",
             str(config_path),
         ]
-        result = run_until_output_files(
-            cmd,
-            tmp_output_dir,
-            total_saved_frames,
-            test_timeout_ms / 1000,
-            cwd=str(EXAMPLE_DIR),
-        )
+        with MetadataJsonListener(
+            E2E_INSIGHT_HOST,
+            metadata_port_base,
+            num_ports=2,
+            require_all_ports=True,
+        ) as metadata_listener:
+            result = run_until_output_files(
+                cmd,
+                tmp_output_dir,
+                total_saved_frames,
+                test_timeout_ms / 1000,
+                cwd=str(EXAMPLE_DIR),
+            )
+            metadata = metadata_listener.wait_for_messages(5.0)
 
         assert result.returncode == 0, (
             f"main.py exited with code {result.returncode}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert metadata.success, (
+            "object-detection metadata was not received on all streams: "
+            f"{metadata.error}"
         )
 
         files = [

--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
@@ -180,6 +180,7 @@ class TestMetadata:
             frame_h=100,
             output_fps=30,
             video_port=9000,
+            output_name="detections",
         )
         boxes = [
             {

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -26,51 +26,22 @@ Snippet from a pipeline run:
 
 ![Single-stream object detector preview](../../../assets/portal/object-detection/single-stream-object-detector/image.png)
 
-## What Is Insight?
-Insight is SiMa.ai's lightweight, cross-platform development and visualization tool for vision pipelines on DevKits:
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
-- a media source manager that can host test media and stream it as RTSP
-- a zero-install web viewer for real-time video and metadata visualization
+To create a reproducible RTSP input:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use a sample video or upload your own video.
+4. Start the stream and copy the RTSP URL.
+5. Put that RTSP URL into `source.rtsp_url`.
 
-For this sample, the most important part is the viewer/output contract: the application sends video on the Insight video channel and sends detection metadata as JSON on the Insight side channel. That allows the browser UI to display the live stream together with object detections without relying on external tools such as `ffplay`, VLC, or ad hoc debug viewers.
-
-For more information regarding Insight, please refer to this [page](https://developer.sima.ai/software/tools/insight).
-
-## Architecture
-The sample is split into three independent runtime stages:
-
-1. `RTSP ingest and decode`
-   The application first probes the RTSP source to learn the decoded frame size, then builds a decode graph that outputs NV12 frames. This avoids hardcoding `640x480` and makes the example more robust when the source changes resolution.
-
-2. `YOLO inference`
-   Decoded NV12 frames are pushed into a dedicated YOLO pipeline:
-   `Input -> model.graph() -> Output`
-
-   The model stage is isolated from transport logic so detection behavior can be debugged separately from RTSP or Insight issues.
-
-3. `Insight output`
-   The original decoded frame is pushed into `VideoSender`. The nodegroup owns the raw-frame video transport path, including conversion, raw NV12 caps, H.264 encoding, RTP packetization, and UDP output. Detection results from the YOLO path are converted into Insight metadata and sent on the metadata side channel.
-
-## Neat Library API Usage
-
-- RTSP ingest: `RtspDecodedInputOptions` -> `Graph.add(rtsp_decoded_input)` -> `Graph.build(...)`
-- YOLO path:
-  C++ and Python use `Input -> model.graph() -> Output`
-- Insight output:
-  C++ and Python build a dedicated `VideoSender` runtime plus `MetadataSender`.
-
-## Lifecycle
-The example uses a producer/consumer design:
-
-- the producer thread pulls decoded frames from the RTSP graph and places them into a bounded queue
-- the consumer thread pulls frames from that queue, submits them to YOLO, converts detection results to Insight objects, and publishes both video and metadata
-
-This separation keeps the RTSP graph from being tightly coupled to the inference latency of each frame and makes profile output easier to interpret.
+Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit
-- RTSP camera source or use Insight to start RTSP source
-- Model artifacts are user-managed. Download the model variant you want to run into `assets/models/`.
+- RTSP source created in Insight or provided by your camera
+- Default model downloaded, or `model.path` set to another readable model package
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -86,185 +57,76 @@ cd apps
 After this setup, follow the example-specific commands below.
 
 ## Download Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download all supported batch-1 variants:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
 sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```
 
-## Important Behavior
-- The sample always publishes to Insight.
-- Video is sent to the configured Insight video UDP port.
-- Detection metadata is sent to the configured Insight metadata UDP port.
-- The app adds only the `VideoSender` nodegroup for video output. It does not manually add lower-level color conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes.
-- This example feeds raw decoded frames to `VideoSender` with the raw-frame option. If an upstream pipeline already produces H.264, `VideoSender` also supports the encoded-input option, where it parses, packetizes, and sends without re-encoding.
-- `model.path` must point to a valid YOLO compiled model package file.
-- `source.rtsp_url` must be set before running.
-- If `inference.frames` is zero, the sample runs continuously.
-- If `runtime.profile` is true, the sample prints aggregate profile summaries every `runtime.profile_interval` published frames.
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
-## Command-Line Options
-- `--config <path>`
-  Optional. YAML config path. Defaults to `src/common/config.yaml`.
-- `--validate-config-only`
-  Validate YAML config and exit without opening the RTSP stream.
+## Configure
+Edit `examples/object-detection/single-stream-object-detector/src/common/config.yaml`.
 
-## Build
-This example can be built in either of these environments:
+```yaml
+model:
+  path: <model-path>                                      # Path to the model package.
 
-- from a Neat Development Environment
-- directly on a `DevKit`
+source:
+  rtsp_url: <rtsp-url-copied-from-insight>                # RTSP stream URL.
+  tcp: true                                               # Use TCP transport for RTSP.
 
-Within either environment, the C++ implementation can be built in two ways. The Python implementation does not require a compile step.
+inference:
+  frames: 0                                               # Frame limit. 0 runs continuously.
+  min_score: 0.30                                         # Minimum object confidence.
 
-### Build From The Apps Repo
-Build all C++ examples from the `apps` repo root:
-
-```bash
-cd <apps-repo-root>
-./build.sh
+output:
+  insight:
+    host: <insight-host-ip>                               # Host running Insight.
+    video_port: <videoUDP start port from neat>           # UDP video port.
+    metadata_port: <metadataUDP start port from neat>     # UDP metadata port.
 ```
-
-The resulting binary is:
-
-```bash
-./build/examples/object-detection/single-stream-object-detector/single-stream-object-detector
-```
-
-### Build This Example Directly With CMake
-Configure and build only this example from its own directory:
-
-```bash
-cd <apps-repo-root>/examples/object-detection/single-stream-object-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-The resulting binary is:
-
-```bash
-./build/single-stream-object-detector
-```
-
-Direct CMake builds use the shared example module support in the `apps` repo and link against the available Neat Library installation or local core build.
-
-In practice:
-
-- in the Neat Development Environment, this is typically done after activating the environment and then building from the repo or the example folder
-- on `DevKit`, this can be done directly on the target device as long as the required Neat Library dependencies are installed
-
-## RTSP Source
-
-If you want a quick RTSP source for testing, [`tool-mediasources`](https://github.com/SiMa-ai/tool-mediasources) on the host is one option:
-
-```bash
-sima-cli install gh:sima-ai/tool-mediasources
-./mediasrc.sh <video-dir>
-open preview.html
-```
-
-If you use host-streamed sources from a board/devkit, use the host IP in the RTSP URL instead of `127.0.0.1`. Any other RTSP source also works.
 
 ## Run
-### Binary Built From The Apps Repo
+### C++
 ```bash
 ./build/examples/object-detection/single-stream-object-detector/single-stream-object-detector \
   --config examples/object-detection/single-stream-object-detector/src/common/config.yaml
 ```
 
-### Binary Built Directly In The Example Folder
-```bash
-./build/single-stream-object-detector \
-  --config src/common/config.yaml
-```
-
-Set the RTSP source and Insight destination in the config:
-
-```yaml
-source:
-  rtsp_url: rtsp://<host>:8554/<stream>
-  tcp: true
-model:
-  path: <model-path>
-inference:
-  frames: 0
-  min_score: 0.55
-  nms_iou: 0.50
-  max_detections: 100
-runtime:
-  profile: false
-  profile_interval: 100
-output:
-  save_dir: ""
-  save_every: 0
-  insight:
-    host: <insight-host-ip>
-    video_port: 9000
-    metadata_port: 9100
-```
-
-### Python Implementation
-Run the Python sample directly from the example folder:
-
-```bash
-cd <apps-repo-root>/examples/object-detection/single-stream-object-detector
-pip install -r src/python/requirements.txt
-python3 src/python/main.py --config src/common/config.yaml
-```
-
-Example workflow:
-
-Download the default YOLO26 detector model if it is not already available:
-
-```bash
-mkdir -p assets/models
-cd assets/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-cd ../..
-```
-
-Then start the Python app:
-
+### Python
 ```bash
 source ~/pyneat/bin/activate
-pip install -r src/python/requirements.txt
-python3 src/python/main.py --config src/common/config.yaml
+pip install -r examples/object-detection/single-stream-object-detector/src/python/requirements.txt
+python3 examples/object-detection/single-stream-object-detector/src/python/main.py \
+  --config examples/object-detection/single-stream-object-detector/src/common/config.yaml
 ```
-
-Python-specific notes:
-
-- `model.path` must point to a downloaded YOLO26 detector package
-- it sends Insight metadata directly over UDP and streams video through `VideoSender`
 
 ## Debugging Notes
 - If the sample times out waiting for the first RTSP frame, the problem is usually upstream stream delivery or device connectivity, not YOLO itself.
 - If the RTSP source resolution changes, the startup probe is expected to adapt the decode path automatically.
 - If detections are missing but video is flowing, focus on the YOLO session and bbox extraction/parse path.
 - If video and detections are both missing in Insight, verify the host and UDP ports first.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+- `yolo26m-det-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -34,7 +34,7 @@ Insight is SiMa.ai's lightweight, cross-platform development and visualization t
 
 For this sample, the most important part is the viewer/output contract: the application sends video on the Insight video channel and sends detection metadata as JSON on the Insight side channel. That allows the browser UI to display the live stream together with object detections without relying on external tools such as `ffplay`, VLC, or ad hoc debug viewers.
 
-For more information regarding Insight, please refer to this [page](https://docs.sima.ai/pages/insight/main.html#).
+For more information regarding Insight, please refer to this [page](https://developer.sima.ai/software/tools/insight).
 
 ## Architecture
 The sample is split into three independent runtime stages:
@@ -49,7 +49,7 @@ The sample is split into three independent runtime stages:
    The model stage is isolated from transport logic so detection behavior can be debugged separately from RTSP or Insight issues.
 
 3. `Insight output`
-   The original decoded frame is pushed into `VideoSender`. The nodegroup owns the raw-frame video transport path, including conversion, H.264 encoding, RTP packetization, and UDP output. Detection results from the YOLO path are converted into Insight metadata and sent on the metadata side channel.
+   The original decoded frame is pushed into `VideoSender`. The nodegroup owns the raw-frame video transport path, including conversion, raw NV12 caps, H.264 encoding, RTP packetization, and UDP output. Detection results from the YOLO path are converted into Insight metadata and sent on the metadata side channel.
 
 ## Neat Library API Usage
 
@@ -120,7 +120,7 @@ cd ../..
 - The sample always publishes to Insight.
 - Video is sent to the configured Insight video UDP port.
 - Detection metadata is sent to the configured Insight metadata UDP port.
-- The app adds only the `VideoSender` nodegroup for video output. It does not manually add lower-level color conversion, encoder, parser, packetizer, or UDP nodes.
+- The app adds only the `VideoSender` nodegroup for video output. It does not manually add lower-level color conversion, raw capsfilter, encoder, parser, packetizer, or UDP nodes.
 - This example feeds raw decoded frames to `VideoSender` with the raw-frame option. If an upstream pipeline already produces H.264, `VideoSender` also supports the encoded-input option, where it parses, packetizes, and sends without re-encoding.
 - `model.path` must point to a valid YOLO compiled model package file.
 - `source.rtsp_url` must be set before running.
@@ -271,4 +271,4 @@ Python-specific notes:
 - C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
 - Python source: `src/python/main.py`
 - Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Insight documentation: <https://docs.sima.ai/pages/insight/main.html>
+- Insight documentation: <https://developer.sima.ai/software/tools/insight>

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -29,8 +29,16 @@ Snippet from a pipeline run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
+In the Neat Development Environment, install the sample video assets:
+
+```bash
+sima-cli install assets/multi-video-sources
+```
+
+This provides 720p and 480p videos that Insight can stream as RTSP sources.
+
 To create a reproducible RTSP input:
-1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
 2. In Insight, open `RTSP Source`.
 3. Use a sample video or upload your own video.
 4. Start the stream and copy the RTSP URL.
@@ -39,14 +47,14 @@ To create a reproducible RTSP input:
 Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
-- Installed Neat Library and Insight on the DevKit
+- Installed Neat Development Environment + Neat Library.
 - RTSP source created in Insight or provided by your camera
-- Default model downloaded, or `model.path` set to another readable model package
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -54,7 +62,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Download Models
 Use the SDK platform version wherever `<platform-version>` appears.

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -283,6 +283,14 @@ make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& hei
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 
@@ -336,9 +344,15 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   detections_graph.add(
       simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
-  runtime.graph.connect(branch, video_graph);
-  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(branch, video_graph, live_link_options);
+  if (save_debug_frames) {
+    runtime.graph.connect(branch, model_graph);
+  } else {
+    runtime.graph.connect(branch, model_graph, live_link_options);
+  }
   runtime.graph.connect(model_graph, detections_graph);
   if (save_debug_frames) {
     simaai::neat::Graph frames("debug_frame");

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -359,6 +359,12 @@ def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 
@@ -403,9 +409,14 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
-    graph.connect(branch, video_graph)
-    graph.connect(branch, model_graph)
+    graph.connect(branch, video_graph, live_link_options)
+    if save_debug_frames:
+        graph.connect(branch, model_graph)
+    else:
+        graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
     if save_debug_frames:
         frames = pyneat.Graph("debug_frame")
@@ -601,6 +612,8 @@ def main(argv: list[str] | None = None) -> int:
         finally:
             runtime.run.close()
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -38,14 +38,14 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 - Labels file: `examples/object-detection/yolo26-object-detector/src/common/coco_label.txt`
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -53,7 +53,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/object-detection/yolo26-object-detector/src/common/config.yaml`.
@@ -88,7 +88,7 @@ python3 examples/object-detection/yolo26-object-detector/src/python/main.py \
 ```
 
 ## Testing
-Run from the apps repository root:
+On the Modalix/DevKit board, run from the apps repository root:
 
 ```bash
 cd <apps-repo-root>

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -20,18 +20,9 @@ Snippet from a pipeline run:
 ![YOLO26 object detector preview](../../../assets/portal/object-detection/yolo26-object-detector/image.png)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
-
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
 
 Download the default model:
 
@@ -44,9 +35,11 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 - Labels file: `examples/object-detection/yolo26-object-detector/src/common/coco_label.txt`
 
 ## Get The Apps Repo
@@ -62,62 +55,36 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- C++ and Python read runtime values from `src/common/config.yaml`.
-- Labels file is configured under `model.labels`.
-- Output images are written as `.png` files.
-- Use `runtime.profile` to print per-image and aggregate timing plus FPS.
-- Use `runtime.num_runs` to repeat the image set for benchmarking.
-- Use `output.overlay: false` to skip drawing bounding boxes and writing output images.
+## Configure
+Edit `examples/object-detection/yolo26-object-detector/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+```yaml
+model:
+  path: <model-path>                         # Path to the model package.
+  labels: examples/object-detection/yolo26-object-detector/src/common/coco_label.txt
 
-### Python
-- Invocation:
-  `python examples/object-detection/yolo26-object-detector/src/python/main.py [--config <path>]`
-- Optional arguments:
-  `--config <path>`: YAML config path. Defaults to `src/common/config.yaml`.
+io:
+  input_dir: assets/test_images                           # Folder containing input images.
+  output_dir: sandbox/yolo26-object-detector              # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/object-detection/yolo26-object-detector
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/yolo26-object-detector
+decode:
+  score_threshold: 0.40                                   # Minimum object confidence.
+  nms_iou: 0.60                                           # Overlap threshold for NMS.
 ```
 
 ## Run
 ### C++
 ```bash
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector
+./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector \
+  --config examples/object-detection/yolo26-object-detector/src/common/config.yaml
 ```
 
 ### Python
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/yolo26-object-detector/src/python/requirements.txt
-python examples/object-detection/yolo26-object-detector/src/python/main.py
+python3 examples/object-detection/yolo26-object-detector/src/python/main.py \
+  --config examples/object-detection/yolo26-object-detector/src/common/config.yaml
 ```
 
 ## Testing
@@ -164,10 +131,21 @@ pytest examples/object-detection/yolo26-object-detector/tests/python/test_e2e.py
 
 ## Debugging Notes
 - If detections are missing, validate label file ordering and score thresholds.
-- If model load fails, verify `assets/models/yolo26m-det-bf16-mla_tess-b1.tar.gz` exists.
+- If model load fails, verify `model.path` points to a readable model package.
 - Ensure input folder contains supported image extensions (`.jpg`, `.jpeg`, `.png`, `.bmp`).
 - Use `--profile` to identify bottlenecks in the pipeline.
 - Use `decode.score_threshold` and `decode.nms_iou` to tune detection sensitivity.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+- `yolo26m-det-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/object-detection/yolo26-object-detector/src/common/config.yaml
+++ b/examples/object-detection/yolo26-object-detector/src/common/config.yaml
@@ -1,20 +1,20 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Detector model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
   labels: examples/object-detection/yolo26-object-detector/src/common/coco_label.txt
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/yolo26-object-detector
+io:                          # Input and output paths.
+  input_dir: assets/test_images                 # Folder containing input images.
+  output_dir: sandbox/yolo26-object-detector    # Folder for annotated images.
 
-decode:
-  score_threshold: 0.40
-  nms_iou: 0.60
-  max_detections: 50
+decode:                      # YOLO decode settings.
+  score_threshold: 0.40      # Minimum object confidence.
+  nms_iou: 0.60              # Overlap threshold for NMS.
+  max_detections: 50         # Max detections to keep per image.
 
-runtime:
-  timeout_ms: 20000
-  num_runs: 1
-  profile: false
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  num_runs: 1                # Number of repeated runs.
+  profile: false             # Print profiling summaries.
 
-output:
-  overlay: true
+output:                      # Output rendering settings.
+  overlay: true              # Draw boxes and labels on output images.

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -28,43 +28,40 @@ Snippet from a pipeline run:
 
 ![Single stream instance segmenter preview](../../../assets/portal/segmentation/single-stream-instance-segmenter/image.png)
 
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive segmentation metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+
+To create a reproducible RTSP input:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use a sample video or upload your own video.
+4. Start the stream and copy the RTSP URL.
+5. Put that RTSP URL into `source.rtsp_url`.
+
+Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
+
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
-Supported YOLO26 segmentation models:
+Default model: `yolo26m-seg-bf16-b1.tar.gz`.
 
-- `yolo26n-seg-bf16-mla_tess.tar.gz`
-- `yolo26s-seg-bf16-mla_tess.tar.gz`
-- `yolo26m-seg-bf16-mla_tess.tar.gz`
-- `yolo26l-seg-bf16-mla_tess.tar.gz`
-- `yolo26x-seg-bf16-mla_tess.tar.gz`
-- `yolo26m-seg-bf16-b1.tar.gz`
-- `yolo26m-seg-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-seg-int8-b1.tar.gz`
-
-Download the supported variants:
+Download the default model:
 
 ```bash
-PLATFORM_VERSION=<platform-version>
 mkdir -p assets/models/YOLO26-SEGMENTATION
 cd assets/models/YOLO26-SEGMENTATION
 
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz"
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz"
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
 
 cd ../../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - Installed Neat Library and Insight on the DevKit.
-- RTSP camera source, or an Insight/tool-mediasources RTSP stream.
-- A YOLO26 segmentation model package downloaded locally.
+- RTSP source created in Insight or provided by your camera.
+- Default YOLO26 segmentation model downloaded, or `model.path` set to another readable model package.
 - `model.path`, `model.labels`, `source.rtsp_url`, and `output.insight.host` set in `src/common/config.yaml`.
 
 ## Get The Apps Repo
@@ -80,46 +77,26 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- C++ and Python read runtime values from `src/common/config.yaml`.
-- `model.path` must point to a valid YOLO26 segmentation model package.
-- `model.labels` points to the COCO labels file used for overlays and metadata.
-- `source.rtsp_url` must point to a live RTSP stream.
-- `output.insight.host` must point to the host running the Insight receiver/viewer.
-- If `inference.frames` is zero, the sample runs continuously.
-- Masks are rendered into the video stream. Metadata contains object labels, confidences, and boxes.
-- `output.save_dir` and `output.save_every` can be used to save sampled annotated frames.
-- The model path uses model-managed preprocessing with `COCO_YOLO` normalization and `YoloV26Seg` decode.
-- Insight video is sent through `VideoSender`; the app passes raw frames plus stream geometry, and the nodegroup owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output.
+## Configure
+Edit `examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml`.
 
-## Command-Line Options
-- `--config <path>`
-  Optional. YAML config path. Defaults to `src/common/config.yaml`.
-- `--validate-config-only`
-  Validate YAML config and exit without opening the RTSP stream.
+```yaml
+model:
+  path: <model-path>                                                # Path to the model package.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
+source:
+  rtsp_url: <rtsp-url-copied-from-insight>                          # RTSP stream URL.
+  tcp: true                                                          # Use TCP transport for RTSP.
 
-Binary output:
-```bash
-./build/examples/segmentation/single-stream-instance-segmenter/single-stream-instance-segmenter
-```
+inference:
+  frames: 0                                                          # Frame limit. 0 runs continuously.
+  min_score: 0.55                                                    # Minimum instance confidence.
 
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/segmentation/single-stream-instance-segmenter
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/single-stream-instance-segmenter
+output:
+  insight:
+    host: <insight-host-ip>                                          # Host running Insight.
+    video_port: <videoUDP start port from neat>                      # UDP video port.
+    metadata_port: <metadataUDP start port from neat>                # UDP metadata port.
 ```
 
 ## Run
@@ -137,45 +114,23 @@ python3 examples/segmentation/single-stream-instance-segmenter/src/python/main.p
   --config examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
 ```
 
-Example config:
-
-```yaml
-model:
-  path: assets/models/YOLO26-SEGMENTATION/yolo26m-seg-bf16-b1.tar.gz
-  labels: examples/segmentation/single-stream-instance-segmenter/src/common/coco_label.txt
-
-source:
-  rtsp_url: rtsp://<host>:8554/<stream>
-  tcp: true
-  latency_ms: 100
-
-inference:
-  frames: 0
-  min_score: 0.55
-  nms_iou: 0.60
-  max_detections: 50
-
-runtime:
-  profile: false
-  profile_interval: 100
-
-output:
-  save_dir: ""
-  save_every: 0
-  mask_alpha: 0.55
-  mask_threshold: 0.50
-  draw_boxes: true
-  insight:
-    host: <insight-host-ip>
-    video_port: 9000
-    metadata_port: 9100
-```
-
 ## Debugging Notes
 - If startup fails, verify `model.path` and `source.rtsp_url`.
 - If the app times out waiting for RTSP, verify source reachability first.
 - If Insight receives no video, verify `output.insight.host` and UDP ports.
 - If saved frames are needed for inspection, set `output.save_dir` and `output.save_every`.
+
+## Appendix: Additional Models
+Other supported YOLO26 segmentation models:
+- `yolo26n-seg-bf16-mla_tess.tar.gz`
+- `yolo26s-seg-bf16-mla_tess.tar.gz`
+- `yolo26m-seg-bf16-mla_tess.tar.gz`
+- `yolo26l-seg-bf16-mla_tess.tar.gz`
+- `yolo26x-seg-bf16-mla_tess.tar.gz`
+- `yolo26m-seg-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-seg-int8-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -90,6 +90,7 @@ After this setup, follow the example-specific commands below.
 - Masks are rendered into the video stream. Metadata contains object labels, confidences, and boxes.
 - `output.save_dir` and `output.save_every` can be used to save sampled annotated frames.
 - The model path uses model-managed preprocessing with `COCO_YOLO` normalization and `YoloV26Seg` decode.
+- Insight video is sent through `VideoSender`; the app passes raw frames plus stream geometry, and the nodegroup owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output.
 
 ## Command-Line Options
 - `--config <path>`

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -31,8 +31,16 @@ Snippet from a pipeline run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive segmentation metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
+In the Neat Development Environment, install the sample video assets:
+
+```bash
+sima-cli install assets/multi-video-sources
+```
+
+This provides 720p and 480p videos that Insight can stream as RTSP sources.
+
 To create a reproducible RTSP input:
-1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
 2. In Insight, open `RTSP Source`.
 3. Use a sample video or upload your own video.
 4. Start the stream and copy the RTSP URL.
@@ -59,15 +67,15 @@ cd ../../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Library and Insight on the DevKit.
+- Installed Neat Development Environment + Neat Library.
 - RTSP source created in Insight or provided by your camera.
-- Default YOLO26 segmentation model downloaded, or `model.path` set to another readable model package.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default YOLO26 segmentation model, or set `model.path` to another readable model package.
 - `model.path`, `model.labels`, `source.rtsp_url`, and `output.insight.host` set in `src/common/config.yaml`.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -75,7 +83,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml`.

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -339,6 +339,14 @@ make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& hei
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -449,6 +449,12 @@ def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 
@@ -797,6 +803,8 @@ def main(argv: list[str] | None = None) -> int:
         finally:
             runtime.video_run.close()
             runtime.run.close()
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -20,17 +20,26 @@ Snippet from a pipeline run:
 ![Instance segmenter preview](../../../assets/portal/segmentation/yolov8-instance-segmenter/image.jpg)
 
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
-Also works with: `yolo_v8s_seg`, `yolo_v8m_seg`, `yolo_v8l_seg`
+Default model: `yolo_v8n_seg`.
 
-Download any variant into `assets/models/`:
-- `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get yolo_v8n_seg && cd ../..`
+Download the default model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+
+sima-cli modelzoo -v <platform-version> get yolo_v8n_seg
+
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
 - Installed Neat Development Environment.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`.
-- Download command: `mkdir -p assets/models && cd assets/models && sima-cli modelzoo -v <platform-version> get yolo_v8n_seg && cd ../..`
+- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
 Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
@@ -45,54 +54,19 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- Model path is positional and required.
-- Input directory is scanned for common image extensions.
-- Output images include per-instance mask overlays plus bounding boxes/class labels.
-- Runtime and decode settings live in `src/common/config.yaml`.
-- Inference runs on a resized model input, but saved overlays preserve the original image resolution.
-- Uses YOLOv8-seg tensors for box regression/class scores, mask coefficients, and prototype masks.
-- Masks, mask contours, and bounding boxes share the same vivid class-color palette.
+## Configure
+Edit `examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  `./build/examples/segmentation/yolov8-instance-segmenter/yolov8-instance-segmenter [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+```yaml
+model:
+  path: <model-path>                   # Path to the model package.
 
-### Python
-- Invocation:
-  `python3 examples/segmentation/yolov8-instance-segmenter/src/python/main.py [--config <path>]`
-- Required arguments:
-  None. Defaults to `src/common/config.yaml`.
-- Optional arguments:
-  `--config <path>`
+io:
+  input_dir: assets/test_images                 # Folder containing input images.
+  output_dir: sandbox/yolov8-instance-segmenter # Folder for annotated images.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
-
-Binary output:
-```bash
-./build/examples/segmentation/yolov8-instance-segmenter/yolov8-instance-segmenter
-```
-
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>/examples/segmentation/yolov8-instance-segmenter
-cmake -S src/cpp -B build
-cmake --build build -j
-```
-
-Binary output:
-```bash
-./build/yolov8-instance-segmenter
+decode:
+  score_threshold: 0.25                         # Minimum instance confidence.
 ```
 
 ## Run
@@ -114,6 +88,10 @@ python3 examples/segmentation/yolov8-instance-segmenter/src/python/main.py \
 - If startup fails, verify model file path and filename.
 - If output is empty, check `decode.score_threshold` and `runtime.infer_size`.
 - Ensure output directory is writable.
+
+## Appendix: Additional Models
+This example also works with `yolo_v8s_seg`, `yolo_v8m_seg`, and `yolo_v8l_seg`.
+Replace `yolo_v8n_seg` in the download command and update `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -38,13 +38,13 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- Installed Neat Development Environment.
-- Model artifacts are user-managed. Download the default model, or set `model.path` to another readable model package.
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -52,7 +52,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml`.

--- a/examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml
+++ b/examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml
@@ -1,19 +1,19 @@
-model:
-  path: <model-path>  # Example: assets/models/<model-pack>.tar.gz
+model:                       # Segmenter model selection.
+  path: <model-path>         # Example: assets/models/<model-pack>.tar.gz
 
-io:
-  input_dir: assets/test_images
-  output_dir: sandbox/yolov8-instance-segmenter
+io:                          # Input and output paths.
+  input_dir: assets/test_images                    # Folder containing input images.
+  output_dir: sandbox/yolov8-instance-segmenter    # Folder for annotated images.
 
-runtime:
-  infer_size: 640
-  timeout_ms: 20000
-  queue_depth: 8
+runtime:                     # Runtime settings.
+  infer_size: 640            # Square model input size.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  queue_depth: 8             # Runtime queue depth.
 
-decode:
-  score_threshold: 0.60
-  nms_iou: 0.45
-  max_detections: 200
+decode:                      # YOLOv8 segmentation decode settings.
+  score_threshold: 0.60      # Minimum instance confidence.
+  nms_iou: 0.45              # Overlap threshold for NMS.
+  max_detections: 200        # Max instances to keep per image.
 
-visualization:
-  mask_alpha: 0.65
+visualization:               # Overlay rendering settings.
+  mask_alpha: 0.65           # Mask overlay opacity.

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -19,7 +19,7 @@ Both the Python and C++ entrypoints use one complete graph per RTSP stream:
 ```text
 RtspDecodedInput
   -> Branch(video, model[, debug_frame])
-    -> video: VideoSender(H.264 RTP/UDP)
+    -> video: VideoSender(raw caps + H.264 RTP/UDP)
     -> model: YOLO26 model.graph() -> Output(detections)
     -> debug only: Combine(debug_frame, detections, ByFrame) -> debug_output
 ```
@@ -92,6 +92,7 @@ After this setup, follow the example-specific commands below.
 - `inference.min_score`, `inference.nms_iou`, and `inference.max_detections` are explicit detector decode parameters in the checked-in config.
 - The example defaults to person class id `0`, and tracker behavior is configurable from the config file.
 - Both C++ and Python add the `VideoSender` nodegroup for video transport and use `model.graph()` for model-owned preprocessing, inference, and YOLO26 decode.
+- `VideoSender` owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. The app does not add those lower-level nodes itself.
 - Debug saves use `Combine(ByFrame)` so saved frames and tracks stay aligned.
 
 ## Command-Line Options

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -22,8 +22,16 @@ Preview image from a live run:
 ## Insight Setup
 [Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive tracking metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
 
+In the Neat Development Environment, install the sample video assets:
+
+```bash
+sima-cli install assets/multi-video-sources
+```
+
+This provides 720p and 480p videos that Insight can stream as RTSP sources.
+
 To create reproducible RTSP inputs:
-1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
 2. In Insight, open `RTSP Source`.
 3. Use sample videos or upload your own videos.
 4. Start each stream and copy the RTSP URLs.
@@ -50,15 +58,16 @@ cd ../..
 The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
 
 ## Prerequisites
-- A Neat Python environment with `pyneat`, `numpy`, and OpenCV available.
+- Installed Neat Development Environment + Neat Library.
+- A Neat Library Python environment with `pyneat`, `numpy`, and OpenCV available.
 - RTSP sources created in Insight or provided by your cameras.
-- Default YOLO26 detector model downloaded, or `model.path` set to another readable model package.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default YOLO26 detector model, or set `model.path` to another readable model package.
 - An Insight viewer instance reachable from the board/host running this example.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Clone and build the apps repo inside the Neat Development Environment:
 
 ```bash
 git clone https://github.com/sima-neat/apps.git
@@ -66,7 +75,7 @@ cd apps
 ./build.sh --clean
 ```
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Configure
 Edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml`.

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -14,58 +14,45 @@
 ## Concept
 Multi-stream people tracking example with RTSP inputs, mixed-resolution support, Insight live video plus metadata output, and optional sampled overlay saves. The pipeline filters detector output to the configured person class and assigns stable track IDs per stream.
 
-Both the Python and C++ entrypoints use one complete graph per RTSP stream:
-
-```text
-RtspDecodedInput
-  -> Branch(video, model[, debug_frame])
-    -> video: VideoSender(raw caps + H.264 RTP/UDP)
-    -> model: YOLO26 model.graph() -> Output(detections)
-    -> debug only: Combine(debug_frame, detections, ByFrame) -> debug_output
-```
-
-Each stream has one lightweight consumer that pulls detections, updates that stream's `PeopleTracker`, and sends Insight tracking metadata. There is no shared detector pool, mailbox queue, worker scheduler, or cross-camera identity tracking.
-
 ## Preview
 Preview image from a live run:
 
 ![Multi-stream people tracker preview](../../../assets/portal/tracking/multi-stream-people-tracker/image.png)
 
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive tracking metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+
+To create reproducible RTSP inputs:
+1. Run `neat` in the Neat Developer Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use sample videos or upload your own videos.
+4. Start each stream and copy the RTSP URLs.
+5. Put those RTSP URLs into `streams`.
+
+Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
+
 ## Supported Models
-Use the platform version wherever `<platform-version>` appears.
+Use the SDK platform version wherever `<platform-version>` appears.
 
 Default model: `yolo26m-det-int8-b1.tar.gz`.
 
-Supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Download all supported batch-1 variants:
+Download the default model:
 
 ```bash
 mkdir -p assets/models
 cd assets/models
 
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
 sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
 
 cd ../..
 ```
 
+The command stores the model under `assets/models/` as a repo-local convention. `model.path` can point to any readable model package path.
+
 ## Prerequisites
 - A Neat Python environment with `pyneat`, `numpy`, and OpenCV available.
-- One or more reachable RTSP camera URLs.
-- A YOLO26 detector model pack downloaded into `assets/models/`.
+- RTSP sources created in Insight or provided by your cameras.
+- Default YOLO26 detector model downloaded, or `model.path` set to another readable model package.
 - An Insight viewer instance reachable from the board/host running this example.
 
 ## Get The Apps Repo
@@ -81,126 +68,63 @@ cd apps
 
 After this setup, follow the example-specific commands below.
 
-## Important Behavior
-- The Python and C++ implementations follow the same per-stream graph structure.
-- The `streams:` list in `src/common/config.yaml` controls the number of cameras dynamically. This phase supports up to four streams.
-- The checked-in `src/common/config.yaml` uses placeholder RTSP and Insight values; fill them with your own camera URLs and receiver host before running.
-- Stream `i` publishes video to `output.insight.video_port_base + i`.
-- Stream `i` publishes tracking metadata to `output.insight.metadata_port_base + i` for Insight-side overlay.
-- `inference.frames: 0` runs indefinitely.
-- `output.debug_dir: null` and `output.save_every: 0` disable saved overlay frames while keeping live Insight output enabled.
-- `inference.min_score`, `inference.nms_iou`, and `inference.max_detections` are explicit detector decode parameters in the checked-in config.
-- The example defaults to person class id `0`, and tracker behavior is configurable from the config file.
-- Both C++ and Python add the `VideoSender` nodegroup for video transport and use `model.graph()` for model-owned preprocessing, inference, and YOLO26 decode.
-- `VideoSender` owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. The app does not add those lower-level nodes itself.
-- Debug saves use `Combine(ByFrame)` so saved frames and tracks stay aligned.
+## Configure
+Edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml`.
 
-## Command-Line Options
-### C++
-- Invocation:
-  ```bash
-  ./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker \
-    --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
-  ```
-- Required arguments:
-  None.
-- Optional arguments:
-  `--config <path>` to load a different YAML configuration file.
+```yaml
+model:
+  path: <model-path>                                   # Path to the model package.
 
-### Python
-- Invocation:
-  ```bash
-  python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
-    --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
-  ```
-- Required arguments:
-  None.
-- Optional arguments:
-  `--config <path>` to load a different YAML configuration file.
+streams:
+  - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
+  - <second-rtsp-url-copied-from-insight>              # Second RTSP stream.
 
-## Build
-### Build From The Apps Repo
-```bash
-cd <apps-repo-root>
-./build.sh
-```
+inference:
+  frames: 0                                            # Frame limit per stream. 0 runs continuously.
+  min_score: 0.30                                      # Minimum person confidence.
 
-Binary output:
-```bash
-./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker
-```
+tracking:
+  max_missing_frames: 15                               # Frames to keep a missing track alive.
 
-### Build This Example Directly With CMake
-```bash
-cd <apps-repo-root>
-cmake -S examples/tracking/multi-stream-people-tracker/src/cpp -B build/multi-stream-people-tracker
-cmake --build build/multi-stream-people-tracker -j
-```
-
-Binary output:
-```bash
-./build/multi-stream-people-tracker/multi-stream-people-tracker
+output:
+  insight:
+    host: <insight-host-ip>                            # Host running Insight.
+    video_port_base: <videoUDP start port from neat>   # First UDP video port.
+    metadata_port_base: <metadataUDP start port from neat> # First UDP metadata port.
 ```
 
 ## Run
-Before running either entrypoint, edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml` and replace the placeholder values in:
-
-- `streams`
-- `output.insight.host`
-
 ### C++
 ```bash
 ./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker \
   --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
 ```
 
-The C++ binary follows the same config contract and per-stream graph topology as the Python example.
-
 ### Python
-Install the small Python-side dependencies:
-
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/tracking/multi-stream-people-tracker/src/python/requirements.txt
-```
-
-Edit the example config in `src/common/config.yaml`, especially the placeholder values in:
-
-- `streams`
-- `output.insight.host`
-
-The `streams:` list controls the number of cameras dynamically.
-
-Run the Python example with that config:
-
-```bash
 python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
   --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
 ```
 
-Notes:
-
-- stream `i` feeds clean frames into `VideoSender` at
-  `output.insight.video_port_base + i`
-- stream `i` sends object-detection metadata with track IDs to `output.insight.metadata_port_base + i`
-- the default config runs indefinitely and does not save frames because
-  `output.debug_dir` is `null` and `output.save_every` is `0`
-- set `inference.frames` for a bounded smoke run
-- set `output.debug_dir` and `output.save_every` if you want sampled overlay frames
-  written as `stream_<index>_frame_<frame>.jpg`; the live Insight video stays clean
-- if the app runs on a DevKit, set `output.insight.host` to the Insight host IP,
-  not `127.0.0.1`
-- `pyneat.Model(...)` is still used, but the detector runtime composes the
-  model-owned graph fragment instead of a black-box one-call inference path
-- live metadata is emitted separately from video in Insight object-detection
-  format, with one channel per stream
-
 ## Debugging Notes
 - Start with one RTSP stream and confirm the config before scaling to multiple cameras.
-- Confirm the model file exists under `assets/models/`.
+- Confirm `model.path` points to a readable model package.
 - Confirm each RTSP URL is reachable from the board or host running the example.
 - If Insight appears idle, verify `output.insight.host`, `video_port_base`, and `metadata_port_base`.
 - If you want saved overlay frames, set both `output.debug_dir` and `output.save_every`.
+
+## Appendix: Additional Models
+Other supported batch-1 YOLO26 detection models:
+- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
+- `yolo26m-det-bf16-b1.tar.gz`
+
+Replace the default filename in the download command and `model.path`.
 
 ## Source Files
 - C++ source: `src/cpp/main.cpp`

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -390,6 +390,14 @@ make_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, 
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
+  if (width_out > 0 && height_out > 0 && fps_out > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = width_out;
+    opt.output_caps.height = height_out;
+    opt.output_caps.fps = fps_out;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
   return opt;
 }
 
@@ -435,6 +443,8 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   }
   auto branch = simaai::neat::graphs::Branch("source", outputs);
 
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   runtime.graph.connect(source, branch);
   if (cfg.video_enabled) {
     auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
@@ -447,7 +457,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
     simaai::neat::Graph video_graph("video");
     video_graph.connect(simaai::neat::nodes::Input("video"),
                         simaai::neat::nodes::groups::VideoSender(video_options));
-    runtime.graph.connect(branch, video_graph);
+    runtime.graph.connect(branch, video_graph, live_link_options);
   }
 
   simaai::neat::Graph model_graph("model");
@@ -455,7 +465,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   simaai::neat::Graph detections_graph("detections");
   detections_graph.add(
       simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
-  runtime.graph.connect(branch, model_graph);
+  runtime.graph.connect(branch, model_graph, live_link_options);
   runtime.graph.connect(model_graph, detections_graph);
 
   if (save_debug_frames) {
@@ -653,8 +663,9 @@ void run_app(const AppConfig& cfg) {
   }
 
   std::signal(SIGINT, previous_sigint);
-  if (first_error)
+  if (first_error) {
     std::rethrow_exception(first_error);
+  }
 }
 
 } // namespace

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -390,6 +390,12 @@ def make_source_options(cfg: AppConfig, url: str, fps: int, width: int, height: 
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.fallback_h264_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
     return opt
 
 
@@ -421,6 +427,8 @@ def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamR
     branch = pyneat.graphs.branch("source", outputs)
 
     graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
     graph.connect(source, branch)
     video_port = 0
     if cfg.video_enabled:
@@ -433,13 +441,13 @@ def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamR
 
         video_graph = pyneat.Graph("video")
         video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
-        graph.connect(branch, video_graph)
+        graph.connect(branch, video_graph, live_link_options)
 
     model_graph = pyneat.Graph("model")
     model_graph.connect(pyneat.nodes.input("model"), model)
     detections_graph = pyneat.Graph("detections")
     detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
-    graph.connect(branch, model_graph)
+    graph.connect(branch, model_graph, live_link_options)
     graph.connect(model_graph, detections_graph)
 
     if save_debug_frames:
@@ -666,6 +674,7 @@ def run_app(cfg: AppConfig) -> None:
             consumer.join()
     except KeyboardInterrupt:
         stop_event.set()
+        raise
     finally:
         stop_event.set()
         for stream in streams:
@@ -694,6 +703,8 @@ def main(argv: list[str] | None = None) -> int:
         load_runtime_dependencies()
         run_app(cfg)
         return 0
+    except KeyboardInterrupt:
+        return 130
     except Exception as exc:
         print(f"[ERR] {exc}", file=sys.stderr)
         return 1

--- a/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
+++ b/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
@@ -12,6 +12,10 @@
 namespace fs = std::filesystem;
 using namespace sima_examples::testing;
 
+namespace {
+constexpr const char* kE2eInsightHost = "127.0.0.1";
+} // namespace
+
 int main(int argc, char** argv) {
   if (argc < 2) {
     std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
@@ -39,9 +43,6 @@ int main(int argc, char** argv) {
   }
 
   const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-  const std::string insight_host = env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       ? env_or_null("SIMANEAT_APPS_TEST_INSIGHT_HOST")
-                                       : "127.0.0.1";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
@@ -50,7 +51,7 @@ int main(int argc, char** argv) {
   write_e2e_config("multi-stream-people-tracker", config_path,
                    {{"model.path", model_path},
                     {"output.debug_dir", output_dir},
-                    {"output.insight.host", insight_host},
+                    {"output.insight.host", kE2eInsightHost},
                     {"output.insight.video_port_base", std::to_string(video_port_base)},
                     {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
                     {"inference.frames", "140"}},
@@ -58,7 +59,7 @@ int main(int argc, char** argv) {
 
   const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   MetadataJsonListenerOptions metadata_options;
-  metadata_options.host = insight_host;
+  metadata_options.host = kE2eInsightHost;
   metadata_options.base_port = metadata_port_base;
   metadata_options.num_ports = 2;
   metadata_options.timeout_ms = 5000;
@@ -72,8 +73,8 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const ProcessResult result =
-      spawn_and_wait(binary, {"--config", config_path.string()}, timeout_ms);
+  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
+                                                        output_dir, total_saved_frames, timeout_ms);
 
   int rc = 0;
   if (result.exit_code != 0) {

--- a/examples/tracking/multi-stream-people-tracker/tests/python/test_e2e.py
+++ b/examples/tracking/multi-stream-people-tracker/tests/python/test_e2e.py
@@ -9,9 +9,12 @@ import sys
 
 import pytest
 
+from tests.utils.metadata_json_listener import MetadataJsonListener
+
 
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+E2E_INSIGHT_HOST = "127.0.0.1"
 
 
 def _runtime_deps_ready() -> bool:
@@ -21,10 +24,6 @@ def _runtime_deps_ready() -> bool:
 def _env_int_or_default(name: str, default: int) -> int:
     raw = os.environ.get(name, "").strip()
     return int(raw) if raw else default
-
-
-def _env_str_or_default(name: str, default: str) -> str:
-    return os.environ.get(name, "").strip() or default
 
 
 @pytest.mark.e2e
@@ -47,21 +46,18 @@ class TestE2E:
         skip_unless_e2e_ready(len(rtsp_urls) >= 2, "need at least two RTSP URLs for multistream e2e")
         output_cfg = e2e_config_section("multi-stream-people-tracker", "testing.e2e.output")
         total_saved_frames = int(output_cfg["total_saved_frames"])
+        metadata_port_base = _env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100)
 
         config_path = e2e_config_writer(
             {
                 "streams": rtsp_urls[:2],
                 "output": {
                     "insight": {
-                        "host": _env_str_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_HOST", "127.0.0.1"
-                        ),
+                        "host": E2E_INSIGHT_HOST,
                         "video_port_base": _env_int_or_default(
                             "SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000
                         ),
-                        "metadata_port_base": _env_int_or_default(
-                            "SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100
-                        ),
+                        "metadata_port_base": metadata_port_base,
                     },
                     "debug_dir": str(tmp_output_dir),
                 },
@@ -77,17 +73,29 @@ class TestE2E:
             "--config",
             str(config_path),
         ]
-        result = run_until_output_files(
-            cmd,
-            tmp_output_dir,
-            0,
-            test_timeout_ms / 1000,
-            cwd=str(EXAMPLE_DIR),
-        )
+        with MetadataJsonListener(
+            E2E_INSIGHT_HOST,
+            metadata_port_base,
+            num_ports=2,
+            metadata_type="tracking",
+            data_array_key="tracks",
+            require_all_ports=True,
+        ) as metadata_listener:
+            result = run_until_output_files(
+                cmd,
+                tmp_output_dir,
+                total_saved_frames,
+                test_timeout_ms / 1000,
+                cwd=str(EXAMPLE_DIR),
+            )
+            metadata = metadata_listener.wait_for_messages(5.0)
 
         assert result.returncode == 0, (
             f"main.py exited with code {result.returncode}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert metadata.success, (
+            f"tracking metadata was not received on all streams: {metadata.error}"
         )
 
         files = [

--- a/portal/src/App.jsx
+++ b/portal/src/App.jsx
@@ -449,7 +449,7 @@ function CatalogPage({ catalog }) {
             <div className="download-modal-header">
               <div>
                 <p className="eyebrow">Download</p>
-                <h2 id="download-modal-title">Install prebuilt apps from any branch</h2>
+                <h2 id="download-modal-title">Download Neat Apps</h2>
               </div>
               <button
                 className="modal-close"
@@ -466,12 +466,10 @@ function CatalogPage({ catalog }) {
               </button>
             </div>
             <p className="download-modal-copy">
-              To download the prebuilt apps package from any branch, run this command from the Modalix DevKit:
+              To download the current prebuilt Apps runtime, run:
             </p>
             <pre className="download-code">
-              <code>{`mkdir /media/nvme/neat-apps && cd /media/nvme/neat-apps &&
-wget -O /tmp/install.sh https://apps.sima-neat.com/tools/install-neat-apps.sh &&
-bash /tmp/install.sh`}</code>
+              <code>{`sima-cli neat install apps`}</code>
             </pre>
           </div>
         </div>

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -216,13 +216,13 @@ render_readme() {
 TODO: describe what this example demonstrates.
 
 ## Prerequisites
-- Installed Neat Development Environment.
+- Installed Neat Development Environment + Neat Library.
 - Model artifacts are user-managed and should be downloaded into \`assets/models/\`.
 
 ## Get The Apps Repo
-Install the Neat Library first by following the official [Neat Library installation guide](https://developer.sima.ai/software/getting-started/installation/neat-library).
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
 
-Then clone and build the apps repo:
+Then clone and build the apps repo inside the Neat Development Environment:
 
 \`\`\`bash
 git clone https://github.com/sima-neat/apps.git
@@ -230,7 +230,7 @@ cd apps
 ./build.sh --clean
 \`\`\`
 
-After this setup, follow the example-specific commands below.
+After building, run the example commands below on the Modalix/DevKit board.
 
 ## Build
 ### Build From The Apps Repo

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -178,6 +178,7 @@ def _run_build(
                 [
                     "develop=devsha1",
                     "main=mainsha1",
+                    "feature%252Fcore-artifact=featsha2",
                     "zz-core-artifact-for-test=featsha1",
                     "scratch-core-for-test=scratchsha1",
                 ]
@@ -185,6 +186,7 @@ def _run_build(
             "NEAT_APPS_TEST_METADATA": "\n".join(
                 [
                     "main:mainsha1",
+                    "feature%252Fcore-artifact:pinnedsha2",
                     "zz-core-artifact-for-test:pinnedsha1",
                 ]
             ),
@@ -364,6 +366,35 @@ def test_dependency_object_manifest_uses_valid_artifact(tmp_path, ref_key):
         "https://core.test/zz-core-artifact-for-test/pinnedsha1/metadata.json"
         in _curl_log(tmp_path)
     )
+
+
+def test_dependency_object_manifest_url_encodes_slash_branch_for_artifact(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"branch": "feature/core-artifact", "spec": "pinnedsha2"},
+        args=["--only-install-neat-core"],
+        env=_installer_env(tmp_path),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == "--minimum feature/core-artifact pinnedsha2"
+    assert (
+        "https://core.test/feature%252Fcore-artifact/pinnedsha2/metadata.json"
+        in _curl_log(tmp_path)
+    )
+
+
+def test_dependency_object_manifest_url_encodes_slash_branch_for_latest(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        neat_core={"branch": "feature/core-artifact"},
+        args=["--only-install-neat-core"],
+        env=_installer_env(tmp_path),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == "--minimum feature/core-artifact featsha2"
+    assert "https://core.test/feature%252Fcore-artifact/latest.tag" in _curl_log(tmp_path)
 
 
 def test_explicit_manifest_fails_when_artifact_is_invalid(tmp_path):

--- a/tests/utils/metadata_json_listener.py
+++ b/tests/utils/metadata_json_listener.py
@@ -1,0 +1,138 @@
+"""Test-only UDP listener for Insight metadata JSON."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import select
+import socket
+import time
+
+
+@dataclass(frozen=True)
+class MetadataJsonMessage:
+    port: int
+    payload: str
+    frame_id: str
+    timestamp_ms: int
+    object_count: int
+
+
+@dataclass(frozen=True)
+class MetadataJsonResult:
+    success: bool
+    ports_with_valid_json: set[int] = field(default_factory=set)
+    messages: list[MetadataJsonMessage] = field(default_factory=list)
+    error: str = ""
+
+
+class MetadataJsonListener:
+    """Receive metadata JSON emitted by e2e examples."""
+
+    def __init__(
+        self,
+        host: str,
+        base_port: int,
+        num_ports: int,
+        metadata_type: str = "object-detection",
+        data_array_key: str = "objects",
+        require_all_ports: bool = False,
+    ) -> None:
+        if num_ports <= 0:
+            raise ValueError("num_ports must be > 0")
+        if base_port <= 0:
+            raise ValueError("base_port must be > 0")
+
+        self._metadata_type = metadata_type
+        self._data_array_key = data_array_key
+        self._require_all_ports = require_all_ports
+        self._sockets: dict[socket.socket, int] = {}
+        try:
+            for offset in range(num_ports):
+                port = base_port + offset
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind((host, port))
+                sock.setblocking(False)
+                self._sockets[sock] = port
+        except Exception:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        for sock in self._sockets:
+            sock.close()
+        self._sockets.clear()
+
+    def __enter__(self) -> "MetadataJsonListener":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def wait_for_messages(self, timeout_s: float) -> MetadataJsonResult:
+        ports_with_valid_json: set[int] = set()
+        messages: list[MetadataJsonMessage] = []
+        last_error = "metadata timeout"
+        deadline = time.monotonic() + timeout_s
+
+        while time.monotonic() < deadline:
+            remaining = max(0.0, deadline - time.monotonic())
+            readable, _, _ = select.select(list(self._sockets.keys()), [], [], min(0.2, remaining))
+            for sock in readable:
+                payload, _ = sock.recvfrom(65536)
+                port = self._sockets[sock]
+                message, error = self._parse_message(port, payload)
+                if message is None:
+                    last_error = error
+                    continue
+                messages.append(message)
+                ports_with_valid_json.add(port)
+                if self._success_reached(ports_with_valid_json):
+                    return MetadataJsonResult(True, ports_with_valid_json, messages)
+
+        missing = sorted(set(self._sockets.values()) - ports_with_valid_json)
+        if missing:
+            last_error = f"missing metadata on ports {missing}; last_error={last_error}"
+        return MetadataJsonResult(False, ports_with_valid_json, messages, last_error)
+
+    def _success_reached(self, ports_with_valid_json: set[int]) -> bool:
+        if self._require_all_ports:
+            return len(ports_with_valid_json) == len(self._sockets)
+        return bool(ports_with_valid_json)
+
+    def _parse_message(
+        self, port: int, payload: bytes
+    ) -> tuple[MetadataJsonMessage | None, str]:
+        try:
+            parsed = json.loads(payload.decode("utf-8"))
+        except Exception as exc:
+            return None, f"json parse failed: {exc}"
+
+        if not isinstance(parsed, dict):
+            return None, "json root is not an object"
+        if parsed.get("type") != self._metadata_type:
+            return None, "missing or invalid type"
+        timestamp = parsed.get("timestamp")
+        if not isinstance(timestamp, int):
+            return None, "missing or invalid timestamp"
+        frame_id = parsed.get("frame_id")
+        if not isinstance(frame_id, str):
+            return None, "missing or invalid frame_id"
+        data = parsed.get("data")
+        if not isinstance(data, dict):
+            return None, "missing or invalid data"
+        objects = data.get(self._data_array_key)
+        if not isinstance(objects, list):
+            return None, f"missing or invalid data.{self._data_array_key}"
+
+        return (
+            MetadataJsonMessage(
+                port=port,
+                payload=payload.decode("utf-8", errors="replace"),
+                frame_id=frame_id,
+                timestamp_ms=timestamp,
+                object_count=len(objects),
+            ),
+            "",
+        )


### PR DESCRIPTION
## Release Intent

Prepare the `sima-neat/apps` 0.2.0 release by promoting the accumulated `develop` branch into `main`.

This is a release-candidate merge PR, not a narrow feature PR. It captures the current `develop` state for the Apps 2.1.2 release train and should be reviewed as a release-readiness PR.

## Version / Target

- Platform version: `2.1.2` from `deps/manifest.json`
- SDK channel: `develop`
- Core policy: `snap`
- Merge direction: `develop` -> `main`
- Head: `541cd0a` (`docs: clarify example build environment (#262)`)

## Scope Summary

This release updates Apps for the 2.1.2 SDK train, including example documentation cleanup, RTSP/Insight runtime fixes, benchmark refresh tooling, manifest policy updates, and CI/test-harness improvements.

The compare from `main` to `develop` is intentionally broad:

- `47` files changed
- major changed areas: example READMEs/configs, RTSP/Insight examples, benchmark tooling, test utilities, manifest policy, portal rendering, and Vulcan CI

## Release Contents

### Release Targeting and CI

- Updates `deps/manifest.json` from platform `2.0.0` to `2.1.2`.
- Switches the SDK channel from `main` to `develop` for this release branch.
- Keeps `neat-core` resolution on `snap`.
- Updates Vulcan CI to print SDK compiler diagnostics.
- Adds manifest contract coverage for release-policy checks.

### Example Documentation and Setup Flow

- Simplifies example reproduction docs across the Apps catalog.
- Clarifies that Apps builds run inside the Neat Development Environment.
- Clarifies that example runtime commands run on the Modalix/DevKit board.
- Standardizes prerequisites around Neat Development Environment plus Neat Library.
- Documents that model artifacts are user-managed under `assets/models/`.
- Adds `sima-cli install assets/multi-video-sources` to RTSP + Insight examples so users can install 720p and 480p sample videos for Insight RTSP streaming.
- Updates Apps portal behavior/content generated from the README catalog.

### Benchmark Tooling

- Adds `examples/benchmarking/model-benchmark/scripts/refresh_results.py`.
- Updates benchmark docs and results guidance around local model paths and refresh flow.
- Clarifies benchmark measurement scope and output behavior.

### RTSP and Insight Runtime Fixes

- Pins RTSP output caps for affected examples.
- Applies realtime-latest link behavior on live RTSP branch edges so live streams do not use lossless backpressure semantics.
- Updates single-stream and multistream Insight examples while preserving the existing video and metadata payload contracts.
- Aligns single-stream Insight defaults with the SDK port mapping.
- Adjusts multistream lifecycle handling and metadata test expectations.

### Test and Utility Updates

- Adds `tests/utils/metadata_json_listener.py`.
- Updates RTSP e2e tests for multistream object detection and people tracking.
- Adds/updates manifest-contract test coverage.
- Updates scaffold/template docs to match the revised example structure and setup wording.

## Notable Included PRs / Commits

- #262 docs: clarify example build environment
- #261 docs: simplify example reproduction docs
- #260 Pin Apps to codec service core artifact
- #255 Prepare apps for 2.1.2

## Validation Record

This PR is a release promotion PR. Before merging, confirm:

- Vulcan CI passes for the release PR.
- The resolved SDK/Core artifacts match the intended 2.1.2 release train.
- README validation passes for the generated example catalog.
- Portal catalog generation and portal build pass.
- RTSP/Insight e2e coverage is run with reachable RTSP sources and configured Insight endpoints.
- Benchmark refresh tooling is run only on the intended target hardware/runtime environment.
- Model-download and sample-asset instructions work from a clean Neat Development Environment.

Historical validation called out in included commits covers README validation, portal build checks, benchmark helper execution paths, and RTSP/Insight behavior fixes. The final release decision should still rely on this PR's current CI and release checklist.

## Merge Notes

- Reviewers should treat this as a release-readiness PR, not a line-by-line review of every accumulated example/doc change.
- Focus review on release targeting, manifest correctness, artifact resolution, example reproducibility, RTSP/Insight runtime readiness, and documentation accuracy for the 2.1.2 SDK train.
