### PR TITLE
Backport segmenter empty-output crash fix to integration/0.2.1

### DIFF
--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -280,6 +280,9 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
   std::vector<SegmentationDetection> detections;
   const size_t mask_bytes = 160U * 160U;
   for (const auto& item : decoded) {
+    if (!item.boxes.shape.empty() && item.boxes.shape.front() == 0) {
+      continue;
+    }
     const auto boxes = tensor_to_floats(item.boxes);
     const auto masks = tensor_to_u8(item.masks);
     const int count = static_cast<int>(boxes.size() / 6U);


### PR DESCRIPTION
## Summary

- Cherry-pick the `single-stream-instance-segmenter` empty-output fix onto `integration/0.2.1`.
- Skip decoded segmentation items with zero box rows before copying boxes or masks.
- Keep zero-detection frames alive so the example continues publishing frames without overlays.

## Scope

This PR intentionally contains only the segmenter fix from `b2b0317` / #272. It does not include develop-only multimodal assistant changes or any other feature work.

Changed file:

- `examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp`

## Root Cause

`decode_segmentation(...)` can return valid empty decoded tensors when no instances survive filtering, such as boxes shaped `[0, 6]`. The example copied those tensors with `copy_dense_bytes_tight()`, which treats zero dense bytes as an unknown dense size and throws.

Refs #271

## Validation

- `clang-format -i examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp`
- `git diff --check origin/integration/0.2.1...HEAD`
- `docker exec ghcr.io-sima-neat-sdk-latest bash -lc 'cd /workspace/sima-neat/apps && cmake --build build --target app__workspace_sima_neat_apps_examples_segmentation_single_stream_instance_segmenter_src_cpp_single_stream_instance_segmenter -j2'`
- Modalix runtime check from the develop PR confirmed the fix works on the segmentation path
