### PR TITLE
Add analytics to the Examples portal and fix examples

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -337,6 +337,7 @@ jobs:
       - resolve-portal-publish-config
       - test-runtime
     runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-portal-publish-config.outputs.vulcan_env }}
     env:
       PORTAL_BASE_URL: ${{ format('{0}/examples', needs.resolve-portal-publish-config.outputs.sysdoc_base_url) }}
 
@@ -350,6 +351,43 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Configure AWS credentials for Vulcan config
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ needs.resolve-portal-publish-config.outputs.aws_region }}
+          role-to-assume: ${{ needs.resolve-portal-publish-config.outputs.config_reader_role_arn }}
+          role-session-name: vulcan-apps-ga-config-${{ github.run_id }}
+
+      - name: Resolve GA measurement ID
+        shell: bash
+        env:
+          VULCAN_CONFIG_S3_URI: ${{ needs.resolve-portal-publish-config.outputs.config_s3_uri }}
+          DEPLOY_ENV: ${{ needs.resolve-portal-publish-config.outputs.vulcan_env }}
+        run: |
+          set -euo pipefail
+
+          config_file="${RUNNER_TEMP}/vulcan-environment.json"
+          aws s3 cp "${VULCAN_CONFIG_S3_URI}" "${config_file}" --only-show-errors
+
+          CONFIG_FILE="${config_file}" python3 - <<'PY' >> "${GITHUB_ENV}"
+          import json
+          import os
+          import sys
+
+          with open(os.environ["CONFIG_FILE"], encoding="utf-8") as handle:
+              config = json.load(handle)
+
+          analytics = config.get("analytics") or {}
+          measurement_id = analytics.get("ga_measurement_id") or ""
+
+          state = "enabled" if measurement_id else "disabled"
+          print(
+              f"GA4 analytics: {state} for env {os.environ.get('DEPLOY_ENV')}",
+              file=sys.stderr,
+          )
+          print(f"PORTAL_GA_MEASUREMENT_ID={measurement_id}")
+          PY
 
       - name: Install portal dependencies
         working-directory: portal

--- a/examples/genai/multimodal-assistant/src/python/ui/flask_app.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/flask_app.py
@@ -123,6 +123,7 @@ class TalkController:
         self.totalk = ''
         self.talk = []
         self.pipers = {}
+        self.utterance_speed = 1.0
         self.missing_voice_warnings = set()
         self._init_pipers_threaded(supported_langs or ['en'])
         
@@ -146,6 +147,16 @@ class TalkController:
     def set_language(self, lang):
         self.current_language = lang if lang in self.supported_langs else 'xx'
 
+    def set_utterance_speed(self, speed):
+        try:
+            speed = float(speed)
+        except (TypeError, ValueError):
+            speed = 1.0
+        self.utterance_speed = max(0.5, min(2.0, speed))
+        for piper in self.pipers.values():
+            if hasattr(piper, 'set_utterance_speed'):
+                piper.set_utterance_speed(self.utterance_speed)
+
     def _init_pipers_threaded(self, langs):
         threads = []
         assets = Path("assets")
@@ -153,9 +164,11 @@ class TalkController:
         def load_piper(lang_code, onnx_file):
             from pipertts import PiperTTS # import here if needed locally
             try:
-                self.pipers[lang_code] = PiperTTS(
+                piper = PiperTTS(
                     model_path=str(onnx_file)
                 )
+                piper.set_utterance_speed(self.utterance_speed)
+                self.pipers[lang_code] = piper
                 logging.info(f"Loaded Piper model for {lang_code}")
             except Exception as e:
                 logging.warning(f"Failed to load Piper model for {lang_code}: {e}")
@@ -629,7 +642,7 @@ class AppContext:
             self.set_system_prompt(self.system_prompt)
 
         if not self.apionly:
-            self.talk_ctrl = TalkController(['en', 'fr', 'es', 'de', 'it', 'zh']) 
+            self.talk_ctrl = TalkController(['en', 'fr', 'es', 'de', 'it', 'zh', 'vi'])
 
     def update_from_config(self, app_cfg):
         model_server = f"{app_cfg.openai.client_host}:{app_cfg.openai.port}"
@@ -812,6 +825,7 @@ class AppContext:
                 with self.talk_ctrl.lock:
                     old = self.talk_ctrl.pipers.get(lang)
                     new_voice = PiperTTS(model_path=str(candidate))
+                    new_voice.set_utterance_speed(self.talk_ctrl.utterance_speed)
                     self.talk_ctrl.pipers[lang] = new_voice
                     self.current_voice_by_lang[lang] = candidate.name
                     # Drop reference to old instance; GC will reclaim when unreferenced
@@ -881,6 +895,7 @@ class AppContext:
 
             # Handle form fields
             language = request.form.get('language', 'en')
+            utterance_speed = request.form.get('utteranceSpeed', '1.0')
             chat = request.form.get('textchat', '').strip()
             search_rag = request.form.get('searchRag', 'false').lower() == 'true'
             include_chat_history = request.form.get('includeChatHistory', 'true').lower() == 'true'
@@ -892,6 +907,7 @@ class AppContext:
 
             self.talk_ctrl.reset()
             self.talk_ctrl.set_language(language)
+            self.talk_ctrl.set_utterance_speed(utterance_speed)
             had_active_generation = self.interrupt_active_generation(
                 preserve_partial=include_chat_history
             )
@@ -1035,6 +1051,7 @@ class AppContext:
                 model = data.get('model', 'piper-tts')
                 voice = data.get('voice', 'default')
                 language = data.get('language', 'en')
+                utterance_speed = data.get('utterance_speed', data.get('utteranceSpeed', 1.0))
                 response_format = data.get('response_format', 'wav')
 
                 if not text:
@@ -1046,6 +1063,7 @@ class AppContext:
 
                 logging.info(f"Received TTS request: model={model}, voice={voice}, format={response_format}")
 
+                self.talk_ctrl.set_utterance_speed(utterance_speed)
                 result = self.talk_ctrl.tts_on_demand(text, language=language)
 
                 # Default to WAV for Piper. If mp3 is requested, you need ffmpeg to convert.

--- a/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
@@ -50,6 +50,16 @@ class PiperTTS:
             normalize_audio=True
         )
 
+
+    def set_utterance_speed(self, speed):
+        """Set speech speed as a multiplier where 1.0 is normal."""
+        try:
+            speed = float(speed)
+        except (TypeError, ValueError):
+            speed = 1.0
+        speed = max(0.5, min(2.0, speed))
+        self.config.length_scale = 1.0 / speed
+
     def synthesize(self, text):
         """
         Synthesize speech from the provided text into a WAV audio buffer.

--- a/examples/genai/multimodal-assistant/src/python/ui/static/newui.css
+++ b/examples/genai/multimodal-assistant/src/python/ui/static/newui.css
@@ -366,6 +366,25 @@ body {
   font-size: 11px;
 }
 
+.utterance-speed-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.utterance-speed-control input[type="range"] {
+  flex: 1;
+  min-width: 120px;
+}
+
+#utteranceSpeedValue {
+  width: 42px;
+  text-align: right;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
 /* Metrics Section */
 .metrics-section {
   display: flex;

--- a/examples/genai/multimodal-assistant/src/python/ui/static/newui.js
+++ b/examples/genai/multimodal-assistant/src/python/ui/static/newui.js
@@ -460,6 +460,7 @@ window.onload = function () {
 
   // Initialize dashboard functionality
   initializeVoiceSync();
+  initializeUtteranceSpeedControl();
   initializeChatModelSelect();
   hideRagControlsIfDisabled();
   if (isRagEnabled()) {
@@ -939,12 +940,7 @@ function resetSettingsToDefaults() {
   const languageSelect = document.getElementById('languageSelect');
   if (languageSelect) {
     languageSelect.value = 'en';
-  }
-
-  // Reset voice select to default
-  const voiceSelect = document.getElementById('voiceSelect');
-  if (voiceSelect) {
-    voiceSelect.value = 'default';
+    refreshVoiceOptions();
   }
 
   // Clear any status messages
@@ -1009,12 +1005,7 @@ function showSettingsRows() {
     languageRow.style.display = 'block';
   }
 
-  // Voice row logic depends on language selection
-  const voiceRow = document.getElementById('voiceRow');
-  const languageSelect = document.getElementById('languageSelect');
-  if (voiceRow && languageSelect) {
-    voiceRow.style.display = languageSelect.value === 'en' ? 'block' : 'none';
-  }
+  refreshVoiceOptions();
 }
 
 // Clear only status messages, preserve settings values
@@ -1029,6 +1020,26 @@ function clearStatusMessages() {
   // that should persist across chat sessions
 }
 
+
+function getUtteranceSpeed() {
+  const speedRange = document.getElementById('utteranceSpeedRange');
+  const speed = speedRange ? parseFloat(speedRange.value) : 1.0;
+  return Number.isFinite(speed) && speed > 0 ? speed : 1.0;
+}
+
+function updateUtteranceSpeedValue() {
+  const speedValue = document.getElementById('utteranceSpeedValue');
+  if (speedValue) {
+    speedValue.textContent = `${getUtteranceSpeed().toFixed(2)}x`;
+  }
+}
+
+function initializeUtteranceSpeedControl() {
+  const speedRange = document.getElementById('utteranceSpeedRange');
+  if (!speedRange) return;
+  updateUtteranceSpeedValue();
+  speedRange.addEventListener('input', updateUtteranceSpeedValue);
+}
 function captureAndAnimateSnap(textchat = null) {
   const includeImageCheckbox = document.getElementById('toggleImagePrompt');
 
@@ -1214,6 +1225,7 @@ async function startProcessingInternal(resultMessage, textchat = null, waitForTr
   formData.append('searchRag', isRagEnabled() && searchRag ? searchRag.checked : false);
   formData.append('includeChatHistory', includeChatHistory ? includeChatHistory.checked : true);
   formData.append('chatModel', getSelectedChatModel());
+  formData.append('utteranceSpeed', getUtteranceSpeed().toFixed(2));
 
   const sendRequest = async () => {
     activeGeneration = true;
@@ -1636,28 +1648,80 @@ async function processSystemAudioOnce(data) {
   }
 }
 
+function getSelectedVoiceLanguage() {
+  const languageSelect = document.getElementById('languageSelect');
+  return languageSelect ? languageSelect.value : 'en';
+}
+
+function getVoiceStorageKey(lang) {
+  return `${lang}VoiceId`;
+}
+
+function setVoiceRowVisible(visible) {
+  const voiceRow = document.getElementById('voiceRow');
+  if (voiceRow) {
+    voiceRow.style.display = visible ? 'block' : 'none';
+  }
+}
+
+function setVoiceLabel(lang) {
+  const voiceLabel = document.querySelector('label[for="voiceSelect"]');
+  const languageSelect = document.getElementById('languageSelect');
+  const selectedOption = languageSelect ? languageSelect.options[languageSelect.selectedIndex] : null;
+  const label = selectedOption ? selectedOption.textContent.replace(/\s*\([^)]*\)\s*$/, '') : lang;
+  if (voiceLabel) {
+    voiceLabel.textContent = `${label} Voice:`;
+  }
+}
+
+async function refreshVoiceOptions() {
+  const voiceSelect = document.getElementById('voiceSelect');
+  if (!voiceSelect) return;
+
+  const lang = getSelectedVoiceLanguage();
+  setVoiceLabel(lang);
+
+  try {
+    const response = await fetch(`/voices?lang=${encodeURIComponent(lang)}`);
+    if (!response.ok) throw new Error('Failed to load voices');
+
+    const data = await response.json();
+    const voices = Array.isArray(data.voices) ? data.voices : [];
+    while (voiceSelect.firstChild) voiceSelect.removeChild(voiceSelect.firstChild);
+
+    if (voices.length === 0) {
+      voiceSelect.dataset.lang = lang;
+      voiceSelect.dataset.prev = '';
+      setVoiceRowVisible(false);
+      return;
+    }
+
+    const stored = localStorage.getItem(getVoiceStorageKey(lang));
+    const current = data.current;
+    const toSelect = current || stored || voices[0].id;
+
+    voices.forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = v.id;
+      opt.textContent = v.label || v.id;
+      voiceSelect.appendChild(opt);
+    });
+
+    const found = Array.from(voiceSelect.options).some(o => o.value === toSelect);
+    voiceSelect.value = found ? toSelect : voiceSelect.options[0].value;
+    voiceSelect.dataset.lang = lang;
+    voiceSelect.dataset.prev = voiceSelect.value;
+    setVoiceRowVisible(voices.length > 1);
+  } catch (e) {
+    voiceSelect.dataset.lang = lang;
+    voiceSelect.dataset.prev = '';
+    setVoiceRowVisible(false);
+  }
+}
+
 // Settings are now always visible, so initialize voice sync on load
 function initializeVoiceSync() {
-  try {
-    const voiceSelect = document.getElementById('voiceSelect');
-    const languageSelect = document.getElementById('languageSelect');
-    if (voiceSelect && languageSelect && languageSelect.value === 'en') {
-      fetch('/voices?lang=en')
-        .then(res => res.ok ? res.json() : null)
-        .then(data => {
-          if (data && data.current) {
-            const found = Array.from(voiceSelect.options).some(o => o.value === data.current);
-            if (found) {
-              voiceSelect.value = data.current;
-              voiceSelect.dataset.prev = voiceSelect.value;
-            }
-          }
-        })
-        .catch(() => { });
-    }
-  } catch (e) {
-    // ignore sync errors
-  }
+  refreshVoiceOptions();
 }
 
 function setRagControls(dbReady) {
@@ -1720,51 +1784,13 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Initialize voice row visibility based on current language
-  const voiceRow = document.getElementById('voiceRow');
-  const languageSelect = document.getElementById('languageSelect');
-  if (voiceRow && languageSelect) {
-    voiceRow.style.display = languageSelect.value === 'en' ? 'block' : 'none';
-  }
-
-  // Fetch English voices and populate dropdown
-  const voiceSelect = document.getElementById('voiceSelect');
-  if (voiceSelect) {
-    fetch('/voices?lang=en')
-      .then(r => r.ok ? r.json() : Promise.reject(new Error('Failed to load voices')))
-      .then(data => {
-        if (!data || !Array.isArray(data.voices) || data.voices.length === 0) return;
-        while (voiceSelect.firstChild) voiceSelect.removeChild(voiceSelect.firstChild);
-        const stored = localStorage.getItem('enVoiceId');
-        const current = data.current;
-        let toSelect = stored || current || (data.voices[0] && data.voices[0].id);
-        data.voices.forEach(v => {
-          const opt = document.createElement('option');
-          opt.value = v.id;
-          opt.textContent = v.label || v.id;
-          voiceSelect.appendChild(opt);
-        });
-        if (toSelect) {
-          const found = Array.from(voiceSelect.options).some(o => o.value === toSelect);
-          voiceSelect.value = found ? toSelect : voiceSelect.options[0].value;
-        }
-        if (voiceRow && languageSelect) {
-          voiceRow.style.display = languageSelect.value === 'en' ? 'block' : 'none';
-        }
-      })
-      .catch(() => { });
-  }
+  refreshVoiceOptions();
 });
 
 // Toggle voice selector on language change
 const languageSelectEl = document.getElementById('languageSelect');
 if (languageSelectEl) {
-  languageSelectEl.addEventListener('change', () => {
-    const voiceRow = document.getElementById('voiceRow');
-    if (voiceRow) {
-      voiceRow.style.display = languageSelectEl.value === 'en' ? 'block' : 'none';
-    }
-  });
+  languageSelectEl.addEventListener('change', refreshVoiceOptions);
 }
 
 // Chat functionality now handled by new dashboard interface
@@ -1972,7 +1998,7 @@ document.getElementById("importRagDatabaseButton").addEventListener("click", asy
   };
 });
 
-// Wire English voice selection change
+// Wire language-aware voice selection change
 (function setupVoiceSelection() {
   const voiceSelectEl = document.getElementById('voiceSelect');
   if (!voiceSelectEl) return;
@@ -2019,11 +2045,11 @@ document.getElementById("importRagDatabaseButton").addEventListener("click", asy
       const res = await fetch('/voices/select', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ lang: 'en', voiceId: chosen })
+        body: JSON.stringify({ lang: getSelectedVoiceLanguage(), voiceId: chosen })
       });
       if (!res.ok) throw new Error('Server rejected voice');
       const data = await res.json();
-      localStorage.setItem('enVoiceId', chosen);
+      localStorage.setItem(getVoiceStorageKey(getSelectedVoiceLanguage()), chosen);
       voiceSelectEl.dataset.prev = chosen;
       // brief confirmation: write into voiceStatus if present
       if (voiceMsg) {

--- a/examples/genai/multimodal-assistant/src/python/ui/templates/newui.html
+++ b/examples/genai/multimodal-assistant/src/python/ui/templates/newui.html
@@ -79,12 +79,13 @@
                   <option value="ja">日本語 (Japanese)</option>
                   <option value="ko">한국어 (Korean)</option>
                   <option value="zh">中文 (Chinese)</option>
+                  <option value="vi">Tiếng Việt (Vietnamese)</option>
                 </select>
               </div>
 
               <div class="setting-row voice-language-group" id="voiceRow">
                 <label for="voiceSelect" class="setting-label">
-                  English Voice:
+                  Voice:
                 </label>
                 <select id="voiceSelect" class="setting-select">
                   <option value="default" selected>Default</option>
@@ -93,6 +94,15 @@
                   <option value="amy">Amy</option>
                 </select>
                 <div id="voiceStatus" class="voice-status"></div>
+              </div>
+              <div class="setting-row utterance-speed-row">
+                <label for="utteranceSpeedRange" class="setting-label">
+                  Utterance Speed:
+                </label>
+                <div class="utterance-speed-control">
+                  <input type="range" id="utteranceSpeedRange" min="0.75" max="1.50" step="0.05" value="1.00">
+                  <span id="utteranceSpeedValue">1.00x</span>
+                </div>
               </div>
             </div>
 

--- a/examples/genai/multimodal-assistant/src/python/voice_install.sh
+++ b/examples/genai/multimodal-assistant/src/python/voice_install.sh
@@ -19,6 +19,8 @@ VOICES=(
   "en_US-hfc_male-medium"
   "en_US-kristin-medium"
   "en_GB-northern_english_male-medium"
+  "vi_VN-vivos-x_low"
+  "vi_VN-vais1000-medium"
   "de_DE-thorsten-medium"
   "es_ES-davefx-medium"
   "fr_FR-siwis-medium"

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -280,6 +280,9 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
   std::vector<SegmentationDetection> detections;
   const size_t mask_bytes = 160U * 160U;
   for (const auto& item : decoded) {
+    if (!item.boxes.shape.empty() && item.boxes.shape.front() == 0) {
+      continue;
+    }
     const auto boxes = tensor_to_floats(item.boxes);
     const auto masks = tensor_to_u8(item.masks);
     const int count = static_cast<int>(boxes.size() / 6U);

--- a/portal/src/analytics.js
+++ b/portal/src/analytics.js
@@ -1,0 +1,106 @@
+// Read-only analytics for the Examples (Apps Portal) section.
+//
+// The Developer Center stores one cookie-consent decision in localStorage on
+// the shared developer.sima.ai origin (written by the docs/core consent
+// banners). This module only *reads* that decision — it never renders a banner
+// and never writes consent. GA4 is loaded only when analytics consent is
+// already granted, so undecided/denied visitors are never tracked.
+//
+// The measurement ID is injected at build time from the per-env Vulcan config
+// (analytics.ga_measurement_id) via Vite `define` (see vite.config.js), so
+// examples reports into the same GA4 property as the rest of the Developer
+// Center: staging G-T1D371DW1K, prod G-Y6YREB4EG5.
+
+const CONSENT_KEY = "sima-developer-center-cookie-consent";
+const CONSENT_VERSION = 1;
+
+// Replaced at build time by Vite `define`. Falls back to "" when unset
+// (local dev, or a config bundle without the key) so gtag never loads.
+const MEASUREMENT_ID =
+  typeof __PORTAL_GA_MEASUREMENT_ID__ !== "undefined" ? __PORTAL_GA_MEASUREMENT_ID__ : "";
+
+const deniedConsent = {
+  ad_storage: "denied",
+  ad_user_data: "denied",
+  ad_personalization: "denied",
+  analytics_storage: "denied",
+};
+
+const grantedConsent = {
+  ...deniedConsent,
+  analytics_storage: "granted",
+};
+
+let gtagLoaded = false;
+let lastTrackedLocation = "";
+
+function getStoredConsent() {
+  try {
+    const value = window.localStorage.getItem(CONSENT_KEY);
+    const parsed = value ? JSON.parse(value) : null;
+    if (!parsed || parsed.version !== CONSENT_VERSION) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function analyticsGranted() {
+  return getStoredConsent()?.analytics === true;
+}
+
+function currentPath() {
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function ensureGtag() {
+  window.dataLayer = window.dataLayer || [];
+  if (!window.gtag) {
+    window.gtag = function gtag() {
+      window.dataLayer.push(arguments);
+    };
+  }
+  window.gtag("consent", "default", deniedConsent);
+}
+
+export function trackPageView() {
+  if (!window.gtag || !analyticsGranted()) {
+    return;
+  }
+  const path = currentPath();
+  if (path === lastTrackedLocation) {
+    return;
+  }
+  lastTrackedLocation = path;
+  window.gtag("event", "page_view", {
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: path,
+    page_section: "examples",
+  });
+}
+
+export function loadGtag() {
+  if (gtagLoaded || !MEASUREMENT_ID || !analyticsGranted()) {
+    return;
+  }
+  gtagLoaded = true;
+
+  ensureGtag();
+  window.gtag("consent", "update", grantedConsent);
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(MEASUREMENT_ID)}`;
+  document.head.appendChild(script);
+
+  window.gtag("js", new Date());
+  window.gtag("config", MEASUREMENT_ID, {
+    anonymize_ip: true,
+    send_page_view: false,
+  });
+
+  trackPageView();
+}

--- a/portal/src/main.jsx
+++ b/portal/src/main.jsx
@@ -1,14 +1,28 @@
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, useLocation } from "react-router-dom";
 import App from "./App";
+import { loadGtag, trackPageView } from "./analytics";
 import "./styles.css";
 
 const basename = import.meta.env.BASE_URL.replace(/\/$/, "") || "/";
 
+// Read-only analytics: loads GA4 only if consent was already granted elsewhere
+// in the Developer Center, then records a page_view on first render and on each
+// route change. Renders nothing.
+function RouteAnalytics() {
+  const location = useLocation();
+  useEffect(() => {
+    loadGtag();
+    trackPageView();
+  }, [location.pathname, location.search]);
+  return null;
+}
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter basename={basename}>
+      <RouteAnalytics />
       <App />
     </BrowserRouter>
   </React.StrictMode>,

--- a/portal/vite.config.js
+++ b/portal/vite.config.js
@@ -21,6 +21,9 @@ function resolveBasePath() {
 export default defineConfig({
   plugins: [react()],
   base: resolveBasePath(),
+  define: {
+    __PORTAL_GA_MEASUREMENT_ID__: JSON.stringify(process.env.PORTAL_GA_MEASUREMENT_ID || ""),
+  },
   server: {
     host: "0.0.0.0",
     port: 5000,


### PR DESCRIPTION
Changes:
- Add Google Analytics to the Examples portal; it reads the shared Developer Center cookie consent and shows no separate banner
- Fix segmenter empty-output handling
- Add Vietnamese to Llima

Deployment: merging to `main` deploys examples to production automatically.