### PR TITLE
fix: use memory policy in examples

### DIFF
--- a/examples/genai/detection-to-vlm-assistant/src/python/detector_app.py
+++ b/examples/genai/detection-to-vlm-assistant/src/python/detector_app.py
@@ -479,7 +479,7 @@ def build_video_run(cfg: Config, width: int, height: int, fps: int):
     input_opt.caps_override = (
         f"video/x-raw,format=RGB,width={width},height={height},framerate={max(1, fps)}/1"
     )
-    input_opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
+    input_opt.memory_policy = pyneat.InputMemoryPolicy.Ev74
 
     sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
     sender_opt.host = cfg.insight_host
@@ -493,7 +493,7 @@ def build_video_run(cfg: Config, width: int, height: int, fps: int):
         np.zeros((height, width, 3), dtype=np.uint8),
         copy=True,
         image_format=pyneat.PixelFormat.RGB,
-        memory=pyneat.TensorMemory.CPU,
+        memory=pyneat.TensorMemory.EV74,
     )
     return graph, graph.build([seed])
 

--- a/examples/genai/detection-to-vlm-assistant/src/python/detector_app.py
+++ b/examples/genai/detection-to-vlm-assistant/src/python/detector_app.py
@@ -479,7 +479,7 @@ def build_video_run(cfg: Config, width: int, height: int, fps: int):
     input_opt.caps_override = (
         f"video/x-raw,format=RGB,width={width},height={height},framerate={max(1, fps)}/1"
     )
-    input_opt.use_simaai_pool = False
+    input_opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
 
     sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
     sender_opt.host = cfg.insight_host

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -584,7 +584,7 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   video_input.width = runtime.frame_w;
   video_input.height = runtime.frame_h;
   video_input.depth = 3;
-  video_input.use_simaai_pool = false;
+  video_input.memory_policy = simaai::neat::InputMemoryPolicy::SystemMemory;
 
   auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
       runtime.frame_w, runtime.frame_h, runtime.output_fps);

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -597,7 +597,9 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   runtime.video_graph.add(simaai::neat::nodes::Input(video_input));
   runtime.video_graph.add(simaai::neat::nodes::groups::VideoSender(video_options));
   cv::Mat seed(runtime.frame_h, runtime.frame_w, CV_8UC3, cv::Scalar(0, 0, 0));
-  runtime.video_run = runtime.video_graph.build(std::vector<cv::Mat>{seed});
+  const auto seed_tensor = simaai::neat::Tensor::from_cv_mat(
+      seed, simaai::neat::ImageSpec::PixelFormat::RGB, simaai::neat::TensorMemory::EV74);
+  runtime.video_run = runtime.video_graph.build(simaai::neat::TensorList{seed_tensor});
 
   simaai::neat::MetadataSenderOptions metadata_options;
   metadata_options.host = cfg.insight_host;

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -584,7 +584,7 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   video_input.width = runtime.frame_w;
   video_input.height = runtime.frame_h;
   video_input.depth = 3;
-  video_input.memory_policy = simaai::neat::InputMemoryPolicy::SystemMemory;
+  video_input.memory_policy = simaai::neat::InputMemoryPolicy::Ev74;
 
   auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
       runtime.frame_w, runtime.frame_h, runtime.output_fps);

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -488,7 +488,7 @@ def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
     input_opt.depth = 3
     input_opt.fps_n = max(1, fps)
     input_opt.fps_d = 1
-    input_opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
+    input_opt.memory_policy = pyneat.InputMemoryPolicy.Ev74
 
     sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
     sender_opt.host = cfg.insight_host

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -488,7 +488,7 @@ def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
     input_opt.depth = 3
     input_opt.fps_n = max(1, fps)
     input_opt.fps_d = 1
-    input_opt.use_simaai_pool = False
+    input_opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
 
     sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
     sender_opt.host = cfg.insight_host


### PR DESCRIPTION
## Summary

Replace example-level `use_simaai_pool` assignments with explicit `memory_policy` intent. Raw video-sender inputs that seed and push EV74-backed frames now declare `Ev74` directly.

This also handles the Apps cleanup tracked in #291: the updated examples no longer use the deprecated `use_simaai_pool` option.

## Why

Examples should express memory placement intent through the public `memory_policy` API instead of teaching users the allocator-specific `use_simaai_pool` knob. This makes the expected input placement visible to users and keeps the examples aligned with Core behavior from sima-neat/core#486.

## Validation

- `python3 -m py_compile examples/genai/detection-to-vlm-assistant/src/python/detector_app.py examples/segmentation/single-stream-instance-segmenter/src/python/main.py`
- `clang-format` on the changed C++ file
- `git diff --check`

## Related

Handles #291
Refs sima-neat/core#486
Refs sima-neat/core#490
