### PR TITLE
Use inferred encoded caps in RTSP examples

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -413,8 +413,6 @@ bool output_caps_enabled(
 simaai::neat::InputOptions h264_encoded_input_options() {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  opt.caps_override =
-      "video/x-h264,parsed=true,stream-format=(string)byte-stream,alignment=(string)au";
   return opt;
 }
 

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -433,10 +433,6 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
 def h264_encoded_input_options():
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    opt.caps_override = (
-        "video/x-h264,parsed=true,stream-format=(string)byte-stream,"
-        "alignment=(string)au"
-    )
     return opt
 
 

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -313,8 +313,6 @@ bool output_caps_enabled(
 simaai::neat::InputOptions h264_encoded_input_options() {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  opt.caps_override =
-      "video/x-h264,parsed=true,stream-format=(string)byte-stream,alignment=(string)au";
   return opt;
 }
 

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -414,10 +414,6 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
 def h264_encoded_input_options():
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    opt.caps_override = (
-        "video/x-h264,parsed=true,stream-format=(string)byte-stream,"
-        "alignment=(string)au"
-    )
     return opt
 
 

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -416,8 +416,6 @@ bool output_caps_enabled(
 simaai::neat::InputOptions h264_encoded_input_options() {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  opt.caps_override =
-      "video/x-h264,parsed=true,stream-format=(string)byte-stream,alignment=(string)au";
   return opt;
 }
 

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -444,10 +444,6 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
 def h264_encoded_input_options():
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    opt.caps_override = (
-        "video/x-h264,parsed=true,stream-format=(string)byte-stream,"
-        "alignment=(string)au"
-    )
     return opt
 
 


### PR DESCRIPTION
## Why

The RTSP examples now split the encoded source graph from the decode and video sender graphs. With Core preserving encoded sample caps across graph boundaries, the Apps examples should not hardcode H.264 caps on every downstream encoded input.

This keeps the example topology minimal and lets Core own the encoded caps contract.

## What Changed

- Removed explicit H.264 `caps_override` values from the single-stream object detector.
- Removed explicit H.264 `caps_override` values from the multi-stream object detector.
- Removed explicit H.264 `caps_override` values from the multi-stream people tracker.
- Kept downstream graph inputs marked as encoded so Core can forward the exact caps from the upstream encoded sample.

## Validation

- `git diff --check`
- `python3 -m py_compile examples/object-detection/single-stream-object-detector/src/python/main.py examples/object-detection/multi-stream-object-detector/src/python/main.py examples/tracking/multi-stream-people-tracker/src/python/main.py`
- Earlier focused validation on this branch:
  - single-stream pytest passed
  - multi-stream pytest passed
  - tracking pytest passed
  - SDK C++ builds passed for the affected example targets

## Notes

This depends on sima-neat/core#494 for automatic encoded caps preservation.

Closes #300.
