### PR TITLE
Enable release issue validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,7 @@ jobs:
       prerelease: ${{ inputs.prerelease }}
       latest: ${{ inputs.latest }}
       dry_run: ${{ inputs.dry_run }}
+      validate_release_issues: true
+    secrets:
+      NEAT_RELEASES_APP_ID: ${{ secrets.NEAT_RELEASES_APP_ID }}
+      NEAT_RELEASES_APP_PRIVATE_KEY: ${{ secrets.NEAT_RELEASES_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Enable the shared Release Engineering issue gate in the release workflow.
- Pass the Release Engineering GitHub App credentials through to the shared Vulcan release workflow.
- This validates that all issues targeted to the requested release version are in `Done` before branch/tag/draft release creation proceeds.

## Behavior
When `.github/workflows/release.yml` is manually dispatched, the shared `vulcan-release.yml` now runs `release-engineering.yml` first with `release_version` set from the requested tag. If validation fails, the release job is skipped and no release branch, tag, or draft release is created.

## Validation
- `actionlint .github/workflows/release.yml`
- `git diff --check`

Reference
https://github.com/sima-neat/.github/issues/82
