### PR TITLE
Adopt RtspEncodedInput in multi-stream examples

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -419,23 +419,13 @@ simaai::neat::InputOptions h264_encoded_input_options() {
 simaai::neat::Graph
 build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt) {
   simaai::neat::Graph source("rtsp_encoded_source");
-  const bool use_auto_caps = opt.auto_caps_from_stream &&
-                             (opt.h264_fps <= 0 || opt.h264_width <= 0 || opt.h264_height <= 0);
-  const bool insert_queue = opt.insert_queue && !opt.sync_mode;
-  source.add(simaai::neat::nodes::RTSPInput(opt.url, opt.latency_ms, opt.tcp));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  source.add(simaai::neat::nodes::H264Depacketize(opt.payload_type, opt.h264_parse_config_interval,
-                                                  opt.h264_fps, opt.h264_width, opt.h264_height,
-                                                  /*enforce_h264_caps=*/!use_auto_caps));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  if (use_auto_caps) {
-    source.add(simaai::neat::nodes::H264CapsFixup(opt.fallback_h264_fps, opt.fallback_h264_width,
-                                                  opt.fallback_h264_height));
-  }
+
+  simaai::neat::nodes::groups::RtspEncodedInputOptions encoded_opt;
+  encoded_opt.url = opt.url;
+  encoded_opt.codec = simaai::neat::nodes::groups::RtspCodec::H264;
+  encoded_opt.latency_ms = opt.latency_ms;
+  encoded_opt.tcp = opt.tcp;
+  source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded_opt));
   source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
   return source;
 }

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -401,31 +401,13 @@ def output_caps_enabled(caps) -> bool:
 
 def build_encoded_source_graph(opt) -> pyneat.Graph:
     source = pyneat.Graph("rtsp_encoded_source")
-    use_auto_caps = opt.auto_caps_from_stream and (
-        opt.h264_fps <= 0 or opt.h264_width <= 0 or opt.h264_height <= 0
-    )
-    insert_queue = opt.insert_queue and not opt.sync_mode
-    source.add(pyneat.nodes.rtsp_input(opt.url, opt.latency_ms, opt.tcp))
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    source.add(
-        pyneat.nodes.h264_depacketize(
-            payload_type=opt.payload_type,
-            h264_parse_config_interval=opt.h264_parse_config_interval,
-            h264_fps=opt.h264_fps,
-            h264_width=opt.h264_width,
-            h264_height=opt.h264_height,
-            enforce_h264_caps=not use_auto_caps,
-        )
-    )
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    if use_auto_caps:
-        source.add(
-            pyneat.nodes.h264_caps_fixup(
-                opt.fallback_h264_fps, opt.fallback_h264_width, opt.fallback_h264_height
-            )
-        )
+
+    encoded_opt = pyneat.RtspEncodedInputOptions()
+    encoded_opt.url = opt.url
+    encoded_opt.codec = pyneat.RtspCodec.H264
+    encoded_opt.latency_ms = opt.latency_ms
+    encoded_opt.tcp = opt.tcp
+    source.add(pyneat.groups.rtsp_encoded_input(encoded_opt))
     source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
     return source
 

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -422,23 +422,13 @@ simaai::neat::InputOptions h264_encoded_input_options() {
 simaai::neat::Graph
 build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt) {
   simaai::neat::Graph source("rtsp_encoded_source");
-  const bool use_auto_caps = opt.auto_caps_from_stream &&
-                             (opt.h264_fps <= 0 || opt.h264_width <= 0 || opt.h264_height <= 0);
-  const bool insert_queue = opt.insert_queue && !opt.sync_mode;
-  source.add(simaai::neat::nodes::RTSPInput(opt.url, opt.latency_ms, opt.tcp));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  source.add(simaai::neat::nodes::H264Depacketize(opt.payload_type, opt.h264_parse_config_interval,
-                                                  opt.h264_fps, opt.h264_width, opt.h264_height,
-                                                  /*enforce_h264_caps=*/!use_auto_caps));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  if (use_auto_caps) {
-    source.add(simaai::neat::nodes::H264CapsFixup(opt.fallback_h264_fps, opt.fallback_h264_width,
-                                                  opt.fallback_h264_height));
-  }
+
+  simaai::neat::nodes::groups::RtspEncodedInputOptions encoded_opt;
+  encoded_opt.url = opt.url;
+  encoded_opt.codec = simaai::neat::nodes::groups::RtspCodec::H264;
+  encoded_opt.latency_ms = opt.latency_ms;
+  encoded_opt.tcp = opt.tcp;
+  source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded_opt));
   source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
   return source;
 }

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -412,31 +412,13 @@ def output_caps_enabled(caps) -> bool:
 
 def build_encoded_source_graph(opt) -> pyneat.Graph:
     source = pyneat.Graph("rtsp_encoded_source")
-    use_auto_caps = opt.auto_caps_from_stream and (
-        opt.h264_fps <= 0 or opt.h264_width <= 0 or opt.h264_height <= 0
-    )
-    insert_queue = opt.insert_queue and not opt.sync_mode
-    source.add(pyneat.nodes.rtsp_input(opt.url, opt.latency_ms, opt.tcp))
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    source.add(
-        pyneat.nodes.h264_depacketize(
-            payload_type=opt.payload_type,
-            h264_parse_config_interval=opt.h264_parse_config_interval,
-            h264_fps=opt.h264_fps,
-            h264_width=opt.h264_width,
-            h264_height=opt.h264_height,
-            enforce_h264_caps=not use_auto_caps,
-        )
-    )
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    if use_auto_caps:
-        source.add(
-            pyneat.nodes.h264_caps_fixup(
-                opt.fallback_h264_fps, opt.fallback_h264_width, opt.fallback_h264_height
-            )
-        )
+
+    encoded_opt = pyneat.RtspEncodedInputOptions()
+    encoded_opt.url = opt.url
+    encoded_opt.codec = pyneat.RtspCodec.H264
+    encoded_opt.latency_ms = opt.latency_ms
+    encoded_opt.tcp = opt.tcp
+    source.add(pyneat.groups.rtsp_encoded_input(encoded_opt))
     source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
     return source
 


### PR DESCRIPTION
## Why

The multi-stream detector and tracker examples still built the RTSP H.264 source path by hand, even though Core now provides a reusable codec-aware encoded RTSP input group.

That made these examples carry source/depacketize/parse/caps details that should live behind the Core API. Users reading the examples should see the intended workflow: build an encoded RTSP source with `RtspEncodedInput(H264)`, then feed the existing decode/model and video sender paths.

Parent: #302  
Refs #304

## What Changed

- Updated the multi-stream object detector C++ and Python examples to use Core `RtspEncodedInput(H264)` for the encoded source graph.
- Updated the multi-stream people tracker C++ and Python examples to use the same encoded source API.
- Kept H.264 explicit in both APIs:
  - C++: `RtspEncodedInputOptions`, `RtspCodec::H264`, `RtspEncodedInput(...)`
  - Python: `pyneat.RtspEncodedInputOptions`, `pyneat.RtspCodec.H264`, `pyneat.groups.rtsp_encoded_input(...)`
- Preserved existing app config behavior for `url`, `latency_ms`, and `tcp`.
- Left the existing split runtime topology unchanged:
  - encoded source graph
  - decode/model graph
  - encoded `VideoSender` graph
  - save-frame graph only when saving is enabled
- Left decoder output as raw NV12.
- Kept these examples H.264-only in this step.

## Compatibility

No config changes are required.

Existing H.264 RTSP multi-stream configs should continue to work with the same source settings. This PR does not change single-stream examples, MJPEG support, HTTP MJPEG support, or board-side preview encoding behavior.

## Risk

Runtime behavior now depends on the Core `RtspEncodedInput(H264)` group instead of the Apps examples manually assembling the RTSP source/depacketize/parse path.

The intended behavior is the same, but the affected examples still need focused SDK/Modalix smoke validation before the PR is moved out of draft.

## Validation

- `clang-format` on touched C++ files
- `git diff --check`
- `python3 -m py_compile` on touched Python entrypoints

SDK build and Modalix runtime smoke tests were not run in this session.
