### PR TITLE
Add apps CODEOWNERS owner team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership
+* @sima-neat/owners-apps


### PR DESCRIPTION
## Summary

Add a default-only CODEOWNERS file for the `apps` owner team.

## Notes

This PR depends on `@sima-neat/owners-apps` existing with sufficient `apps` access before GitHub can request it as a CODEOWNER.

Refs sima-neat/.github#98

## Validation

- `git diff --cached --check`
