### PR TITLE
Promote integration/0.2.1 segmenter fix to release-0.2

### DIFF
--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -280,6 +280,9 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
   std::vector<SegmentationDetection> detections;
   const size_t mask_bytes = 160U * 160U;
   for (const auto& item : decoded) {
+    if (!item.boxes.shape.empty() && item.boxes.shape.front() == 0) {
+      continue;
+    }
     const auto boxes = tensor_to_floats(item.boxes);
     const auto masks = tensor_to_u8(item.masks);
     const int count = static_cast<int>(boxes.size() / 6U);


### PR DESCRIPTION
## Summary

Patch-release PR for Apps `0.2.1` into the `release-0.2` line.

This merges `integration/0.2.1` into `release-0.2` with one scoped runtime fix: `single-stream-instance-segmenter` no longer crashes when a frame produces zero segmentation detections.

Changed file:

- `examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp`

## Root Cause

`decode_segmentation(...)` can return a valid decoded result with zero detections. In that case the decoded boxes tensor has zero rows, and the app tried to copy boxes and masks through `copy_dense_bytes_tight()`. That path surfaced as `copy_dense_bytes_tight: unknown dense size` for the empty decoded tensor.

## Fix

Skip decoded segmentation items whose boxes tensor has zero rows before copying boxes or masks.

This keeps the patch-release scope narrow:

- no graph topology changes
- no model or preprocessing changes
- no output transport changes
- no multi-model assistant example changes

## Validation

- Verified `origin/integration/0.2.1` is ahead of `origin/release-0.2` only by the merged #275 segmenter fix.
- `git diff --name-only origin/release-0.2...origin/integration/0.2.1`
- `git diff --check origin/release-0.2...origin/integration/0.2.1`
- The same fix was clang-formatted and SDK-built before merging #275.
