### PR TITLE
Fix GenAI detection-to-VLM PyNeat format usage

### DIFF
--- a/examples/genai/detection-to-vlm-assistant/src/python/main.py
+++ b/examples/genai/detection-to-vlm-assistant/src/python/main.py
@@ -59,7 +59,7 @@ def build_rtsp_run(cfg: Config, width: int, height: int, fps: int):
 def build_video_run(cfg: Config, width: int, height: int, fps: int):
     input_opt = pyneat.InputOptions()
     input_opt.payload_type = pyneat.PayloadType.Image
-    input_opt.format = "RGB"
+    input_opt.format = pyneat.Format.RGB
     input_opt.width = width
     input_opt.height = height
     input_opt.depth = 3
@@ -105,7 +105,7 @@ def build_detector_run(cfg: Config, width: int, height: int):
 
     input_opt = model.input_appsrc_options(False)
     input_opt.payload_type = pyneat.PayloadType.Image
-    input_opt.format = "BGR"
+    input_opt.format = pyneat.Format.BGR
     input_opt.width = width
     input_opt.height = height
     input_opt.depth = 3

--- a/examples/genai/detection-to-vlm-assistant/tests/python/test_unit.py
+++ b/examples/genai/detection-to-vlm-assistant/tests/python/test_unit.py
@@ -1,0 +1,28 @@
+"""Unit tests for detection-to-vlm-assistant (Python)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+
+
+@pytest.mark.unit
+def test_input_options_format_uses_pyneat_enum() -> None:
+    tree = ast.parse(MAIN_PY.read_text(encoding="utf-8"))
+    bad_lines: list[int] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Constant) or not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Attribute) and target.attr == "format":
+                bad_lines.append(node.lineno)
+
+    assert bad_lines == []

--- a/examples/genai/detection-to-vlm-assistant/tests/test-scope.yaml
+++ b/examples/genai/detection-to-vlm-assistant/tests/test-scope.yaml
@@ -8,7 +8,7 @@ models:
     repo: TBD
     path: TBD
 unit:
-  python: false
+  python: true
   cpp: false
 e2e:
   python:


### PR DESCRIPTION
## Summary

- Use `pyneat.Format` enum values for `InputOptions.format` in the GenAI detection-to-VLM example.
- Add minimal Python unit coverage for this API contract.
- Enable Python unit coverage for the example while keeping GenAI e2e disabled.

## Validation

- `python3 -m py_compile examples/genai/detection-to-vlm-assistant/src/python/main.py examples/genai/detection-to-vlm-assistant/tests/python/test_unit.py`
- `python3 -m pytest -q examples/genai/detection-to-vlm-assistant/tests/python/test_unit.py`
- `python3 tests/utils/test_scope.py --scope-file examples validate --quiet`
- `git diff --check`

Closes #284