### PR TITLE
Add GA4 analytics to the Examples portal (read-only consent)

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -337,6 +337,7 @@ jobs:
       - resolve-portal-publish-config
       - test-runtime
     runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-portal-publish-config.outputs.vulcan_env }}
     env:
       PORTAL_BASE_URL: ${{ format('{0}/examples', needs.resolve-portal-publish-config.outputs.sysdoc_base_url) }}
 
@@ -350,6 +351,43 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Configure AWS credentials for Vulcan config
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ needs.resolve-portal-publish-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-portal-publish-config.outputs.config_reader_role_arn }}
+          role-session-name: vulcan-apps-ga-config-${{ github.run_id }}
+
+      - name: Resolve GA measurement ID
+        shell: bash
+        env:
+          VULCAN_CONFIG_S3_URI: ${{ needs.resolve-portal-publish-config.outputs.config_s3_uri }}
+          DEPLOY_ENV: ${{ needs.resolve-portal-publish-config.outputs.vulcan_env }}
+        run: |
+          set -euo pipefail
+
+          config_file="${RUNNER_TEMP}/vulcan-environment.json"
+          aws s3 cp "${VULCAN_CONFIG_S3_URI}" "${config_file}" --only-show-errors
+
+          CONFIG_FILE="${config_file}" python3 - <<'PY' >> "${GITHUB_ENV}"
+          import json
+          import os
+          import sys
+
+          with open(os.environ["CONFIG_FILE"], encoding="utf-8") as handle:
+              config = json.load(handle)
+
+          analytics = config.get("analytics") or {}
+          measurement_id = analytics.get("ga_measurement_id") or ""
+
+          state = "enabled" if measurement_id else "disabled"
+          print(
+              f"GA4 analytics: {state} for env {os.environ.get('DEPLOY_ENV')}",
+              file=sys.stderr,
+          )
+          print(f"PORTAL_GA_MEASUREMENT_ID={measurement_id}")
+          PY
 
       - name: Install portal dependencies
         working-directory: portal

--- a/portal/src/analytics.js
+++ b/portal/src/analytics.js
@@ -1,0 +1,106 @@
+// Read-only analytics for the Examples (Apps Portal) section.
+//
+// The Developer Center stores one cookie-consent decision in localStorage on
+// the shared developer.sima.ai origin (written by the docs/core consent
+// banners). This module only *reads* that decision — it never renders a banner
+// and never writes consent. GA4 is loaded only when analytics consent is
+// already granted, so undecided/denied visitors are never tracked.
+//
+// The measurement ID is injected at build time from the per-env Vulcan config
+// (analytics.ga_measurement_id) via Vite `define` (see vite.config.js), so
+// examples reports into the same GA4 property as the rest of the Developer
+// Center: staging G-T1D371DW1K, prod G-Y6YREB4EG5.
+
+const CONSENT_KEY = "sima-developer-center-cookie-consent";
+const CONSENT_VERSION = 1;
+
+// Replaced at build time by Vite `define`. Falls back to "" when unset
+// (local dev, or a config bundle without the key) so gtag never loads.
+const MEASUREMENT_ID =
+  typeof __PORTAL_GA_MEASUREMENT_ID__ !== "undefined" ? __PORTAL_GA_MEASUREMENT_ID__ : "";
+
+const deniedConsent = {
+  ad_storage: "denied",
+  ad_user_data: "denied",
+  ad_personalization: "denied",
+  analytics_storage: "denied",
+};
+
+const grantedConsent = {
+  ...deniedConsent,
+  analytics_storage: "granted",
+};
+
+let gtagLoaded = false;
+let lastTrackedLocation = "";
+
+function getStoredConsent() {
+  try {
+    const value = window.localStorage.getItem(CONSENT_KEY);
+    const parsed = value ? JSON.parse(value) : null;
+    if (!parsed || parsed.version !== CONSENT_VERSION) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function analyticsGranted() {
+  return getStoredConsent()?.analytics === true;
+}
+
+function currentPath() {
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function ensureGtag() {
+  window.dataLayer = window.dataLayer || [];
+  if (!window.gtag) {
+    window.gtag = function gtag() {
+      window.dataLayer.push(arguments);
+    };
+  }
+  window.gtag("consent", "default", deniedConsent);
+}
+
+export function trackPageView() {
+  if (!window.gtag || !analyticsGranted()) {
+    return;
+  }
+  const path = currentPath();
+  if (path === lastTrackedLocation) {
+    return;
+  }
+  lastTrackedLocation = path;
+  window.gtag("event", "page_view", {
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: path,
+    page_section: "examples",
+  });
+}
+
+export function loadGtag() {
+  if (gtagLoaded || !MEASUREMENT_ID || !analyticsGranted()) {
+    return;
+  }
+  gtagLoaded = true;
+
+  ensureGtag();
+  window.gtag("consent", "update", grantedConsent);
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(MEASUREMENT_ID)}`;
+  document.head.appendChild(script);
+
+  window.gtag("js", new Date());
+  window.gtag("config", MEASUREMENT_ID, {
+    anonymize_ip: true,
+    send_page_view: false,
+  });
+
+  trackPageView();
+}

--- a/portal/src/main.jsx
+++ b/portal/src/main.jsx
@@ -1,14 +1,28 @@
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, useLocation } from "react-router-dom";
 import App from "./App";
+import { loadGtag, trackPageView } from "./analytics";
 import "./styles.css";
 
 const basename = import.meta.env.BASE_URL.replace(/\/$/, "") || "/";
 
+// Read-only analytics: loads GA4 only if consent was already granted elsewhere
+// in the Developer Center, then records a page_view on first render and on each
+// route change. Renders nothing.
+function RouteAnalytics() {
+  const location = useLocation();
+  useEffect(() => {
+    loadGtag();
+    trackPageView();
+  }, [location.pathname, location.search]);
+  return null;
+}
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter basename={basename}>
+      <RouteAnalytics />
       <App />
     </BrowserRouter>
   </React.StrictMode>,

--- a/portal/vite.config.js
+++ b/portal/vite.config.js
@@ -21,6 +21,9 @@ function resolveBasePath() {
 export default defineConfig({
   plugins: [react()],
   base: resolveBasePath(),
+  define: {
+    __PORTAL_GA_MEASUREMENT_ID__: JSON.stringify(process.env.PORTAL_GA_MEASUREMENT_ID || ""),
+  },
   server: {
     host: "0.0.0.0",
     port: 5000,


### PR DESCRIPTION
The Examples section (`developer.sima.ai/examples`, the Apps Portal) had no analytics. This wires GA4 into the Vite/React portal so it reports into the same property as home/hardware (docs) and software (core).

## Read-only consent
The portal **reads** the shared Developer Center consent (`localStorage["sima-developer-center-cookie-consent"]`, same origin) and loads GA4 only when `analytics === true`. It does **not** render its own banner and does **not** write consent — undecided/denied visitors are never tracked. This avoids a third copy of the consent banner; consolidating all banners into the shared shell stays a separate task.

## Changes
- `portal/src/analytics.js` (new): read consent (key/shape/version match docs/core), idempotent `loadGtag()` (only if granted + ID present; `anonymize_ip`, `send_page_view: false`), `trackPageView()` (`page_view` with `page_path`/`page_location`/`page_section: examples`, deduped).
- `portal/src/main.jsx`: a `<RouteAnalytics>` inside `<BrowserRouter>` calls `loadGtag()` + `trackPageView()` on mount and every `useLocation` change.
- `portal/vite.config.js`: `define` injects `__PORTAL_GA_MEASUREMENT_ID__` from `process.env.PORTAL_GA_MEASUREMENT_ID` (empty when unset → gtag never loads).
- `.github/workflows/vulcan-ci.yml` (`build-sysdoc-examples`): adds `environment:` (required for the config-reader OIDC role) + AWS config-reader creds + a `Resolve GA measurement ID` step that reads `analytics.ga_measurement_id` from the per-env Vulcan bundle and sets `PORTAL_GA_MEASUREMENT_ID` for the build. No GitHub-variable fallback (examples never had one) — absent key ⇒ empty ⇒ GA off.

## Verification (local build `PORTAL_GA_MEASUREMENT_ID=G-TEST00000 PORTAL_BASE_URL=/examples`, headless Chrome)
| Scenario | Result |
|---|---|
| Consent granted | `page_view` fires on `/examples/` **and** on navigation to `/examples/app/<id>` (both confirmed in `dataLayer` with correct `page_path`) |
| Consent denied | 0 events, no banner |
| No consent stored | 0 events, no banner |

Also: measurement ID baked into the bundle via the Vite `define`; workflow YAML parses; the Python extractor returns the ID / empty (no crash) for bundles with/without the key.

## Dependency / deploy
vulcan#18 is applied to staging and prod, so the per-env IDs are live. The portal builds/deploys to staging from branches, so this can be validated at `developer-stg.sima.ai/examples` in the staging property (`G-T1D371DW1K`). The `environment:` key matches the publish jobs so the config-reader role assumes cleanly (same OIDC fix as sima-neat/core#431).