### PR TITLE
Fix single-stream segmenter empty output crash

### DIFF
--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -280,6 +280,9 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
   std::vector<SegmentationDetection> detections;
   const size_t mask_bytes = 160U * 160U;
   for (const auto& item : decoded) {
+    if (!item.boxes.shape.empty() && item.boxes.shape.front() == 0) {
+      continue;
+    }
     const auto boxes = tensor_to_floats(item.boxes);
     const auto masks = tensor_to_u8(item.masks);
     const int count = static_cast<int>(boxes.size() / 6U);


### PR DESCRIPTION
## Summary

- Skip decoded segmentation items with zero box rows before copying boxes or masks.
- Keep zero-detection frames alive so `single-stream-instance-segmenter` continues publishing frames without overlays.

## Root Cause

`decode_segmentation(...)` can return valid empty decoded tensors when no instances survive filtering, such as boxes shaped `[0, 6]` and masks shaped `[0, 160, 160]`. The example copied those tensors with `copy_dense_bytes_tight()`, which treats zero dense bytes as an unknown dense size and throws.

## Scope

This is intentionally app-only. It does not change Core tensor semantics, BoxDecode configuration, thresholds, graph topology, or output transport.

Closes #271

## Validation

- all e2e tests passed. 
- ran the pipeline under heavy load for a long time and did not observe the bug.
