### PR TITLE
Adopt codec-aware inputs in single-stream examples

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -419,23 +419,13 @@ simaai::neat::InputOptions h264_encoded_input_options() {
 simaai::neat::Graph
 build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt) {
   simaai::neat::Graph source("rtsp_encoded_source");
-  const bool use_auto_caps = opt.auto_caps_from_stream &&
-                             (opt.h264_fps <= 0 || opt.h264_width <= 0 || opt.h264_height <= 0);
-  const bool insert_queue = opt.insert_queue && !opt.sync_mode;
-  source.add(simaai::neat::nodes::RTSPInput(opt.url, opt.latency_ms, opt.tcp));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  source.add(simaai::neat::nodes::H264Depacketize(opt.payload_type, opt.h264_parse_config_interval,
-                                                  opt.h264_fps, opt.h264_width, opt.h264_height,
-                                                  /*enforce_h264_caps=*/!use_auto_caps));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  if (use_auto_caps) {
-    source.add(simaai::neat::nodes::H264CapsFixup(opt.fallback_h264_fps, opt.fallback_h264_width,
-                                                  opt.fallback_h264_height));
-  }
+
+  simaai::neat::nodes::groups::RtspEncodedInputOptions encoded_opt;
+  encoded_opt.url = opt.url;
+  encoded_opt.codec = simaai::neat::nodes::groups::RtspCodec::H264;
+  encoded_opt.latency_ms = opt.latency_ms;
+  encoded_opt.tcp = opt.tcp;
+  source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded_opt));
   source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
   return source;
 }

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -401,31 +401,13 @@ def output_caps_enabled(caps) -> bool:
 
 def build_encoded_source_graph(opt) -> pyneat.Graph:
     source = pyneat.Graph("rtsp_encoded_source")
-    use_auto_caps = opt.auto_caps_from_stream and (
-        opt.h264_fps <= 0 or opt.h264_width <= 0 or opt.h264_height <= 0
-    )
-    insert_queue = opt.insert_queue and not opt.sync_mode
-    source.add(pyneat.nodes.rtsp_input(opt.url, opt.latency_ms, opt.tcp))
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    source.add(
-        pyneat.nodes.h264_depacketize(
-            payload_type=opt.payload_type,
-            h264_parse_config_interval=opt.h264_parse_config_interval,
-            h264_fps=opt.h264_fps,
-            h264_width=opt.h264_width,
-            h264_height=opt.h264_height,
-            enforce_h264_caps=not use_auto_caps,
-        )
-    )
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    if use_auto_caps:
-        source.add(
-            pyneat.nodes.h264_caps_fixup(
-                opt.fallback_h264_fps, opt.fallback_h264_width, opt.fallback_h264_height
-            )
-        )
+
+    encoded_opt = pyneat.RtspEncodedInputOptions()
+    encoded_opt.url = opt.url
+    encoded_opt.codec = pyneat.RtspCodec.H264
+    encoded_opt.latency_ms = opt.latency_ms
+    encoded_opt.tcp = opt.tcp
+    source.add(pyneat.groups.rtsp_encoded_input(encoded_opt))
     source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
     return source
 

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -94,7 +94,7 @@ source:
   codec: h264                                            # h264 or mjpeg.
   url: <rtsp-url-copied-from-insight>                     # RTSP or HTTP MJPEG stream URL.
   tcp: true                                               # Use TCP transport for RTSP.
-  fps: 0                                                  # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
+  fps: 0                                                  # 0 probes FPS. MJPEG requires config FPS or probeable FPS metadata.
 
 inference:
   frames: 0                                               # Frame limit. 0 runs continuously.

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -14,7 +14,7 @@
 ## Concept
 `single-stream-object-detector` is a focused reference example for a common deployment pattern:
 
-- ingest one RTSP camera stream
+- ingest one RTSP H.264/MJPEG or HTTP MJPEG stream
 - decode the stream into NV12 frames
 - run YOLO26 object detection
 - send H.264 video plus detection metadata to Insight
@@ -42,13 +42,13 @@ To create a reproducible RTSP input:
 2. In Insight, open `RTSP Source`.
 3. Use a sample video or upload your own video.
 4. Start the stream and copy the RTSP URL.
-5. Put that RTSP URL into `source.rtsp_url`.
+5. Put that RTSP URL into `source.url`.
 
 Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
 ## Prerequisites
 - Installed Neat Development Environment + Neat Library.
-- RTSP source created in Insight or provided by your camera
+- RTSP H.264, RTSP MJPEG, or HTTP MJPEG source created in Insight or provided by your camera.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model, or set `model.path` to another readable model package.
 
 ## Get The Apps Repo
@@ -90,8 +90,11 @@ model:
   path: <model-path>                                      # Path to the model package.
 
 source:
-  rtsp_url: <rtsp-url-copied-from-insight>                # RTSP stream URL.
+  type: rtsp                                             # rtsp or http.
+  codec: h264                                            # h264 or mjpeg.
+  url: <rtsp-url-copied-from-insight>                     # RTSP or HTTP MJPEG stream URL.
   tcp: true                                               # Use TCP transport for RTSP.
+  fps: 0                                                  # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
 
 inference:
   frames: 0                                               # Frame limit. 0 runs continuously.

--- a/examples/object-detection/single-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/single-stream-object-detector/src/common/config.yaml
@@ -3,9 +3,14 @@ model:
   labels: examples/object-detection/single-stream-object-detector/src/common/coco_label.txt
 
 source:
-  rtsp_url: <rtsp-url-1>     # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
+  type: rtsp                 # rtsp or http.
+  codec: h264                # h264 or mjpeg.
+  url: <rtsp-url-1>          # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
+  rtsp_url: ""               # Legacy H.264 RTSP key. Used when source.url is empty.
   tcp: true                  # Use TCP for RTSP transport.
   latency_ms: 100            # RTSP receive latency in milliseconds.
+  fps: 0                     # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
+  ssl_strict: true           # Set false for HTTPS MJPEG streams with self-signed certs.
 
 inference:
   frames: 0                  # Frame limit. 0 means run continuously.

--- a/examples/object-detection/single-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/single-stream-object-detector/src/common/config.yaml
@@ -9,7 +9,7 @@ source:
   rtsp_url: ""               # Legacy H.264 RTSP key. Used when source.url is empty.
   tcp: true                  # Use TCP for RTSP transport.
   latency_ms: 100            # RTSP receive latency in milliseconds.
-  fps: 0                     # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
+  fps: 0                     # 0 probes FPS. MJPEG requires config FPS or probeable FPS metadata.
   ssl_strict: true           # Set false for HTTPS MJPEG streams with self-signed certs.
 
 inference:

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -27,9 +27,11 @@
 #include <opencv2/videoio.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cctype>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
@@ -43,8 +45,6 @@
 namespace fs = std::filesystem;
 
 namespace {
-
-constexpr int kDefaultFps = 30;
 
 enum class SourceType { Rtsp, Http };
 enum class SourceCodec { H264, Mjpeg };
@@ -197,7 +197,6 @@ void validate_config(const AppConfig& cfg) {
   if (cfg.source_type == SourceType::Http) {
     sima_examples::require(cfg.source_codec == SourceCodec::Mjpeg,
                            "source.codec must be mjpeg for source.type=http");
-    sima_examples::require(cfg.source_fps > 0, "source.fps must be > 0 for HTTP MJPEG sources");
   }
   sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
@@ -317,6 +316,96 @@ struct SourceGeometry {
   int fps = 0;
 };
 
+int fps_from_rate(const std::string& value) {
+  if (value.empty() || value == "0/0" || value == "0/1")
+    return 0;
+  try {
+    const auto slash = value.find('/');
+    double fps = 0.0;
+    if (slash == std::string::npos) {
+      fps = std::stod(value);
+    } else {
+      const double den = std::stod(value.substr(slash + 1));
+      if (den <= 0.0)
+        return 0;
+      fps = std::stod(value.substr(0, slash)) / den;
+    }
+    return fps > 0.0 ? static_cast<int>(std::lround(fps)) : 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+std::string shell_quote(const std::string& value) {
+  std::string out = "'";
+  for (const char c : value) {
+    out += c == '\'' ? "'\\''" : std::string(1, c);
+  }
+  out += "'";
+  return out;
+}
+
+SourceGeometry probe_ffprobe_geometry(const AppConfig& cfg) {
+  SourceGeometry geometry;
+  std::string command =
+      "ffprobe -v error -rw_timeout 5000000 -select_streams v:0 "
+      "-show_entries stream=width,height,r_frame_rate,avg_frame_rate -of default=nw=1 ";
+  if (!cfg.ssl_strict) {
+    command += "-tls_verify 0 ";
+  }
+  command += shell_quote(cfg.source_url) + " 2>/dev/null";
+
+  FILE* pipe = popen(command.c_str(), "r");
+  if (!pipe) {
+    return geometry;
+  }
+
+  int avg_fps = 0;
+  int r_fps = 0;
+  std::array<char, 256> buffer{};
+  while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe)) {
+    std::string line(buffer.data());
+    while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
+      line.pop_back();
+    }
+    const auto eq = line.find('=');
+    if (eq == std::string::npos) {
+      continue;
+    }
+    const std::string key = line.substr(0, eq);
+    const std::string value = line.substr(eq + 1);
+    if (key == "width") {
+      geometry.width = std::atoi(value.c_str());
+    } else if (key == "height") {
+      geometry.height = std::atoi(value.c_str());
+    } else if (key == "avg_frame_rate") {
+      avg_fps = fps_from_rate(value);
+    } else if (key == "r_frame_rate") {
+      r_fps = fps_from_rate(value);
+    }
+  }
+  pclose(pipe);
+  geometry.fps = avg_fps > 0 ? avg_fps : r_fps;
+  return geometry;
+}
+
+void fill_missing_geometry(SourceGeometry& dst, const SourceGeometry& src) {
+  if (dst.width <= 0)
+    dst.width = src.width;
+  if (dst.height <= 0)
+    dst.height = src.height;
+  if (dst.fps <= 0)
+    dst.fps = src.fps;
+}
+
+void require_mjpeg_fps(const AppConfig& cfg, const SourceGeometry& geometry) {
+  if (cfg.source_codec == SourceCodec::Mjpeg && geometry.fps <= 0) {
+    throw std::runtime_error(
+        "MJPEG source did not provide a valid frame rate; set source.fps or use a source with "
+        "probeable FPS metadata");
+  }
+}
+
 simaai::neat::nodes::groups::RtspDecodedInputOptions
 make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
   simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
@@ -391,35 +480,47 @@ SourceGeometry probe_rtsp_h264_geometry(const AppConfig& cfg) {
   SourceGeometry geometry;
   geometry.width = probe.width;
   geometry.height = probe.height;
-  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps : probe.fps;
+  geometry.fps = probe.fps;
   return geometry;
 }
 
 SourceGeometry probe_rtsp_geometry(const AppConfig& cfg) {
+  SourceGeometry geometry = probe_ffprobe_geometry(cfg);
+  if (cfg.source_fps > 0) {
+    geometry.fps = cfg.source_fps;
+  }
+
   if (cfg.source_codec == SourceCodec::H264) {
-    return probe_rtsp_h264_geometry(cfg);
+    SourceGeometry rtsp_geometry = probe_rtsp_h264_geometry(cfg);
+    if (cfg.source_fps > 0) {
+      rtsp_geometry.fps = cfg.source_fps;
+    }
+    fill_missing_geometry(geometry, rtsp_geometry);
+    return geometry;
   }
 
-  cv::VideoCapture cap(cfg.source_url);
-  if (!cap.isOpened()) {
-    throw std::runtime_error("failed to open RTSP source for probing: " + cfg.source_url);
+  if (geometry.width <= 0 || geometry.height <= 0 || geometry.fps <= 0) {
+    cv::VideoCapture cap(cfg.source_url);
+    if (!cap.isOpened()) {
+      throw std::runtime_error("failed to open RTSP source for probing: " + cfg.source_url);
+    }
+    SourceGeometry cv_geometry;
+    cv_geometry.width = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
+    cv_geometry.height = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
+    cv_geometry.fps = static_cast<int>(std::lround(cap.get(cv::CAP_PROP_FPS)));
+    cap.release();
+    fill_missing_geometry(geometry, cv_geometry);
   }
-
-  SourceGeometry geometry;
-  geometry.width = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
-  geometry.height = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
-  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps
-                                    : static_cast<int>(std::lround(cap.get(cv::CAP_PROP_FPS)));
-  cap.release();
-  if (geometry.fps <= 0) {
-    geometry.fps = kDefaultFps;
+  if (cfg.source_fps > 0) {
+    geometry.fps = cfg.source_fps;
   }
+  require_mjpeg_fps(cfg, geometry);
   return geometry;
 }
 
-SourceGeometry probe_decoded_source_geometry(const AppConfig& cfg) {
+SourceGeometry probe_decoded_source_geometry(const AppConfig& cfg, int fps) {
   SourceGeometry geometry;
-  geometry.fps = cfg.source_fps;
+  geometry.fps = fps;
 
   simaai::neat::Graph probe_graph("source_probe");
   probe_graph.add(make_source_graph(cfg, geometry));
@@ -451,9 +552,13 @@ SourceGeometry resolve_source_geometry(const AppConfig& cfg) {
   if (cfg.source_type == SourceType::Rtsp) {
     return probe_rtsp_geometry(cfg);
   }
-  SourceGeometry geometry = probe_decoded_source_geometry(cfg);
-  if (geometry.fps <= 0 && cfg.source_type == SourceType::Rtsp) {
-    geometry.fps = kDefaultFps;
+  SourceGeometry geometry = probe_ffprobe_geometry(cfg);
+  if (cfg.source_fps > 0) {
+    geometry.fps = cfg.source_fps;
+  }
+  require_mjpeg_fps(cfg, geometry);
+  if (geometry.width <= 0 || geometry.height <= 0) {
+    fill_missing_geometry(geometry, probe_decoded_source_geometry(cfg, geometry.fps));
   }
   return geometry;
 }

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -24,33 +24,41 @@
 #include <nodes/io/MetadataSender.h>
 
 #include <opencv2/imgcodecs.hpp>
+#include <opencv2/videoio.hpp>
 
 #include <algorithm>
-#include <atomic>
 #include <chrono>
+#include <cmath>
+#include <cctype>
 #include <cstdint>
 #include <cstdlib>
-#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <mutex>
-#include <optional>
+#include <stdexcept>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
 
 namespace {
 
+constexpr int kDefaultFps = 30;
+
+enum class SourceType { Rtsp, Http };
+enum class SourceCodec { H264, Mjpeg };
+
 struct AppConfig {
   std::string model_path;
   fs::path labels_path;
-  std::string rtsp_url;
+  std::string source_url;
+  SourceType source_type = SourceType::Rtsp;
+  SourceCodec source_codec = SourceCodec::H264;
   int latency_ms = 200;
   bool tcp = true;
+  int source_fps = 0;
+  bool ssl_strict = true;
   int frames = 0;
   double min_score = 0.55;
   double nms_iou = 0.60;
@@ -111,15 +119,8 @@ struct ProfileWindow {
 
 struct PipelineRuntime {
   std::unique_ptr<simaai::neat::Model> model;
-  simaai::neat::Graph source_graph;
-  simaai::neat::Run source_run;
-  simaai::neat::Graph decode_graph;
-  simaai::neat::Run decode_run;
-  simaai::neat::Graph video_graph;
-  simaai::neat::Run video_run;
-  simaai::neat::Graph save_graph;
-  simaai::neat::Run save_run;
-  std::optional<simaai::neat::Sample> pending_encoded_sample;
+  simaai::neat::Graph graph;
+  simaai::neat::Run run;
   std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
   std::vector<std::string> labels;
   int frame_w = 0;
@@ -127,6 +128,42 @@ struct PipelineRuntime {
   int output_fps = 0;
   int video_port = 0;
 };
+
+std::string lower_copy(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+SourceType parse_source_type(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "rtsp") {
+    return SourceType::Rtsp;
+  }
+  if (lowered == "http" || lowered == "https") {
+    return SourceType::Http;
+  }
+  throw std::runtime_error("source.type must be rtsp or http");
+}
+
+SourceCodec parse_source_codec(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "h264" || lowered == "h.264") {
+    return SourceCodec::H264;
+  }
+  if (lowered == "mjpeg" || lowered == "jpeg") {
+    return SourceCodec::Mjpeg;
+  }
+  throw std::runtime_error("source.codec must be h264 or mjpeg");
+}
+
+const char* source_type_name(SourceType value) {
+  return value == SourceType::Rtsp ? "rtsp" : "http";
+}
+
+const char* source_codec_name(SourceCodec value) {
+  return value == SourceCodec::H264 ? "h264" : "mjpeg";
+}
 
 CliOptions parse_args(int argc, char** argv) {
   CliOptions options;
@@ -151,11 +188,17 @@ CliOptions parse_args(int argc, char** argv) {
 }
 
 void validate_config(const AppConfig& cfg) {
-  sima_examples::require(!cfg.rtsp_url.empty(), "source.rtsp_url must be set");
+  sima_examples::require(!cfg.source_url.empty(), "source.url or source.rtsp_url must be set");
   sima_examples::require(!cfg.model_path.empty(), "model.path must be set");
   sima_examples::require(!cfg.labels_path.empty(), "model.labels must be set");
   sima_examples::require(!cfg.insight_host.empty(), "output.insight.host must be set");
   sima_examples::require(cfg.latency_ms >= 0, "source.latency_ms must be >= 0");
+  sima_examples::require(cfg.source_fps >= 0, "source.fps must be >= 0");
+  if (cfg.source_type == SourceType::Http) {
+    sima_examples::require(cfg.source_codec == SourceCodec::Mjpeg,
+                           "source.codec must be mjpeg for source.type=http");
+    sima_examples::require(cfg.source_fps > 0, "source.fps must be > 0 for HTTP MJPEG sources");
+  }
   sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
@@ -175,9 +218,14 @@ AppConfig load_app_config(const fs::path& config_path) {
       fs::path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR).parent_path() / "common" / "coco_label.txt";
   cfg.model_path = raw.string_or("model.path", "");
   cfg.labels_path = raw.string_or("model.labels", default_labels.string());
-  cfg.rtsp_url = raw.string_or("source.rtsp_url", "");
+  const std::string legacy_rtsp_url = raw.string_or("source.rtsp_url", "");
+  cfg.source_url = raw.string_or("source.url", legacy_rtsp_url);
+  cfg.source_type = parse_source_type(raw.string_or("source.type", "rtsp"));
+  cfg.source_codec = parse_source_codec(raw.string_or("source.codec", "h264"));
   cfg.latency_ms = raw.int_or("source.latency_ms", 200);
   cfg.tcp = raw.bool_or("source.tcp", true);
+  cfg.source_fps = raw.int_or("source.fps", 0);
+  cfg.ssl_strict = raw.bool_or("source.ssl_strict", true);
   cfg.frames = raw.int_or("inference.frames", 0);
   cfg.min_score = raw.double_or("inference.min_score", 0.55);
   cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
@@ -263,151 +311,164 @@ std::vector<sima_examples::MetadataBox> build_metadata_boxes(const std::vector<o
   return metadata_boxes;
 }
 
+struct SourceGeometry {
+  int width = 0;
+  int height = 0;
+  int fps = 0;
+};
+
 simaai::neat::nodes::groups::RtspDecodedInputOptions
-build_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& height_out) {
+make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
+  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
+  opt.url = cfg.source_url;
+  opt.latency_ms = cfg.latency_ms;
+  opt.tcp = cfg.tcp;
+  opt.insert_queue = true;
+  opt.out_format = "NV12";
+  opt.decoder_name = "decoder";
+  opt.decoder_raw_output = true;
+  opt.auto_caps_from_stream = true;
+  opt.codec = cfg.source_codec == SourceCodec::H264 ? simaai::neat::nodes::groups::RtspCodec::H264
+                                                    : simaai::neat::nodes::groups::RtspCodec::MJPEG;
+  if (cfg.source_codec == SourceCodec::H264) {
+    opt.payload_type = 96;
+    opt.fallback_h264_width = geometry.width;
+    opt.fallback_h264_height = geometry.height;
+    opt.fallback_h264_fps = geometry.fps;
+  } else {
+    opt.mjpeg_payload_type = 26;
+    opt.dec_width = geometry.width;
+    opt.dec_height = geometry.height;
+    opt.dec_fps = geometry.fps;
+  }
+  if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = geometry.width;
+    opt.output_caps.height = geometry.height;
+    opt.output_caps.fps = geometry.fps;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
+  return opt;
+}
+
+simaai::neat::nodes::groups::HttpMjpegDecodedInputOptions
+make_http_mjpeg_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
+  simaai::neat::nodes::groups::HttpMjpegDecodedInputOptions opt;
+  opt.url = cfg.source_url;
+  opt.decoder_name = "decoder";
+  opt.decoder_raw_output = true;
+  opt.dec_fps = geometry.fps;
+  opt.ssl_strict = cfg.ssl_strict;
+  if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = geometry.width;
+    opt.output_caps.height = geometry.height;
+    opt.output_caps.fps = geometry.fps;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
+  return opt;
+}
+
+simaai::neat::Graph make_source_graph(const AppConfig& cfg, const SourceGeometry& geometry) {
+  if (cfg.source_type == SourceType::Rtsp) {
+    return simaai::neat::nodes::groups::RtspDecodedInput(make_rtsp_source_options(cfg, geometry));
+  }
+  return simaai::neat::nodes::groups::HttpMjpegDecodedInput(
+      make_http_mjpeg_source_options(cfg, geometry));
+}
+
+SourceGeometry probe_rtsp_h264_geometry(const AppConfig& cfg) {
   sima_examples::RtspStreamInfo probe;
   sima_examples::RtspProbeOptions probe_options;
   probe_options.payload_type = 96;
   probe_options.latency_ms = cfg.latency_ms;
   probe_options.rtsp_tcp = cfg.tcp;
   probe_options.debug = cfg.profile;
-  (void)sima_examples::probe_rtsp_stream_info(cfg.rtsp_url, probe_options, probe);
+  (void)sima_examples::probe_rtsp_stream_info(cfg.source_url, probe_options, probe);
 
-  // RTSP options
-  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
-  opt.url = cfg.rtsp_url;
-  opt.latency_ms = cfg.latency_ms;
-  opt.tcp = cfg.tcp;
-  opt.payload_type = 96;
-  opt.insert_queue = true;
-  opt.out_format = "NV12";
-  opt.decoder_name = "decoder";
-  opt.decoder_raw_output = true;
-  opt.auto_caps_from_stream = true;
-  if (probe.width > 0 && probe.height > 0) {
-    opt.fallback_h264_width = probe.width;
-    opt.fallback_h264_height = probe.height;
-    width_out = probe.width;
-    height_out = probe.height;
-  }
-  if (probe.fps > 0) {
-    opt.fallback_h264_fps = probe.fps;
-    fps_out = probe.fps;
-  }
-  if (width_out > 0 && height_out > 0 && fps_out > 0) {
-    opt.output_caps.enable = true;
-    opt.output_caps.format = "NV12";
-    opt.output_caps.width = width_out;
-    opt.output_caps.height = height_out;
-    opt.output_caps.fps = fps_out;
-    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
-  }
-  return opt;
+  SourceGeometry geometry;
+  geometry.width = probe.width;
+  geometry.height = probe.height;
+  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps : probe.fps;
+  return geometry;
 }
 
-bool output_caps_enabled(
-    const simaai::neat::nodes::groups::RtspDecodedInputOptions::OutputCaps& caps) {
-  return caps.enable || caps.width > 0 || caps.height > 0 || caps.fps > 0;
+SourceGeometry probe_rtsp_geometry(const AppConfig& cfg) {
+  if (cfg.source_codec == SourceCodec::H264) {
+    return probe_rtsp_h264_geometry(cfg);
+  }
+
+  cv::VideoCapture cap(cfg.source_url);
+  if (!cap.isOpened()) {
+    throw std::runtime_error("failed to open RTSP source for probing: " + cfg.source_url);
+  }
+
+  SourceGeometry geometry;
+  geometry.width = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
+  geometry.height = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
+  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps
+                                    : static_cast<int>(std::lround(cap.get(cv::CAP_PROP_FPS)));
+  cap.release();
+  if (geometry.fps <= 0) {
+    geometry.fps = kDefaultFps;
+  }
+  return geometry;
 }
 
-simaai::neat::InputOptions h264_encoded_input_options() {
-  simaai::neat::InputOptions opt;
-  opt.payload_type = simaai::neat::PayloadType::Encoded;
-  return opt;
+SourceGeometry probe_decoded_source_geometry(const AppConfig& cfg) {
+  SourceGeometry geometry;
+  geometry.fps = cfg.source_fps;
+
+  simaai::neat::Graph probe_graph("source_probe");
+  probe_graph.add(make_source_graph(cfg, geometry));
+  probe_graph.add(simaai::neat::nodes::Output("frame", simaai::neat::OutputOptions::EveryFrame(1)));
+
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 3;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
+  simaai::neat::Run run = probe_graph.build(run_options);
+
+  simaai::neat::Sample sample;
+  simaai::neat::PullError pull_error;
+  const auto status = run.pull("frame", 20000, sample, &pull_error);
+  run.close();
+  if (status != simaai::neat::PullStatus::Ok) {
+    throw std::runtime_error("failed to probe decoded source frame: " + pull_error.message);
+  }
+
+  const auto tensors = simaai::neat::tensors_from_sample(sample, false);
+  if (!tensors.empty()) {
+    (void)sima_examples::infer_dims(tensors.front(), geometry.width, geometry.height);
+  }
+  return geometry;
 }
 
-simaai::neat::Graph
-build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt) {
-  simaai::neat::Graph source("rtsp_encoded_source");
-  const bool use_auto_caps = opt.auto_caps_from_stream &&
-                             (opt.h264_fps <= 0 || opt.h264_width <= 0 || opt.h264_height <= 0);
-  const bool insert_queue = opt.insert_queue && !opt.sync_mode;
-  source.add(simaai::neat::nodes::RTSPInput(opt.url, opt.latency_ms, opt.tcp));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
+SourceGeometry resolve_source_geometry(const AppConfig& cfg) {
+  if (cfg.source_type == SourceType::Rtsp) {
+    return probe_rtsp_geometry(cfg);
   }
-  source.add(simaai::neat::nodes::H264Depacketize(opt.payload_type, opt.h264_parse_config_interval,
-                                                  opt.h264_fps, opt.h264_width, opt.h264_height,
-                                                  /*enforce_h264_caps=*/!use_auto_caps));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
+  SourceGeometry geometry = probe_decoded_source_geometry(cfg);
+  if (geometry.fps <= 0 && cfg.source_type == SourceType::Rtsp) {
+    geometry.fps = kDefaultFps;
   }
-  if (use_auto_caps) {
-    source.add(simaai::neat::nodes::H264CapsFixup(opt.fallback_h264_fps, opt.fallback_h264_width,
-                                                  opt.fallback_h264_height));
-  }
-  source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
-  return source;
+  return geometry;
 }
 
-simaai::neat::Graph
-build_decode_model_graph(const std::string& input_name, const std::string& output_name,
-                         const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt,
-                         simaai::neat::Model& model) {
-  simaai::neat::Graph decode("decode_model");
-  const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
-  const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps;
-
-  decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
-  decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
-                                             opt.decoder_name, opt.decoder_raw_output,
-                                             opt.decoder_next_element, dec_w, dec_h, dec_fps));
-  if (opt.use_videoconvert) {
-    decode.add(simaai::neat::nodes::VideoConvert());
-  }
-  if (opt.use_videoscale) {
-    decode.add(simaai::neat::nodes::VideoScale());
-  }
-  if (output_caps_enabled(opt.output_caps)) {
-    const auto& caps = opt.output_caps;
-    decode.add(
-        simaai::neat::nodes::CapsRaw(caps.format, caps.width, caps.height, caps.fps, caps.memory));
-  }
-  if (!opt.extra_fragment.empty()) {
-    decode.add(simaai::neat::nodes::Custom(opt.extra_fragment));
-  }
-  decode.add(model);
-  decode.add(simaai::neat::nodes::Output(output_name, simaai::neat::OutputOptions::EveryFrame(4)));
-  return decode;
-}
-
-simaai::neat::Graph
-build_video_sender_graph(const std::string& input_name,
-                         const simaai::neat::nodes::groups::VideoSenderOptions& video_options) {
-  simaai::neat::Graph video("video_sender");
-  video.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
-  video.add(simaai::neat::nodes::groups::VideoSender(video_options));
-  return video;
-}
-
-simaai::neat::Graph
-build_save_frame_graph(const std::string& input_name,
-                       const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt) {
-  simaai::neat::Graph save("save_frame");
-  const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
-  const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps;
-
-  save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
-  save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
-                                           opt.decoder_name, opt.decoder_raw_output,
-                                           opt.decoder_next_element, dec_w, dec_h, dec_fps));
-  if (output_caps_enabled(opt.output_caps)) {
-    const auto& caps = opt.output_caps;
-    save.add(
-        simaai::neat::nodes::CapsRaw(caps.format, caps.width, caps.height, caps.fps, caps.memory));
-  }
-  save.add(simaai::neat::nodes::Output("frame", simaai::neat::OutputOptions::EveryFrame(4)));
-  return save;
-}
-
-std::unique_ptr<simaai::neat::Model> build_model(const AppConfig& cfg) {
+std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg,
+                                                const SourceGeometry& geometry) {
   // Model options
   simaai::neat::Model::Options model_opt;
   model_opt.preprocess.kind = simaai::neat::InputKind::Image;
   model_opt.preprocess.enable = simaai::neat::AutoFlag::On;
   model_opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::NV12;
+  if (geometry.width > 0 && geometry.height > 0) {
+    model_opt.preprocess.input_max_width = geometry.width;
+    model_opt.preprocess.input_max_height = geometry.height;
+  }
   model_opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
   model_opt.decode_type = simaai::neat::BoxDecodeType::YoloV26;
   model_opt.score_threshold = cfg.min_score;
@@ -416,74 +477,75 @@ std::unique_ptr<simaai::neat::Model> build_model(const AppConfig& cfg) {
   return std::make_unique<simaai::neat::Model>(cfg.model_path, model_opt);
 }
 
-simaai::neat::RunOptions build_run_options() {
+PipelineRuntime build_pipeline(const AppConfig& cfg) {
+  PipelineRuntime runtime;
+  const SourceGeometry geometry = resolve_source_geometry(cfg);
+  runtime.frame_w = geometry.width;
+  runtime.frame_h = geometry.height;
+  runtime.output_fps = geometry.fps;
+  sima_examples::require(runtime.frame_w > 0 && runtime.frame_h > 0,
+                         "failed to probe source frame dimensions");
+  sima_examples::require(runtime.output_fps > 0, "failed to resolve source frame rate");
+
+  runtime.model = make_model(cfg, geometry);
+  runtime.labels = load_labels(cfg.labels_path);
+
+  auto source = make_source_graph(cfg, geometry);
+  const bool save_debug_frames = !cfg.save_dir.empty() && cfg.save_every > 0;
+  std::vector<std::string> source_outputs = {"video", "model"};
+  if (save_debug_frames) {
+    source_outputs.push_back("debug_frame");
+  }
+  auto branch = simaai::neat::graphs::Branch("source", source_outputs);
+
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
+      runtime.frame_w, runtime.frame_h, runtime.output_fps);
+  video_options.host = cfg.insight_host;
+  video_options.channel = 0;
+  video_options.video_port_base = cfg.video_port;
+  video_options.encoder.bitrate_kbps = 1000;
+  runtime.video_port = video_options.video_port();
+  simaai::neat::Graph video_graph("video");
+  video_graph.connect(simaai::neat::nodes::Input("video"),
+                      simaai::neat::nodes::groups::VideoSender(video_options));
+
+  simaai::neat::Graph model_graph("model");
+  model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
+  simaai::neat::Graph detections_graph("detections");
+  detections_graph.add(
+      simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
+
+  simaai::neat::GraphLinkOptions live_link_options;
+  live_link_options.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
+  runtime.graph.connect(source, branch);
+  runtime.graph.connect(branch, video_graph, live_link_options);
+  if (save_debug_frames) {
+    runtime.graph.connect(branch, model_graph);
+  } else {
+    runtime.graph.connect(branch, model_graph, live_link_options);
+  }
+  runtime.graph.connect(model_graph, detections_graph);
+  if (save_debug_frames) {
+    simaai::neat::Graph frames("debug_frame");
+    frames.add(
+        simaai::neat::nodes::Output("debug_frame", simaai::neat::OutputOptions::EveryFrame(4)));
+    auto debug_join = simaai::neat::graphs::Combine({"debug_frame", "detections"}, "debug_output",
+                                                    simaai::neat::CombinePolicy::ByPts);
+    runtime.graph.connect(branch, frames);
+    runtime.graph.connect(frames, debug_join);
+    runtime.graph.connect(detections_graph, debug_join);
+  }
+  if (cfg.profile) {
+    std::cout << "Backend:\n" << runtime.graph.describe_backend() << "\n";
+  }
+
+  // Runtime options
   simaai::neat::RunOptions run_options;
   run_options.preset = simaai::neat::RunPreset::Realtime;
   run_options.queue_depth = 3;
   run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
   run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
-  return run_options;
-}
-
-bool save_frames_enabled(const AppConfig& cfg) {
-  return !cfg.save_dir.empty() && cfg.save_every > 0;
-}
-
-PipelineRuntime build_pipeline(const AppConfig& cfg) {
-  PipelineRuntime runtime;
-  const auto source_options =
-      build_source_options(cfg, runtime.output_fps, runtime.frame_w, runtime.frame_h);
-  sima_examples::require(runtime.frame_w > 0 && runtime.frame_h > 0,
-                         "failed to probe RTSP frame dimensions");
-  sima_examples::require(runtime.output_fps > 0, "failed to probe RTSP frame rate");
-
-  runtime.model = build_model(cfg);
-  runtime.labels = load_labels(cfg.labels_path);
-
-  runtime.source_graph = build_encoded_source_graph(source_options);
-  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromEncoded();
-  video_options.host = cfg.insight_host;
-  video_options.channel = 0;
-  video_options.video_port_base = cfg.video_port;
-  runtime.video_port = video_options.video_port();
-  runtime.decode_graph =
-      build_decode_model_graph("encoded", "detections", source_options, *runtime.model);
-  runtime.video_graph = build_video_sender_graph("encoded", video_options);
-  if (save_frames_enabled(cfg)) {
-    runtime.save_graph = build_save_frame_graph("encoded", source_options);
-  }
-  if (cfg.profile) {
-    std::cout << "Source backend:\n" << runtime.source_graph.describe_backend() << "\n";
-    std::cout << "Decode backend:\n" << runtime.decode_graph.describe_backend() << "\n";
-    std::cout << "Video backend:\n" << runtime.video_graph.describe_backend() << "\n";
-    if (save_frames_enabled(cfg)) {
-      std::cout << "Save backend:\n" << runtime.save_graph.describe_backend() << "\n";
-    }
-  }
-
-  runtime.source_run = runtime.source_graph.build(build_run_options());
-  simaai::neat::Sample first_encoded_sample;
-  simaai::neat::PullError pull_error;
-  const auto first_status =
-      runtime.source_run.pull("encoded", 20000, first_encoded_sample, &pull_error);
-  if (first_status == simaai::neat::PullStatus::Timeout) {
-    throw std::runtime_error("timed out waiting for encoded RTSP frame");
-  }
-  if (first_status != simaai::neat::PullStatus::Ok) {
-    throw std::runtime_error("failed to pull encoded RTSP frame: " + pull_error.message);
-  }
-  runtime.pending_encoded_sample = std::move(first_encoded_sample);
-
-  auto downstream_options = build_run_options();
-  downstream_options.startup_preflight = false;
-  runtime.decode_run =
-      runtime.decode_graph.build(*runtime.pending_encoded_sample, downstream_options);
-  runtime.video_run =
-      runtime.video_graph.build(*runtime.pending_encoded_sample, downstream_options);
-  if (save_frames_enabled(cfg)) {
-    runtime.save_run =
-        runtime.save_graph.build(*runtime.pending_encoded_sample, downstream_options);
-  }
+  runtime.run = runtime.graph.build(run_options);
 
   simaai::neat::MetadataSenderOptions metadata_options;
   metadata_options.host = cfg.insight_host;
@@ -494,9 +556,10 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
       std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
   sima_examples::require(runtime.metadata_sender->ok(), metadata_err);
 
-  std::cout << "rtsp=" << cfg.rtsp_url << " stream=" << runtime.frame_w << "x" << runtime.frame_h
-            << "@" << runtime.output_fps << " insight=" << cfg.insight_host
-            << " video=" << runtime.video_port
+  std::cout << "source=" << cfg.source_url << " type=" << source_type_name(cfg.source_type)
+            << " codec=" << source_codec_name(cfg.source_codec) << " stream=" << runtime.frame_w
+            << "x" << runtime.frame_h << "@" << runtime.output_fps
+            << " insight=" << cfg.insight_host << " video=" << runtime.video_port
             << " metadata=" << runtime.metadata_sender->metadata_port() << " channel=0\n";
   return runtime;
 }
@@ -540,154 +603,49 @@ void maybe_save_debug_frame(const AppConfig& cfg, int processed, const simaai::n
   }
 }
 
-void set_first_error(std::exception_ptr error, std::exception_ptr& first_error,
-                     std::mutex& error_mutex) {
-  std::lock_guard<std::mutex> lock(error_mutex);
-  if (!first_error) {
-    first_error = error;
-  }
-}
-
-void rethrow_first_error_if_set(std::exception_ptr& first_error, std::mutex& error_mutex) {
-  std::lock_guard<std::mutex> lock(error_mutex);
-  if (first_error) {
-    std::rethrow_exception(first_error);
-  }
-}
-
-void pump_encoded_samples(PipelineRuntime& runtime, std::atomic_bool& stop_requested,
-                          std::exception_ptr& first_error, std::mutex& error_mutex) {
-  try {
-    constexpr int kPullTimeoutMs = 200;
-    std::optional<simaai::neat::Sample> pending = std::move(runtime.pending_encoded_sample);
-    runtime.pending_encoded_sample.reset();
-    while (!stop_requested.load()) {
-      simaai::neat::Sample encoded_sample;
-      if (pending.has_value()) {
-        encoded_sample = std::move(*pending);
-        pending.reset();
-      } else {
-        simaai::neat::PullError encoded_pull_error;
-        const auto encoded_status =
-            runtime.source_run.pull("encoded", kPullTimeoutMs, encoded_sample, &encoded_pull_error);
-        if (encoded_status == simaai::neat::PullStatus::Timeout) {
-          continue;
-        }
-        if (encoded_status == simaai::neat::PullStatus::Closed || stop_requested.load()) {
-          break;
-        }
-        if (encoded_status != simaai::neat::PullStatus::Ok) {
-          throw std::runtime_error("failed to pull encoded RTSP frame: " +
-                                   encoded_pull_error.message);
-        }
-      }
-      if (!runtime.decode_run.push("encoded", encoded_sample)) {
-        if (stop_requested.load()) {
-          break;
-        }
-        throw std::runtime_error("failed to push encoded sample to decode graph");
-      }
-      if (!runtime.video_run.push("encoded", encoded_sample)) {
-        if (stop_requested.load()) {
-          break;
-        }
-        throw std::runtime_error("failed to push encoded sample to video sender graph");
-      }
-      if (runtime.save_run && !runtime.save_run.push("encoded", encoded_sample)) {
-        if (stop_requested.load()) {
-          break;
-        }
-        throw std::runtime_error("failed to push encoded sample to save graph");
-      }
-    }
-  } catch (...) {
-    set_first_error(std::current_exception(), first_error, error_mutex);
-    stop_requested.store(true);
-  }
-}
-
 void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
   ProfileWindow profile;
   profile.enabled = cfg.profile;
   profile.interval = cfg.profile_interval;
 
-  std::atomic_bool stop_requested{false};
-  std::exception_ptr first_error;
-  std::mutex error_mutex;
-  std::thread pump(pump_encoded_samples, std::ref(runtime), std::ref(stop_requested),
-                   std::ref(first_error), std::ref(error_mutex));
-  const auto stop_pump = [&]() {
-    stop_requested.store(true);
-    runtime.video_run.close();
-    runtime.decode_run.close();
-    if (runtime.save_run) {
-      runtime.save_run.close();
-    }
-    runtime.source_run.close();
-    if (pump.joinable()) {
-      pump.join();
-    }
-  };
-
+  const std::string output_name =
+      (!cfg.save_dir.empty() && cfg.save_every > 0) ? "debug_output" : "detections";
   int processed = 0;
-  try {
-    while (cfg.frames <= 0 || processed < cfg.frames) {
-      rethrow_first_error_if_set(first_error, error_mutex);
-      const double pull_start = sima_examples::time_ms();
-
-      simaai::neat::Sample detection_sample;
-      simaai::neat::PullError pull_error;
-      const auto status =
-          runtime.decode_run.pull("detections", 20000, detection_sample, &pull_error);
-      const double pull_end = sima_examples::time_ms();
-      if (status == simaai::neat::PullStatus::Timeout) {
-        rethrow_first_error_if_set(first_error, error_mutex);
-        std::cerr << "[warn] timed out waiting for detections\n";
-        continue;
-      }
-      if (status == simaai::neat::PullStatus::Closed) {
-        break;
-      }
-      if (status != simaai::neat::PullStatus::Ok) {
-        throw std::runtime_error("failed to pull detections: " + pull_error.message);
-      }
-      simaai::neat::Sample frame_sample;
-      if (runtime.save_run) {
-        simaai::neat::PullError frame_pull_error;
-        const auto frame_status =
-            runtime.save_run.pull("frame", 20000, frame_sample, &frame_pull_error);
-        if (frame_status != simaai::neat::PullStatus::Ok) {
-          throw std::runtime_error("failed to pull decoded save frame: " +
-                                   frame_pull_error.message);
-        }
-      }
-
-      std::vector<std::uint8_t> payload;
-      std::string err;
-      if (!extract_bbox_payload(detection_sample, payload, err)) {
-        throw std::runtime_error("bbox extract failed: " + err);
-      }
-      const auto boxes = objdet::parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h,
-                                                    cfg.max_detections, false);
-
-      const double metadata_start = sima_examples::time_ms();
-      send_metadata(runtime, detection_sample, boxes);
-      const double metadata_end = sima_examples::time_ms();
-
-      ++processed;
-      if (runtime.save_run) {
-        maybe_save_debug_frame(cfg, processed, frame_sample, boxes);
-      }
-      profile.add(pull_end - pull_start, metadata_end - metadata_start,
-                  static_cast<int>(boxes.size()));
+  while (cfg.frames <= 0 || processed < cfg.frames) {
+    simaai::neat::Sample detection_sample;
+    simaai::neat::PullError pull_error;
+    const double pull_start = sima_examples::time_ms();
+    const auto status = runtime.run.pull(output_name, 20000, detection_sample, &pull_error);
+    const double pull_end = sima_examples::time_ms();
+    if (status == simaai::neat::PullStatus::Timeout) {
+      std::cerr << "[warn] timed out waiting for detections\n";
+      continue;
     }
-  } catch (...) {
-    stop_pump();
-    throw;
-  }
-  stop_pump();
+    if (status == simaai::neat::PullStatus::Closed) {
+      break;
+    }
+    if (status != simaai::neat::PullStatus::Ok) {
+      throw std::runtime_error("failed to pull detections: " + pull_error.message);
+    }
 
-  rethrow_first_error_if_set(first_error, error_mutex);
+    std::vector<std::uint8_t> payload;
+    std::string err;
+    if (!extract_bbox_payload(detection_sample, payload, err)) {
+      throw std::runtime_error("bbox extract failed: " + err);
+    }
+    const auto boxes = objdet::parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h,
+                                                  cfg.max_detections, false);
+
+    const double metadata_start = sima_examples::time_ms();
+    send_metadata(runtime, detection_sample, boxes);
+    const double metadata_end = sima_examples::time_ms();
+
+    ++processed;
+    maybe_save_debug_frame(cfg, processed, detection_sample, boxes);
+    profile.add(pull_end - pull_start, metadata_end - metadata_start,
+                static_cast<int>(boxes.size()));
+  }
+
   profile.flush();
   std::cout << "processed=" << processed << " video_sender=" << cfg.insight_host << ":"
             << runtime.video_port << "\n";
@@ -703,7 +661,7 @@ int main(int argc, char** argv) {
       std::cout << "Config validated: " << cli.config_path << "\n";
       return 0;
     }
-    if (save_frames_enabled(cfg)) {
+    if (!cfg.save_dir.empty()) {
       fs::create_directories(cfg.save_dir);
     }
 
@@ -714,6 +672,7 @@ int main(int argc, char** argv) {
     }
     PipelineRuntime runtime = build_pipeline(cfg);
     run_pipeline(runtime, cfg);
+    runtime.run.close();
     return 0;
   } catch (const std::exception& e) {
     std::cerr << "[ERR] " << e.what() << "\n";

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -10,12 +10,12 @@ import os
 from pathlib import Path
 import struct
 import sys
-import threading
 import time
 
 import yaml
 
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
+DEFAULT_FPS = 30
 
 cv2 = None
 np = None
@@ -26,9 +26,13 @@ pyneat = None
 class AppConfig:
     model_path: str
     labels_path: Path
-    rtsp_url: str
+    source_url: str
+    source_type: str = "rtsp"
+    source_codec: str = "h264"
     latency_ms: int = 200
     tcp: bool = True
+    source_fps: int = 0
+    ssl_strict: bool = True
     frames: int = 0
     min_score: float = 0.55
     nms_iou: float = 0.60
@@ -45,15 +49,8 @@ class AppConfig:
 @dataclass
 class PipelineRuntime:
     model: object
-    source_graph: object
-    source_run: object
-    decode_graph: object
-    decode_run: object
-    video_graph: object
-    video_run: object
-    save_graph: object | None
-    save_run: object | None
-    pending_encoded_sample: object
+    graph: object
+    run: object
     metadata_sender: object
     labels: list[str]
     frame_w: int
@@ -175,9 +172,25 @@ def bool_or(raw: dict, key: str, default: bool) -> bool:
     return value
 
 
+def parse_source_type(value: str) -> str:
+    lowered = value.lower()
+    if lowered in {"rtsp", "http", "https"}:
+        return "http" if lowered == "https" else lowered
+    raise ValueError("source.type must be rtsp or http")
+
+
+def parse_source_codec(value: str) -> str:
+    lowered = value.lower()
+    if lowered in {"h264", "h.264"}:
+        return "h264"
+    if lowered in {"mjpeg", "jpeg"}:
+        return "mjpeg"
+    raise ValueError("source.codec must be h264 or mjpeg")
+
+
 def validate_config(cfg: AppConfig) -> None:
-    if not cfg.rtsp_url:
-        raise ValueError("source.rtsp_url must be set")
+    if not cfg.source_url:
+        raise ValueError("source.url or source.rtsp_url must be set")
     if not cfg.model_path:
         raise ValueError("model.path must be set")
     if not str(cfg.labels_path):
@@ -186,6 +199,12 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("output.insight.host must be set")
     if cfg.latency_ms < 0:
         raise ValueError("source.latency_ms must be >= 0")
+    if cfg.source_fps < 0:
+        raise ValueError("source.fps must be >= 0")
+    if cfg.source_type == "http" and cfg.source_codec != "mjpeg":
+        raise ValueError("source.codec must be mjpeg for source.type=http")
+    if cfg.source_type == "http" and cfg.source_fps <= 0:
+        raise ValueError("source.fps must be > 0 for HTTP MJPEG sources")
     if cfg.frames < 0:
         raise ValueError("inference.frames must be >= 0")
     if not 0.0 <= cfg.min_score <= 1.0:
@@ -220,9 +239,13 @@ def load_app_config(config_path: Path) -> AppConfig:
     cfg = AppConfig(
         model_path=string_or(model, "path"),
         labels_path=Path(string_or(model, "labels", str(default_labels))),
-        rtsp_url=string_or(source, "rtsp_url"),
+        source_url=string_or(source, "url", string_or(source, "rtsp_url")),
+        source_type=parse_source_type(string_or(source, "type", "rtsp")),
+        source_codec=parse_source_codec(string_or(source, "codec", "h264")),
         latency_ms=int_or(source, "latency_ms", 200),
         tcp=bool_or(source, "tcp", True),
+        source_fps=int_or(source, "fps", 0),
+        ssl_strict=bool_or(source, "ssl_strict", True),
         frames=int_or(inference, "frames", 0),
         min_score=float_or(inference, "min_score", 0.55),
         nms_iou=float_or(inference, "nms_iou", 0.60),
@@ -354,154 +377,102 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     return width, height, fps
 
 
-def build_source_options(cfg: AppConfig, fps: int, width: int, height: int):
+def make_rtsp_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt = pyneat.RtspDecodedInputOptions()
-    opt.url = cfg.rtsp_url
+    opt.url = cfg.source_url
     opt.latency_ms = cfg.latency_ms
     opt.tcp = cfg.tcp
-    opt.payload_type = 96
     opt.insert_queue = True
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
-    opt.auto_caps_from_stream = True
-    opt.fallback_h264_width = width
-    opt.fallback_h264_height = height
-    opt.fallback_h264_fps = fps
-    opt.output_caps.enable = True
-    opt.output_caps.format = pyneat.Format.NV12
-    opt.output_caps.width = width
-    opt.output_caps.height = height
-    opt.output_caps.fps = fps
-    opt.output_caps.memory = pyneat.CapsMemory.Any
+    opt.codec = pyneat.RtspCodec.H264 if cfg.source_codec == "h264" else pyneat.RtspCodec.MJPEG
+    if cfg.source_codec == "h264":
+        opt.payload_type = 96
+        opt.auto_caps_from_stream = True
+        opt.fallback_h264_width = width
+        opt.fallback_h264_height = height
+        opt.fallback_h264_fps = fps
+    else:
+        opt.mjpeg_payload_type = 26
+        opt.dec_width = width
+        opt.dec_height = height
+        opt.dec_fps = fps
+    set_output_caps(opt.output_caps, fps, width, height)
     return opt
 
 
-def output_caps_enabled(caps) -> bool:
-    return caps.enable or caps.width > 0 or caps.height > 0 or caps.fps > 0
-
-
-def build_encoded_source_graph(opt) -> pyneat.Graph:
-    source = pyneat.Graph("rtsp_encoded_source")
-    use_auto_caps = opt.auto_caps_from_stream and (
-        opt.h264_fps <= 0 or opt.h264_width <= 0 or opt.h264_height <= 0
-    )
-    insert_queue = opt.insert_queue and not opt.sync_mode
-    source.add(pyneat.nodes.rtsp_input(opt.url, opt.latency_ms, opt.tcp))
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    source.add(
-        pyneat.nodes.h264_depacketize(
-            payload_type=opt.payload_type,
-            h264_parse_config_interval=opt.h264_parse_config_interval,
-            h264_fps=opt.h264_fps,
-            h264_width=opt.h264_width,
-            h264_height=opt.h264_height,
-            enforce_h264_caps=not use_auto_caps,
-        )
-    )
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    if use_auto_caps:
-        source.add(
-            pyneat.nodes.h264_caps_fixup(
-                opt.fallback_h264_fps, opt.fallback_h264_width, opt.fallback_h264_height
-            )
-        )
-    source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
-    return source
-
-
-def h264_encoded_input_options():
-    opt = pyneat.InputOptions()
-    opt.payload_type = pyneat.PayloadType.Encoded
+def make_http_mjpeg_source_options(cfg: AppConfig, fps: int, width: int, height: int):
+    opt = pyneat.HttpMjpegDecodedInputOptions()
+    opt.url = cfg.source_url
+    opt.decoder_name = "decoder"
+    opt.decoder_raw_output = True
+    opt.dec_fps = fps
+    opt.ssl_strict = cfg.ssl_strict
+    set_output_caps(opt.output_caps, fps, width, height)
     return opt
 
 
-def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> pyneat.Graph:
-    decode = pyneat.Graph("decode_model")
-    dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
-    dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+def set_output_caps(caps, fps: int, width: int, height: int) -> None:
+    if width <= 0 or height <= 0 or fps <= 0:
+        return
+    caps.enable = True
+    caps.format = pyneat.Format.NV12
+    caps.width = width
+    caps.height = height
+    caps.fps = fps
+    caps.memory = pyneat.CapsMemory.Any
 
-    decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
-    decode.add(
-        pyneat.nodes.h264_decode(
-            sima_allocator_type=opt.sima_allocator_type,
-            out_format="NV12",
-            decoder_name=opt.decoder_name,
-            raw_output=opt.decoder_raw_output,
-            next_element=opt.decoder_next_element,
-            dec_width=dec_w,
-            dec_height=dec_h,
-            dec_fps=dec_fps,
-        )
+
+def make_source_graph(cfg: AppConfig, fps: int, width: int, height: int):
+    if cfg.source_type == "rtsp":
+        return pyneat.groups.rtsp_decoded_input(make_rtsp_source_options(cfg, fps, width, height))
+    return pyneat.groups.http_mjpeg_decoded_input(
+        make_http_mjpeg_source_options(cfg, fps, width, height)
     )
-    if opt.use_videoconvert:
-        decode.add(pyneat.nodes.video_convert())
-    if opt.use_videoscale:
-        decode.add(pyneat.nodes.video_scale())
-    if output_caps_enabled(opt.output_caps):
-        decode.add(
-            pyneat.nodes.caps_raw(
-                "NV12",
-                opt.output_caps.width,
-                opt.output_caps.height,
-                opt.output_caps.fps,
-                opt.output_caps.memory,
-            )
-        )
-    if opt.extra_fragment:
-        decode.add(pyneat.nodes.custom(opt.extra_fragment))
-    decode.add(model)
-    decode.add(pyneat.nodes.output(output_name, pyneat.OutputOptions.every_frame(4)))
-    return decode
 
 
-def build_video_sender_graph(input_name: str, video_options) -> pyneat.Graph:
-    video = pyneat.Graph("video_sender")
-    video.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
-    video.add(pyneat.groups.video_sender(video_options))
-    return video
+def probe_decoded_source(cfg: AppConfig) -> tuple[int, int, int]:
+    fps = cfg.source_fps
+    graph = pyneat.Graph("source_probe")
+    graph.add(make_source_graph(cfg, fps, 0, 0))
+    graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(1)))
+
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 3
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
+    run = graph.build(run_options)
+    try:
+        sample = run.pull("frame", 20000)
+    finally:
+        run.close()
+    if sample is None:
+        raise RuntimeError("failed to probe decoded source frame")
+    tensor = first_tensor_from_sample(sample)
+    if tensor is None:
+        raise RuntimeError("decoded source probe did not produce a tensor")
+    return tensor_dim(tensor, "width"), tensor_dim(tensor, "height"), fps
 
 
-def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
-    save = pyneat.Graph("save_frame")
-    dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
-    dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
-
-    save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
-    save.add(
-        pyneat.nodes.h264_decode(
-            sima_allocator_type=opt.sima_allocator_type,
-            out_format="NV12",
-            decoder_name=opt.decoder_name,
-            raw_output=opt.decoder_raw_output,
-            next_element=opt.decoder_next_element,
-            dec_width=dec_w,
-            dec_height=dec_h,
-            dec_fps=dec_fps,
-        )
-    )
-    if output_caps_enabled(opt.output_caps):
-        save.add(
-            pyneat.nodes.caps_raw(
-                "NV12",
-                opt.output_caps.width,
-                opt.output_caps.height,
-                opt.output_caps.fps,
-                opt.output_caps.memory,
-            )
-        )
-    save.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(4)))
-    return save
+def resolve_source_geometry(cfg: AppConfig) -> tuple[int, int, int]:
+    if cfg.source_type == "rtsp":
+        width, height, fps = probe_rtsp(cfg.source_url)
+        return width, height, cfg.source_fps if cfg.source_fps > 0 else fps
+    width, height, fps = probe_decoded_source(cfg)
+    if cfg.source_type == "rtsp" and fps <= 0:
+        fps = DEFAULT_FPS
+    return width, height, fps
 
 
-def build_model(cfg: AppConfig):
+def make_model(cfg: AppConfig, frame_w: int, frame_h: int):
     opt = pyneat.ModelOptions()
     opt.preprocess.kind = pyneat.InputKind.Image
     opt.preprocess.enable = pyneat.AutoFlag.On
     opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.NV12
+    if frame_w > 0 and frame_h > 0:
+        opt.preprocess.input_max_width = frame_w
+        opt.preprocess.input_max_height = frame_h
     opt.preprocess.preset = pyneat.NormalizePreset.COCO_YOLO
     opt.decode_type = pyneat.BoxDecodeType.YoloV26
     opt.score_threshold = cfg.min_score
@@ -510,57 +481,61 @@ def build_model(cfg: AppConfig):
     return pyneat.Model(cfg.model_path, opt)
 
 
-def build_run_options() -> pyneat.RunOptions:
+def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
+    frame_w, frame_h, fps = resolve_source_geometry(cfg)
+    model = make_model(cfg, frame_w, frame_h)
+    labels = load_labels(cfg.labels_path)
+
+    source = make_source_graph(cfg, fps, frame_w, frame_h)
+    save_debug_frames = bool(cfg.save_dir and cfg.save_every > 0)
+    outputs = ["video", "model"]
+    if save_debug_frames:
+        outputs.append("debug_frame")
+    branch = pyneat.graphs.branch("source", outputs)
+
+    video_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(frame_w, frame_h, fps)
+    video_options.host = cfg.insight_host
+    video_options.channel = 0
+    video_options.video_port_base = cfg.video_port
+    video_options.encoder.bitrate_kbps = 1000
+
+    video_graph = pyneat.Graph("video")
+    video_graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(video_options))
+
+    model_graph = pyneat.Graph("model")
+    model_graph.connect(pyneat.nodes.input("model"), model)
+
+    detections_graph = pyneat.Graph("detections")
+    detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
+
+    graph = pyneat.Graph()
+    live_link_options = pyneat.GraphLinkOptions()
+    live_link_options.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
+    graph.connect(source, branch)
+    graph.connect(branch, video_graph, live_link_options)
+    if save_debug_frames:
+        graph.connect(branch, model_graph)
+    else:
+        graph.connect(branch, model_graph, live_link_options)
+    graph.connect(model_graph, detections_graph)
+    if save_debug_frames:
+        frames = pyneat.Graph("debug_frame")
+        frames.add(pyneat.nodes.output("debug_frame", pyneat.OutputOptions.every_frame(4)))
+        debug_join = pyneat.graphs.combine(
+            ["debug_frame", "detections"], "debug_output", pyneat.CombinePolicy.ByPts
+        )
+        graph.connect(branch, frames)
+        graph.connect(frames, debug_join)
+        graph.connect(detections_graph, debug_join)
+    if cfg.profile:
+        print(f"Backend:\n{graph.describe_backend()}")
+
     run_options = pyneat.RunOptions()
     run_options.preset = pyneat.RunPreset.Realtime
     run_options.queue_depth = 3
     run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
     run_options.output_memory = pyneat.OutputMemory.ZeroCopy
-    return run_options
-
-
-def save_frames_enabled(cfg: AppConfig) -> bool:
-    return bool(cfg.save_dir) and cfg.save_every > 0
-
-
-def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
-    frame_w, frame_h, fps = probe_rtsp(cfg.rtsp_url)
-    model = build_model(cfg)
-    labels = load_labels(cfg.labels_path)
-
-    source_options = build_source_options(cfg, fps, frame_w, frame_h)
-    source_graph = build_encoded_source_graph(source_options)
-    video_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_encoded()
-    video_options.host = cfg.insight_host
-    video_options.channel = 0
-    video_options.video_port_base = cfg.video_port
-
-    decode_graph = build_decode_model_graph("encoded", "detections", source_options, model)
-    video_graph = build_video_sender_graph("encoded", video_options)
-    save_graph = (
-        build_save_frame_graph("encoded", source_options) if save_frames_enabled(cfg) else None
-    )
-    if cfg.profile:
-        print(f"Source backend:\n{source_graph.describe_backend()}")
-        print(f"Decode backend:\n{decode_graph.describe_backend()}")
-        print(f"Video backend:\n{video_graph.describe_backend()}")
-        if save_graph is not None:
-            print(f"Save backend:\n{save_graph.describe_backend()}")
-
-    source_run = source_graph.build(build_run_options())
-    pending_encoded_sample = source_run.pull("encoded", 20000)
-    if pending_encoded_sample is None:
-        raise RuntimeError("timed out waiting for encoded RTSP frame")
-
-    downstream_options = build_run_options()
-    downstream_options.startup_preflight = False
-    decode_run = decode_graph.build([pending_encoded_sample], options=downstream_options)
-    video_run = video_graph.build([pending_encoded_sample], options=downstream_options)
-    save_run = (
-        save_graph.build([pending_encoded_sample], options=downstream_options)
-        if save_graph is not None
-        else None
-    )
+    run = graph.build(run_options)
 
     metadata_options = pyneat.MetadataSenderOptions()
     metadata_options.host = cfg.insight_host
@@ -569,21 +544,15 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     metadata_sender = pyneat.MetadataSender(metadata_options)
 
     print(
-        f"rtsp={cfg.rtsp_url} stream={frame_w}x{frame_h}@{fps} "
+        f"source={cfg.source_url} type={cfg.source_type} codec={cfg.source_codec} "
+        f"stream={frame_w}x{frame_h}@{fps} "
         f"insight={cfg.insight_host} video={video_options.video_port} "
         f"metadata={metadata_sender.metadata_port()} channel=0"
     )
     return PipelineRuntime(
         model=model,
-        source_graph=source_graph,
-        source_run=source_run,
-        decode_graph=decode_graph,
-        decode_run=decode_run,
-        video_graph=video_graph,
-        video_run=video_run,
-        save_graph=save_graph,
-        save_run=save_run,
-        pending_encoded_sample=pending_encoded_sample,
+        graph=graph,
+        run=run,
         metadata_sender=metadata_sender,
         labels=labels,
         frame_w=frame_w,
@@ -694,97 +663,29 @@ def maybe_save_debug_frame(cfg: AppConfig, processed: int, sample, boxes: list[d
         print(f"[warn] failed to write output frame: {out_path}", file=sys.stderr)
 
 
-def pump_encoded_samples(
-    runtime: PipelineRuntime,
-    stop_event: threading.Event,
-    errors: list[Exception],
-) -> None:
-    try:
-        encoded_sample = runtime.pending_encoded_sample
-        runtime.pending_encoded_sample = None
-        while not stop_event.is_set():
-            if encoded_sample is None:
-                encoded_sample = runtime.source_run.pull("encoded", 200)
-            if encoded_sample is None:
-                if stop_event.is_set():
-                    break
-                last_error_fn = getattr(runtime.source_run, "last_error", None)
-                last_error = last_error_fn() if callable(last_error_fn) else ""
-                if last_error:
-                    raise RuntimeError(f"source runtime error: {last_error}")
-                continue
-            if not runtime.decode_run.push("encoded", [encoded_sample]):
-                if stop_event.is_set():
-                    break
-                raise RuntimeError("failed to push encoded sample to decode graph")
-            if not runtime.video_run.push("encoded", [encoded_sample]):
-                if stop_event.is_set():
-                    break
-                raise RuntimeError("failed to push encoded sample to video sender graph")
-            if runtime.save_run is not None and not runtime.save_run.push(
-                "encoded", [encoded_sample]
-            ):
-                if stop_event.is_set():
-                    break
-                raise RuntimeError("failed to push encoded sample to save graph")
-            encoded_sample = None
-    except Exception as exc:
-        errors.append(exc)
-        stop_event.set()
-
-
 def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
     profile = ProfileWindow(cfg.profile, cfg.profile_interval)
-    stop_event = threading.Event()
-    pump_errors: list[Exception] = []
-    pump = threading.Thread(
-        target=pump_encoded_samples,
-        args=(runtime, stop_event, pump_errors),
-        name="encoded-pump",
-        daemon=True,
-    )
+    output_name = "debug_output" if cfg.save_dir and cfg.save_every > 0 else "detections"
     processed = 0
-    pump.start()
-    try:
-        while cfg.frames <= 0 or processed < cfg.frames:
-            if pump_errors:
-                raise pump_errors[0]
-            pull_start = time_ms()
-            detection_sample = runtime.decode_run.pull("detections", 20000)
-            pull_end = time_ms()
-            if detection_sample is None:
-                if pump_errors:
-                    raise pump_errors[0]
-                print("[warn] timed out waiting for detections", file=sys.stderr)
-                continue
-            frame_sample = None
-            if runtime.save_run is not None:
-                frame_sample = runtime.save_run.pull("frame", 20000)
-                if frame_sample is None:
-                    raise RuntimeError("timed out waiting for decoded save frame")
+    while cfg.frames <= 0 or processed < cfg.frames:
+        pull_start = time_ms()
+        detection_sample = runtime.run.pull(output_name, 20000)
+        pull_end = time_ms()
+        if detection_sample is None:
+            print("[warn] timed out waiting for detections", file=sys.stderr)
+            continue
 
-            payload = extract_bbox_payload(detection_sample)
-            boxes = parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h, cfg.max_detections)
+        payload = extract_bbox_payload(detection_sample)
+        boxes = parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h, cfg.max_detections)
 
-            metadata_start = time_ms()
-            send_metadata(runtime, detection_sample, boxes)
-            metadata_end = time_ms()
+        metadata_start = time_ms()
+        send_metadata(runtime, detection_sample, boxes)
+        metadata_end = time_ms()
 
-            processed += 1
-            if frame_sample is not None:
-                maybe_save_debug_frame(cfg, processed, frame_sample, boxes)
-            profile.add(pull_end - pull_start, metadata_end - metadata_start, len(boxes))
-    finally:
-        stop_event.set()
-        runtime.video_run.close()
-        runtime.decode_run.close()
-        if runtime.save_run is not None:
-            runtime.save_run.close()
-        runtime.source_run.close()
-        pump.join(timeout=2.0)
+        processed += 1
+        maybe_save_debug_frame(cfg, processed, detection_sample, boxes)
+        profile.add(pull_end - pull_start, metadata_end - metadata_start, len(boxes))
 
-    if pump_errors:
-        raise pump_errors[0]
     profile.flush()
     print(f"processed={processed} video_sender={cfg.insight_host}:{runtime.video_port}")
     return processed
@@ -803,11 +704,14 @@ def main(argv: list[str] | None = None) -> int:
             os.environ.setdefault("SIMA_GST_ELEMENT_TIMINGS", "1")
             os.environ.setdefault("SIMA_GST_FLOW_DEBUG", "1")
             os.environ.setdefault("SIMA_GST_BOUNDARY_PROBES", "1")
-        if save_frames_enabled(cfg):
+        if cfg.save_dir:
             Path(cfg.save_dir).mkdir(parents=True, exist_ok=True)
 
         runtime = build_pipeline(cfg)
-        run_pipeline(runtime, cfg)
+        try:
+            run_pipeline(runtime, cfg)
+        finally:
+            runtime.run.close()
         return 0
     except KeyboardInterrupt:
         return 130

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from fractions import Fraction
 import glob
 import json
 import os
 from pathlib import Path
 import struct
+import subprocess
 import sys
 import time
 
 import yaml
 
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
-DEFAULT_FPS = 30
 
 cv2 = None
 np = None
@@ -203,8 +204,6 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("source.fps must be >= 0")
     if cfg.source_type == "http" and cfg.source_codec != "mjpeg":
         raise ValueError("source.codec must be mjpeg for source.type=http")
-    if cfg.source_type == "http" and cfg.source_fps <= 0:
-        raise ValueError("source.fps must be > 0 for HTTP MJPEG sources")
     if cfg.frames < 0:
         raise ValueError("inference.frames must be >= 0")
     if not 0.0 <= cfg.min_score <= 1.0:
@@ -362,6 +361,57 @@ def build_metadata_boxes(boxes: list[dict], labels: list[str], frame_w: int, fra
     return metadata_boxes
 
 
+def fps_from_rate(value: str) -> int:
+    if not value or value in {"0/0", "0/1"}:
+        return 0
+    try:
+        fps = float(Fraction(value)) if "/" in value else float(value)
+    except (ValueError, ZeroDivisionError):
+        return 0
+    return int(round(fps)) if fps > 0 else 0
+
+
+def int_from_probe(value: str | None) -> int:
+    try:
+        return int(value or 0)
+    except ValueError:
+        return 0
+
+
+def probe_ffprobe(cfg: AppConfig) -> tuple[int, int, int]:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-rw_timeout",
+        "5000000",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=width,height,r_frame_rate,avg_frame_rate",
+        "-of",
+        "default=nw=1",
+    ]
+    if not cfg.ssl_strict:
+        cmd.extend(["-tls_verify", "0"])
+    cmd.append(cfg.source_url)
+    try:
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=5)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 0, 0, 0
+    if result.returncode != 0:
+        return 0, 0, 0
+    values = {}
+    for line in result.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    fps = fps_from_rate(values.get("avg_frame_rate", "")) or fps_from_rate(
+        values.get("r_frame_rate", "")
+    )
+    return int_from_probe(values.get("width")), int_from_probe(values.get("height")), fps
+
+
 def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap = cv2.VideoCapture(url)
     if not cap.isOpened():
@@ -372,8 +422,6 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap.release()
     if width <= 0 or height <= 0:
         raise RuntimeError("failed to probe RTSP frame size")
-    if fps <= 0:
-        raise RuntimeError("failed to probe RTSP frame rate")
     return width, height, fps
 
 
@@ -431,8 +479,15 @@ def make_source_graph(cfg: AppConfig, fps: int, width: int, height: int):
     )
 
 
-def probe_decoded_source(cfg: AppConfig) -> tuple[int, int, int]:
-    fps = cfg.source_fps
+def require_mjpeg_fps(cfg: AppConfig, fps: int) -> None:
+    if cfg.source_codec == "mjpeg" and fps <= 0:
+        raise RuntimeError(
+            "MJPEG source did not provide a valid frame rate; set source.fps or use a source "
+            "with probeable FPS metadata"
+        )
+
+
+def probe_decoded_source(cfg: AppConfig, fps: int) -> tuple[int, int, int]:
     graph = pyneat.Graph("source_probe")
     graph.add(make_source_graph(cfg, fps, 0, 0))
     graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(1)))
@@ -456,12 +511,22 @@ def probe_decoded_source(cfg: AppConfig) -> tuple[int, int, int]:
 
 
 def resolve_source_geometry(cfg: AppConfig) -> tuple[int, int, int]:
+    probed_w, probed_h, probed_fps = probe_ffprobe(cfg)
+    fps = cfg.source_fps if cfg.source_fps > 0 else probed_fps
     if cfg.source_type == "rtsp":
-        width, height, fps = probe_rtsp(cfg.source_url)
-        return width, height, cfg.source_fps if cfg.source_fps > 0 else fps
-    width, height, fps = probe_decoded_source(cfg)
-    if cfg.source_type == "rtsp" and fps <= 0:
-        fps = DEFAULT_FPS
+        width, height = probed_w, probed_h
+        if width <= 0 or height <= 0 or fps <= 0:
+            rtsp_w, rtsp_h, rtsp_fps = probe_rtsp(cfg.source_url)
+            width = width if width > 0 else rtsp_w
+            height = height if height > 0 else rtsp_h
+            fps = fps if fps > 0 else rtsp_fps
+        require_mjpeg_fps(cfg, fps)
+        return width, height, fps
+
+    require_mjpeg_fps(cfg, fps)
+    if probed_w > 0 and probed_h > 0:
+        return probed_w, probed_h, fps
+    width, height, _ = probe_decoded_source(cfg, fps)
     return width, height, fps
 
 

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -14,7 +14,7 @@
 ## Concept
 `single-stream-instance-segmenter` is a single-camera YOLO26 instance segmentation example:
 
-- ingest one RTSP camera stream
+- ingest one RTSP H.264/MJPEG or HTTP MJPEG stream
 - decode the stream into frames
 - run YOLO26 instance segmentation
 - render mask overlays on the video
@@ -44,7 +44,7 @@ To create a reproducible RTSP input:
 2. In Insight, open `RTSP Source`.
 3. Use a sample video or upload your own video.
 4. Start the stream and copy the RTSP URL.
-5. Put that RTSP URL into `source.rtsp_url`.
+5. Put that RTSP URL into `source.url`.
 
 Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
 
@@ -68,9 +68,9 @@ The command stores the model under `assets/models/` as a repo-local convention. 
 
 ## Prerequisites
 - Installed Neat Development Environment + Neat Library.
-- RTSP source created in Insight or provided by your camera.
+- RTSP H.264, RTSP MJPEG, or HTTP MJPEG source created in Insight or provided by your camera.
 - Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default YOLO26 segmentation model, or set `model.path` to another readable model package.
-- `model.path`, `model.labels`, `source.rtsp_url`, and `output.insight.host` set in `src/common/config.yaml`.
+- `model.path`, `model.labels`, `source.url`, and `output.insight.host` set in `src/common/config.yaml`.
 
 ## Get The Apps Repo
 Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
@@ -93,8 +93,11 @@ model:
   path: <model-path>                                                # Path to the model package.
 
 source:
-  rtsp_url: <rtsp-url-copied-from-insight>                          # RTSP stream URL.
+  type: rtsp                                                         # rtsp or http.
+  codec: h264                                                        # h264 or mjpeg.
+  url: <rtsp-url-copied-from-insight>                                # RTSP or HTTP MJPEG stream URL.
   tcp: true                                                          # Use TCP transport for RTSP.
+  fps: 0                                                             # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
 
 inference:
   frames: 0                                                          # Frame limit. 0 runs continuously.
@@ -123,7 +126,7 @@ python3 examples/segmentation/single-stream-instance-segmenter/src/python/main.p
 ```
 
 ## Debugging Notes
-- If startup fails, verify `model.path` and `source.rtsp_url`.
+- If startup fails, verify `model.path` and `source.url`.
 - If the app times out waiting for RTSP, verify source reachability first.
 - If Insight receives no video, verify `output.insight.host` and UDP ports.
 - If saved frames are needed for inspection, set `output.save_dir` and `output.save_every`.

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -97,7 +97,7 @@ source:
   codec: h264                                                        # h264 or mjpeg.
   url: <rtsp-url-copied-from-insight>                                # RTSP or HTTP MJPEG stream URL.
   tcp: true                                                          # Use TCP transport for RTSP.
-  fps: 0                                                             # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
+  fps: 0                                                             # 0 probes FPS. MJPEG requires config FPS or probeable FPS metadata.
 
 inference:
   frames: 0                                                          # Frame limit. 0 runs continuously.

--- a/examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
+++ b/examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
@@ -3,9 +3,14 @@ model:
   labels: examples/segmentation/single-stream-instance-segmenter/src/common/coco_label.txt
 
 source:
-  rtsp_url: <rtsp-url-1>     # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
+  type: rtsp                 # rtsp or http.
+  codec: h264                # h264 or mjpeg.
+  url: <rtsp-url-1>          # Example: rtsp://<rtsp-source-ip>:<port>/<stream-name>
+  rtsp_url: ""               # Legacy H.264 RTSP key. Used when source.url is empty.
   tcp: true                  # Use TCP for RTSP transport.
   latency_ms: 100            # RTSP receive latency in milliseconds.
+  fps: 0                     # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
+  ssl_strict: true           # Set false for HTTPS MJPEG streams with self-signed certs.
 
 inference:
   frames: 0                  # Frame limit. 0 means run continuously.

--- a/examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
+++ b/examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
@@ -9,7 +9,7 @@ source:
   rtsp_url: ""               # Legacy H.264 RTSP key. Used when source.url is empty.
   tcp: true                  # Use TCP for RTSP transport.
   latency_ms: 100            # RTSP receive latency in milliseconds.
-  fps: 0                     # 0 lets RTSP derive/probe FPS. HTTP MJPEG requires a positive FPS.
+  fps: 0                     # 0 probes FPS. MJPEG requires config FPS or probeable FPS metadata.
   ssl_strict: true           # Set false for HTTPS MJPEG streams with self-signed certs.
 
 inference:

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -23,10 +23,12 @@
 
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
 
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -43,12 +45,21 @@ using sima_examples::time_ms;
 
 namespace {
 
+constexpr int kDefaultFps = 30;
+
+enum class SourceType { Rtsp, Http };
+enum class SourceCodec { H264, Mjpeg };
+
 struct AppConfig {
   std::string model_path;
   fs::path labels_path;
-  std::string rtsp_url;
+  std::string source_url;
+  SourceType source_type = SourceType::Rtsp;
+  SourceCodec source_codec = SourceCodec::H264;
   int latency_ms = 200;
   bool tcp = true;
+  int source_fps = 0;
+  bool ssl_strict = true;
   int frames = 0;
   double min_score = 0.55;
   double nms_iou = 0.60;
@@ -153,6 +164,42 @@ struct PipelineRuntime {
   int video_port = 0;
 };
 
+std::string lower_copy(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+SourceType parse_source_type(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "rtsp") {
+    return SourceType::Rtsp;
+  }
+  if (lowered == "http" || lowered == "https") {
+    return SourceType::Http;
+  }
+  throw std::runtime_error("source.type must be rtsp or http");
+}
+
+SourceCodec parse_source_codec(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "h264" || lowered == "h.264") {
+    return SourceCodec::H264;
+  }
+  if (lowered == "mjpeg" || lowered == "jpeg") {
+    return SourceCodec::Mjpeg;
+  }
+  throw std::runtime_error("source.codec must be h264 or mjpeg");
+}
+
+const char* source_type_name(SourceType value) {
+  return value == SourceType::Rtsp ? "rtsp" : "http";
+}
+
+const char* source_codec_name(SourceCodec value) {
+  return value == SourceCodec::H264 ? "h264" : "mjpeg";
+}
+
 CliOptions parse_args(int argc, char** argv) {
   CliOptions options;
   options.config_path = sima_examples::default_config_path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR);
@@ -176,11 +223,17 @@ CliOptions parse_args(int argc, char** argv) {
 }
 
 void validate_config(const AppConfig& cfg) {
-  sima_examples::require(!cfg.rtsp_url.empty(), "source.rtsp_url must be set");
+  sima_examples::require(!cfg.source_url.empty(), "source.url or source.rtsp_url must be set");
   sima_examples::require(!cfg.model_path.empty(), "model.path must be set");
   sima_examples::require(!cfg.labels_path.empty(), "model.labels must be set");
   sima_examples::require(!cfg.insight_host.empty(), "output.insight.host must be set");
   sima_examples::require(cfg.latency_ms >= 0, "source.latency_ms must be >= 0");
+  sima_examples::require(cfg.source_fps >= 0, "source.fps must be >= 0");
+  if (cfg.source_type == SourceType::Http) {
+    sima_examples::require(cfg.source_codec == SourceCodec::Mjpeg,
+                           "source.codec must be mjpeg for source.type=http");
+    sima_examples::require(cfg.source_fps > 0, "source.fps must be > 0 for HTTP MJPEG sources");
+  }
   sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
@@ -206,9 +259,14 @@ AppConfig load_app_config(const fs::path& config_path) {
   AppConfig cfg;
   cfg.model_path = raw.string_or("model.path", "");
   cfg.labels_path = raw.string_or("model.labels", default_labels.string());
-  cfg.rtsp_url = raw.string_or("source.rtsp_url", "");
+  const std::string legacy_rtsp_url = raw.string_or("source.rtsp_url", "");
+  cfg.source_url = raw.string_or("source.url", legacy_rtsp_url);
+  cfg.source_type = parse_source_type(raw.string_or("source.type", "rtsp"));
+  cfg.source_codec = parse_source_codec(raw.string_or("source.codec", "h264"));
   cfg.latency_ms = raw.int_or("source.latency_ms", 200);
   cfg.tcp = raw.bool_or("source.tcp", true);
+  cfg.source_fps = raw.int_or("source.fps", 0);
+  cfg.ssl_strict = raw.bool_or("source.ssl_strict", true);
   cfg.frames = raw.int_or("inference.frames", 0);
   cfg.min_score = raw.double_or("inference.min_score", 0.55);
   cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
@@ -312,52 +370,163 @@ decode_segmentation_output(const simaai::neat::TensorList& tensors, int frame_w,
   return detections;
 }
 
+struct SourceGeometry {
+  int width = 0;
+  int height = 0;
+  int fps = 0;
+};
+
 simaai::neat::nodes::groups::RtspDecodedInputOptions
-make_source_options(const AppConfig& cfg, int& fps_out, int& width_out, int& height_out) {
+make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
+  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
+  opt.url = cfg.source_url;
+  opt.latency_ms = cfg.latency_ms;
+  opt.tcp = cfg.tcp;
+  opt.insert_queue = true;
+  opt.out_format = "NV12";
+  opt.decoder_name = "decoder";
+  opt.decoder_raw_output = true;
+  opt.codec = cfg.source_codec == SourceCodec::H264 ? simaai::neat::nodes::groups::RtspCodec::H264
+                                                    : simaai::neat::nodes::groups::RtspCodec::MJPEG;
+  if (cfg.source_codec == SourceCodec::H264) {
+    opt.payload_type = 96;
+    opt.auto_caps_from_stream = true;
+    opt.fallback_h264_width = geometry.width;
+    opt.fallback_h264_height = geometry.height;
+    opt.fallback_h264_fps = geometry.fps;
+  } else {
+    opt.mjpeg_payload_type = 26;
+    opt.dec_width = geometry.width;
+    opt.dec_height = geometry.height;
+    opt.dec_fps = geometry.fps;
+  }
+  if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = geometry.width;
+    opt.output_caps.height = geometry.height;
+    opt.output_caps.fps = geometry.fps;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
+  return opt;
+}
+
+simaai::neat::nodes::groups::HttpMjpegDecodedInputOptions
+make_http_mjpeg_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
+  simaai::neat::nodes::groups::HttpMjpegDecodedInputOptions opt;
+  opt.url = cfg.source_url;
+  opt.decoder_name = "decoder";
+  opt.decoder_raw_output = true;
+  opt.dec_fps = geometry.fps;
+  opt.ssl_strict = cfg.ssl_strict;
+  if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
+    opt.output_caps.enable = true;
+    opt.output_caps.format = "NV12";
+    opt.output_caps.width = geometry.width;
+    opt.output_caps.height = geometry.height;
+    opt.output_caps.fps = geometry.fps;
+    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  }
+  return opt;
+}
+
+simaai::neat::Graph make_source_graph(const AppConfig& cfg, const SourceGeometry& geometry) {
+  if (cfg.source_type == SourceType::Rtsp) {
+    return simaai::neat::nodes::groups::RtspDecodedInput(make_rtsp_source_options(cfg, geometry));
+  }
+  return simaai::neat::nodes::groups::HttpMjpegDecodedInput(
+      make_http_mjpeg_source_options(cfg, geometry));
+}
+
+SourceGeometry probe_rtsp_h264_geometry(const AppConfig& cfg) {
   sima_examples::RtspStreamInfo probe;
   sima_examples::RtspProbeOptions probe_options;
   probe_options.payload_type = 96;
   probe_options.latency_ms = cfg.latency_ms;
   probe_options.rtsp_tcp = cfg.tcp;
   probe_options.debug = cfg.profile;
-  (void)sima_examples::probe_rtsp_stream_info(cfg.rtsp_url, probe_options, probe);
+  (void)sima_examples::probe_rtsp_stream_info(cfg.source_url, probe_options, probe);
 
-  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
-  opt.url = cfg.rtsp_url;
-  opt.latency_ms = cfg.latency_ms;
-  opt.tcp = cfg.tcp;
-  opt.payload_type = 96;
-  opt.insert_queue = true;
-  opt.out_format = "NV12";
-  opt.decoder_name = "decoder";
-  opt.decoder_raw_output = true;
-  opt.auto_caps_from_stream = true;
-  if (probe.width > 0 && probe.height > 0) {
-    opt.fallback_h264_width = probe.width;
-    opt.fallback_h264_height = probe.height;
-    width_out = probe.width;
-    height_out = probe.height;
-  }
-  if (probe.fps > 0) {
-    opt.fallback_h264_fps = probe.fps;
-    fps_out = probe.fps;
-  }
-  if (width_out > 0 && height_out > 0 && fps_out > 0) {
-    opt.output_caps.enable = true;
-    opt.output_caps.format = "NV12";
-    opt.output_caps.width = width_out;
-    opt.output_caps.height = height_out;
-    opt.output_caps.fps = fps_out;
-    opt.output_caps.memory = simaai::neat::CapsMemory::Any;
-  }
-  return opt;
+  SourceGeometry geometry;
+  geometry.width = probe.width;
+  geometry.height = probe.height;
+  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps : (probe.fps > 0 ? probe.fps : kDefaultFps);
+  return geometry;
 }
 
-std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg) {
+SourceGeometry probe_rtsp_geometry(const AppConfig& cfg) {
+  if (cfg.source_codec == SourceCodec::H264) {
+    return probe_rtsp_h264_geometry(cfg);
+  }
+
+  cv::VideoCapture cap(cfg.source_url);
+  if (!cap.isOpened()) {
+    throw std::runtime_error("failed to open RTSP source for probing: " + cfg.source_url);
+  }
+
+  SourceGeometry geometry;
+  geometry.width = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
+  geometry.height = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
+  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps
+                                    : static_cast<int>(std::lround(cap.get(cv::CAP_PROP_FPS)));
+  cap.release();
+  if (geometry.fps <= 0) {
+    geometry.fps = kDefaultFps;
+  }
+  return geometry;
+}
+
+SourceGeometry probe_decoded_source_geometry(const AppConfig& cfg) {
+  SourceGeometry geometry;
+  geometry.fps = cfg.source_fps;
+
+  simaai::neat::Graph probe_graph("source_probe");
+  probe_graph.add(make_source_graph(cfg, geometry));
+  probe_graph.add(simaai::neat::nodes::Output("frame", simaai::neat::OutputOptions::EveryFrame(1)));
+
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 3;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
+  simaai::neat::Run run = probe_graph.build(run_options);
+
+  simaai::neat::Sample sample;
+  simaai::neat::PullError pull_error;
+  const auto status = run.pull("frame", 20000, sample, &pull_error);
+  run.close();
+  if (status != simaai::neat::PullStatus::Ok) {
+    throw std::runtime_error("failed to probe decoded source frame: " + pull_error.message);
+  }
+
+  const auto tensors = simaai::neat::tensors_from_sample(sample, false);
+  if (!tensors.empty()) {
+    (void)sima_examples::infer_dims(tensors.front(), geometry.width, geometry.height);
+  }
+  return geometry;
+}
+
+SourceGeometry resolve_source_geometry(const AppConfig& cfg) {
+  if (cfg.source_type == SourceType::Rtsp) {
+    return probe_rtsp_geometry(cfg);
+  }
+  SourceGeometry geometry = probe_decoded_source_geometry(cfg);
+  if (geometry.fps <= 0 && cfg.source_type == SourceType::Rtsp) {
+    geometry.fps = kDefaultFps;
+  }
+  return geometry;
+}
+
+std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg,
+                                                const SourceGeometry& geometry) {
   simaai::neat::Model::Options opt;
   opt.preprocess.kind = simaai::neat::InputKind::Image;
   opt.preprocess.enable = simaai::neat::AutoFlag::On;
   opt.preprocess.color_convert.input_format = simaai::neat::PreprocessColorFormat::NV12;
+  if (geometry.width > 0 && geometry.height > 0) {
+    opt.preprocess.input_max_width = geometry.width;
+    opt.preprocess.input_max_height = geometry.height;
+  }
   opt.preprocess.preset = simaai::neat::NormalizePreset::COCO_YOLO;
   opt.decode_type = simaai::neat::BoxDecodeType::YoloV26Seg;
   opt.score_threshold = cfg.min_score;
@@ -536,16 +705,18 @@ build_metadata_boxes(const std::vector<SegmentationDetection>& detections,
 
 PipelineRuntime build_pipeline(const AppConfig& cfg) {
   PipelineRuntime runtime;
-  const auto source_options =
-      make_source_options(cfg, runtime.output_fps, runtime.frame_w, runtime.frame_h);
+  const SourceGeometry geometry = resolve_source_geometry(cfg);
+  runtime.frame_w = geometry.width;
+  runtime.frame_h = geometry.height;
+  runtime.output_fps = geometry.fps;
   sima_examples::require(runtime.frame_w > 0 && runtime.frame_h > 0,
-                         "failed to probe RTSP frame dimensions");
-  sima_examples::require(runtime.output_fps > 0, "failed to probe RTSP frame rate");
+                         "failed to probe source frame dimensions");
+  sima_examples::require(runtime.output_fps > 0, "failed to resolve source frame rate");
 
-  runtime.model = make_model(cfg);
+  runtime.model = make_model(cfg, geometry);
   runtime.labels = load_labels(cfg.labels_path);
 
-  auto source = simaai::neat::nodes::groups::RtspDecodedInput(source_options);
+  auto source = make_source_graph(cfg, geometry);
   auto branch = simaai::neat::graphs::Branch("source", {"frame", "model"});
 
   simaai::neat::Graph frame_graph("frame");
@@ -610,9 +781,10 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
       std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
   sima_examples::require(runtime.metadata_sender->ok(), metadata_err);
 
-  std::cout << "rtsp=" << cfg.rtsp_url << " stream=" << runtime.frame_w << "x" << runtime.frame_h
-            << "@" << runtime.output_fps << " insight=" << cfg.insight_host
-            << " video=" << runtime.video_port
+  std::cout << "source=" << cfg.source_url << " type=" << source_type_name(cfg.source_type)
+            << " codec=" << source_codec_name(cfg.source_codec) << " stream=" << runtime.frame_w
+            << "x" << runtime.frame_h << "@" << runtime.output_fps
+            << " insight=" << cfg.insight_host << " video=" << runtime.video_port
             << " metadata=" << runtime.metadata_sender->metadata_port() << " channel=0\n";
   return runtime;
 }

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -26,9 +26,11 @@
 #include <opencv2/videoio.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cctype>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -44,8 +46,6 @@ namespace fs = std::filesystem;
 using sima_examples::time_ms;
 
 namespace {
-
-constexpr int kDefaultFps = 30;
 
 enum class SourceType { Rtsp, Http };
 enum class SourceCodec { H264, Mjpeg };
@@ -232,7 +232,6 @@ void validate_config(const AppConfig& cfg) {
   if (cfg.source_type == SourceType::Http) {
     sima_examples::require(cfg.source_codec == SourceCodec::Mjpeg,
                            "source.codec must be mjpeg for source.type=http");
-    sima_examples::require(cfg.source_fps > 0, "source.fps must be > 0 for HTTP MJPEG sources");
   }
   sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
@@ -376,6 +375,96 @@ struct SourceGeometry {
   int fps = 0;
 };
 
+int fps_from_rate(const std::string& value) {
+  if (value.empty() || value == "0/0" || value == "0/1")
+    return 0;
+  try {
+    const auto slash = value.find('/');
+    double fps = 0.0;
+    if (slash == std::string::npos) {
+      fps = std::stod(value);
+    } else {
+      const double den = std::stod(value.substr(slash + 1));
+      if (den <= 0.0)
+        return 0;
+      fps = std::stod(value.substr(0, slash)) / den;
+    }
+    return fps > 0.0 ? static_cast<int>(std::lround(fps)) : 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+std::string shell_quote(const std::string& value) {
+  std::string out = "'";
+  for (const char c : value) {
+    out += c == '\'' ? "'\\''" : std::string(1, c);
+  }
+  out += "'";
+  return out;
+}
+
+SourceGeometry probe_ffprobe_geometry(const AppConfig& cfg) {
+  SourceGeometry geometry;
+  std::string command =
+      "ffprobe -v error -rw_timeout 5000000 -select_streams v:0 "
+      "-show_entries stream=width,height,r_frame_rate,avg_frame_rate -of default=nw=1 ";
+  if (!cfg.ssl_strict) {
+    command += "-tls_verify 0 ";
+  }
+  command += shell_quote(cfg.source_url) + " 2>/dev/null";
+
+  FILE* pipe = popen(command.c_str(), "r");
+  if (!pipe) {
+    return geometry;
+  }
+
+  int avg_fps = 0;
+  int r_fps = 0;
+  std::array<char, 256> buffer{};
+  while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe)) {
+    std::string line(buffer.data());
+    while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
+      line.pop_back();
+    }
+    const auto eq = line.find('=');
+    if (eq == std::string::npos) {
+      continue;
+    }
+    const std::string key = line.substr(0, eq);
+    const std::string value = line.substr(eq + 1);
+    if (key == "width") {
+      geometry.width = std::atoi(value.c_str());
+    } else if (key == "height") {
+      geometry.height = std::atoi(value.c_str());
+    } else if (key == "avg_frame_rate") {
+      avg_fps = fps_from_rate(value);
+    } else if (key == "r_frame_rate") {
+      r_fps = fps_from_rate(value);
+    }
+  }
+  pclose(pipe);
+  geometry.fps = avg_fps > 0 ? avg_fps : r_fps;
+  return geometry;
+}
+
+void fill_missing_geometry(SourceGeometry& dst, const SourceGeometry& src) {
+  if (dst.width <= 0)
+    dst.width = src.width;
+  if (dst.height <= 0)
+    dst.height = src.height;
+  if (dst.fps <= 0)
+    dst.fps = src.fps;
+}
+
+void require_mjpeg_fps(const AppConfig& cfg, const SourceGeometry& geometry) {
+  if (cfg.source_codec == SourceCodec::Mjpeg && geometry.fps <= 0) {
+    throw std::runtime_error(
+        "MJPEG source did not provide a valid frame rate; set source.fps or use a source with "
+        "probeable FPS metadata");
+  }
+}
+
 simaai::neat::nodes::groups::RtspDecodedInputOptions
 make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
   simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
@@ -450,35 +539,47 @@ SourceGeometry probe_rtsp_h264_geometry(const AppConfig& cfg) {
   SourceGeometry geometry;
   geometry.width = probe.width;
   geometry.height = probe.height;
-  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps : (probe.fps > 0 ? probe.fps : kDefaultFps);
+  geometry.fps = probe.fps;
   return geometry;
 }
 
 SourceGeometry probe_rtsp_geometry(const AppConfig& cfg) {
+  SourceGeometry geometry = probe_ffprobe_geometry(cfg);
+  if (cfg.source_fps > 0) {
+    geometry.fps = cfg.source_fps;
+  }
+
   if (cfg.source_codec == SourceCodec::H264) {
-    return probe_rtsp_h264_geometry(cfg);
+    SourceGeometry rtsp_geometry = probe_rtsp_h264_geometry(cfg);
+    if (cfg.source_fps > 0) {
+      rtsp_geometry.fps = cfg.source_fps;
+    }
+    fill_missing_geometry(geometry, rtsp_geometry);
+    return geometry;
   }
 
-  cv::VideoCapture cap(cfg.source_url);
-  if (!cap.isOpened()) {
-    throw std::runtime_error("failed to open RTSP source for probing: " + cfg.source_url);
+  if (geometry.width <= 0 || geometry.height <= 0 || geometry.fps <= 0) {
+    cv::VideoCapture cap(cfg.source_url);
+    if (!cap.isOpened()) {
+      throw std::runtime_error("failed to open RTSP source for probing: " + cfg.source_url);
+    }
+    SourceGeometry cv_geometry;
+    cv_geometry.width = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
+    cv_geometry.height = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
+    cv_geometry.fps = static_cast<int>(std::lround(cap.get(cv::CAP_PROP_FPS)));
+    cap.release();
+    fill_missing_geometry(geometry, cv_geometry);
   }
-
-  SourceGeometry geometry;
-  geometry.width = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
-  geometry.height = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
-  geometry.fps = cfg.source_fps > 0 ? cfg.source_fps
-                                    : static_cast<int>(std::lround(cap.get(cv::CAP_PROP_FPS)));
-  cap.release();
-  if (geometry.fps <= 0) {
-    geometry.fps = kDefaultFps;
+  if (cfg.source_fps > 0) {
+    geometry.fps = cfg.source_fps;
   }
+  require_mjpeg_fps(cfg, geometry);
   return geometry;
 }
 
-SourceGeometry probe_decoded_source_geometry(const AppConfig& cfg) {
+SourceGeometry probe_decoded_source_geometry(const AppConfig& cfg, int fps) {
   SourceGeometry geometry;
-  geometry.fps = cfg.source_fps;
+  geometry.fps = fps;
 
   simaai::neat::Graph probe_graph("source_probe");
   probe_graph.add(make_source_graph(cfg, geometry));
@@ -510,9 +611,13 @@ SourceGeometry resolve_source_geometry(const AppConfig& cfg) {
   if (cfg.source_type == SourceType::Rtsp) {
     return probe_rtsp_geometry(cfg);
   }
-  SourceGeometry geometry = probe_decoded_source_geometry(cfg);
-  if (geometry.fps <= 0 && cfg.source_type == SourceType::Rtsp) {
-    geometry.fps = kDefaultFps;
+  SourceGeometry geometry = probe_ffprobe_geometry(cfg);
+  if (cfg.source_fps > 0) {
+    geometry.fps = cfg.source_fps;
+  }
+  require_mjpeg_fps(cfg, geometry);
+  if (geometry.width <= 0 || geometry.height <= 0) {
+    fill_missing_geometry(geometry, probe_decoded_source_geometry(cfg, geometry.fps));
   }
   return geometry;
 }

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from fractions import Fraction
 import glob
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 import time
 
@@ -15,7 +17,6 @@ import yaml
 
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
 DEFAULT_LABELS = DEFAULT_CONFIG.parent / "coco_label.txt"
-DEFAULT_FPS = 30
 MASK_ALPHA = 0.55
 MASK_THRESHOLD = 0.50
 
@@ -244,8 +245,6 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("source.fps must be >= 0")
     if cfg.source_type == "http" and cfg.source_codec != "mjpeg":
         raise ValueError("source.codec must be mjpeg for source.type=http")
-    if cfg.source_type == "http" and cfg.source_fps <= 0:
-        raise ValueError("source.fps must be > 0 for HTTP MJPEG sources")
     if cfg.frames < 0:
         raise ValueError("inference.frames must be >= 0")
     if not 0.0 <= cfg.min_score <= 1.0:
@@ -453,6 +452,57 @@ def decode_segmentation_output(tensors: list, frame_w: int, frame_h: int, max_de
     return detections
 
 
+def fps_from_rate(value: str) -> int:
+    if not value or value in {"0/0", "0/1"}:
+        return 0
+    try:
+        fps = float(Fraction(value)) if "/" in value else float(value)
+    except (ValueError, ZeroDivisionError):
+        return 0
+    return int(round(fps)) if fps > 0 else 0
+
+
+def int_from_probe(value: str | None) -> int:
+    try:
+        return int(value or 0)
+    except ValueError:
+        return 0
+
+
+def probe_ffprobe(cfg: AppConfig) -> tuple[int, int, int]:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-rw_timeout",
+        "5000000",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=width,height,r_frame_rate,avg_frame_rate",
+        "-of",
+        "default=nw=1",
+    ]
+    if not cfg.ssl_strict:
+        cmd.extend(["-tls_verify", "0"])
+    cmd.append(cfg.source_url)
+    try:
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=5)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 0, 0, 0
+    if result.returncode != 0:
+        return 0, 0, 0
+    values = {}
+    for line in result.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    fps = fps_from_rate(values.get("avg_frame_rate", "")) or fps_from_rate(
+        values.get("r_frame_rate", "")
+    )
+    return int_from_probe(values.get("width")), int_from_probe(values.get("height")), fps
+
+
 def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap = cv2.VideoCapture(url)
     if not cap.isOpened():
@@ -463,7 +513,7 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap.release()
     if width <= 0 or height <= 0:
         raise RuntimeError("failed to probe RTSP frame size")
-    return width, height, fps if fps > 0 else DEFAULT_FPS
+    return width, height, fps
 
 
 def set_output_caps(caps, fps: int, width: int, height: int) -> None:
@@ -520,8 +570,15 @@ def make_source_graph(cfg: AppConfig, fps: int, width: int, height: int):
     )
 
 
-def probe_decoded_source(cfg: AppConfig) -> tuple[int, int, int]:
-    fps = cfg.source_fps
+def require_mjpeg_fps(cfg: AppConfig, fps: int) -> None:
+    if cfg.source_codec == "mjpeg" and fps <= 0:
+        raise RuntimeError(
+            "MJPEG source did not provide a valid frame rate; set source.fps or use a source "
+            "with probeable FPS metadata"
+        )
+
+
+def probe_decoded_source(cfg: AppConfig, fps: int) -> tuple[int, int, int]:
     graph = pyneat.Graph("source_probe")
     graph.add(make_source_graph(cfg, fps, 0, 0))
     graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(1)))
@@ -545,12 +602,22 @@ def probe_decoded_source(cfg: AppConfig) -> tuple[int, int, int]:
 
 
 def resolve_source_geometry(cfg: AppConfig) -> tuple[int, int, int]:
+    probed_w, probed_h, probed_fps = probe_ffprobe(cfg)
+    fps = cfg.source_fps if cfg.source_fps > 0 else probed_fps
     if cfg.source_type == "rtsp":
-        width, height, fps = probe_rtsp(cfg.source_url)
-        return width, height, cfg.source_fps if cfg.source_fps > 0 else fps
-    width, height, fps = probe_decoded_source(cfg)
-    if cfg.source_type == "rtsp" and fps <= 0:
-        fps = DEFAULT_FPS
+        width, height = probed_w, probed_h
+        if width <= 0 or height <= 0 or fps <= 0:
+            rtsp_w, rtsp_h, rtsp_fps = probe_rtsp(cfg.source_url)
+            width = width if width > 0 else rtsp_w
+            height = height if height > 0 else rtsp_h
+            fps = fps if fps > 0 else rtsp_fps
+        require_mjpeg_fps(cfg, fps)
+        return width, height, fps
+
+    require_mjpeg_fps(cfg, fps)
+    if probed_w > 0 and probed_h > 0:
+        return probed_w, probed_h, fps
+    width, height, _ = probe_decoded_source(cfg, fps)
     return width, height, fps
 
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -37,9 +37,13 @@ class OutputConfig:
 class AppConfig:
     model_path: str
     labels_path: Path
-    rtsp_url: str
+    source_url: str
+    source_type: str = "rtsp"
+    source_codec: str = "h264"
     latency_ms: int = 200
     tcp: bool = True
+    source_fps: int = 0
+    ssl_strict: bool = True
     frames: int = 0
     min_score: float = 0.55
     nms_iou: float = 0.60
@@ -209,9 +213,25 @@ def bool_or(raw: dict, key: str, default: bool) -> bool:
     return bool(value)
 
 
+def parse_source_type(value: str) -> str:
+    lowered = value.lower()
+    if lowered in {"rtsp", "http", "https"}:
+        return "http" if lowered == "https" else lowered
+    raise ValueError("source.type must be rtsp or http")
+
+
+def parse_source_codec(value: str) -> str:
+    lowered = value.lower()
+    if lowered in {"h264", "h.264"}:
+        return "h264"
+    if lowered in {"mjpeg", "jpeg"}:
+        return "mjpeg"
+    raise ValueError("source.codec must be h264 or mjpeg")
+
+
 def validate_config(cfg: AppConfig) -> None:
-    if not cfg.rtsp_url:
-        raise ValueError("source.rtsp_url must be set")
+    if not cfg.source_url:
+        raise ValueError("source.url or source.rtsp_url must be set")
     if not cfg.model_path:
         raise ValueError("model.path must be set")
     if not str(cfg.labels_path):
@@ -220,6 +240,12 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("output.insight.host must be set")
     if cfg.latency_ms < 0:
         raise ValueError("source.latency_ms must be >= 0")
+    if cfg.source_fps < 0:
+        raise ValueError("source.fps must be >= 0")
+    if cfg.source_type == "http" and cfg.source_codec != "mjpeg":
+        raise ValueError("source.codec must be mjpeg for source.type=http")
+    if cfg.source_type == "http" and cfg.source_fps <= 0:
+        raise ValueError("source.fps must be > 0 for HTTP MJPEG sources")
     if cfg.frames < 0:
         raise ValueError("inference.frames must be >= 0")
     if not 0.0 <= cfg.min_score <= 1.0:
@@ -257,9 +283,13 @@ def load_app_config(config_path: Path) -> AppConfig:
     cfg = AppConfig(
         model_path=string_or(model, "path"),
         labels_path=Path(string_or(model, "labels", str(DEFAULT_LABELS))),
-        rtsp_url=string_or(source, "rtsp_url"),
+        source_url=string_or(source, "url", string_or(source, "rtsp_url")),
+        source_type=parse_source_type(string_or(source, "type", "rtsp")),
+        source_codec=parse_source_codec(string_or(source, "codec", "h264")),
         latency_ms=int_or(source, "latency_ms", 200),
         tcp=bool_or(source, "tcp", True),
+        source_fps=int_or(source, "fps", 0),
+        ssl_strict=bool_or(source, "ssl_strict", True),
         frames=int_or(inference, "frames", 0),
         min_score=float_or(inference, "min_score", 0.55),
         nms_iou=float_or(inference, "nms_iou", 0.60),
@@ -436,33 +466,102 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     return width, height, fps if fps > 0 else DEFAULT_FPS
 
 
-def make_source_options(cfg: AppConfig, fps: int, width: int, height: int):
+def set_output_caps(caps, fps: int, width: int, height: int) -> None:
+    if width <= 0 or height <= 0 or fps <= 0:
+        return
+    caps.enable = True
+    caps.format = pyneat.Format.NV12
+    caps.width = width
+    caps.height = height
+    caps.fps = fps
+    caps.memory = pyneat.CapsMemory.Any
+
+
+def make_rtsp_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt = pyneat.RtspDecodedInputOptions()
-    opt.url = cfg.rtsp_url
+    opt.url = cfg.source_url
     opt.latency_ms = cfg.latency_ms
     opt.tcp = cfg.tcp
-    opt.payload_type = 96
     opt.insert_queue = True
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
-    opt.auto_caps_from_stream = True
-    opt.fallback_h264_width = width
-    opt.fallback_h264_height = height
-    opt.fallback_h264_fps = fps
-    opt.output_caps.enable = True
-    opt.output_caps.format = pyneat.Format.NV12
-    opt.output_caps.width = width
-    opt.output_caps.height = height
-    opt.output_caps.fps = fps
-    opt.output_caps.memory = pyneat.CapsMemory.Any
+    opt.codec = pyneat.RtspCodec.H264 if cfg.source_codec == "h264" else pyneat.RtspCodec.MJPEG
+    if cfg.source_codec == "h264":
+        opt.payload_type = 96
+        opt.auto_caps_from_stream = True
+        opt.fallback_h264_width = width
+        opt.fallback_h264_height = height
+        opt.fallback_h264_fps = fps
+    else:
+        opt.mjpeg_payload_type = 26
+        opt.dec_width = width
+        opt.dec_height = height
+        opt.dec_fps = fps
+    set_output_caps(opt.output_caps, fps, width, height)
     return opt
 
 
-def make_model(cfg: AppConfig):
+def make_http_mjpeg_source_options(cfg: AppConfig, fps: int, width: int, height: int):
+    opt = pyneat.HttpMjpegDecodedInputOptions()
+    opt.url = cfg.source_url
+    opt.decoder_name = "decoder"
+    opt.decoder_raw_output = True
+    opt.dec_fps = fps
+    opt.ssl_strict = cfg.ssl_strict
+    set_output_caps(opt.output_caps, fps, width, height)
+    return opt
+
+
+def make_source_graph(cfg: AppConfig, fps: int, width: int, height: int):
+    if cfg.source_type == "rtsp":
+        return pyneat.groups.rtsp_decoded_input(make_rtsp_source_options(cfg, fps, width, height))
+    return pyneat.groups.http_mjpeg_decoded_input(
+        make_http_mjpeg_source_options(cfg, fps, width, height)
+    )
+
+
+def probe_decoded_source(cfg: AppConfig) -> tuple[int, int, int]:
+    fps = cfg.source_fps
+    graph = pyneat.Graph("source_probe")
+    graph.add(make_source_graph(cfg, fps, 0, 0))
+    graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(1)))
+
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 3
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
+    run = graph.build(run_options)
+    try:
+        sample = run.pull("frame", 20000)
+    finally:
+        run.close()
+    if sample is None:
+        raise RuntimeError("failed to probe decoded source frame")
+    tensors = extract_tensors(sample)
+    if not tensors:
+        raise RuntimeError("decoded source probe did not produce a tensor")
+    return tensor_dim(tensors[0], "width"), tensor_dim(tensors[0], "height"), fps
+
+
+def resolve_source_geometry(cfg: AppConfig) -> tuple[int, int, int]:
+    if cfg.source_type == "rtsp":
+        width, height, fps = probe_rtsp(cfg.source_url)
+        return width, height, cfg.source_fps if cfg.source_fps > 0 else fps
+    width, height, fps = probe_decoded_source(cfg)
+    if cfg.source_type == "rtsp" and fps <= 0:
+        fps = DEFAULT_FPS
+    return width, height, fps
+
+
+def make_model(cfg: AppConfig, frame_w: int, frame_h: int):
     opt = pyneat.ModelOptions()
     opt.preprocess.kind = pyneat.InputKind.Image
     opt.preprocess.enable = pyneat.AutoFlag.On
     opt.preprocess.color_convert.input_format = pyneat.PreprocessColorFormat.NV12
+    if frame_w > 0 and frame_h > 0:
+        opt.preprocess.input_max_width = frame_w
+        opt.preprocess.input_max_height = frame_h
     opt.preprocess.preset = pyneat.NormalizePreset.COCO_YOLO
     opt.decode_type = pyneat.BoxDecodeType.YoloV26Seg
     opt.score_threshold = cfg.min_score
@@ -510,11 +609,11 @@ def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
 
 
 def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
-    frame_w, frame_h, fps = probe_rtsp(cfg.rtsp_url)
-    model = make_model(cfg)
+    frame_w, frame_h, fps = resolve_source_geometry(cfg)
+    model = make_model(cfg, frame_w, frame_h)
     labels = load_labels(cfg.labels_path)
 
-    source = pyneat.groups.rtsp_decoded_input(make_source_options(cfg, fps, frame_w, frame_h))
+    source = make_source_graph(cfg, fps, frame_w, frame_h)
     branch = pyneat.graphs.branch("source", ["frame", "model"])
 
     frame_graph = pyneat.Graph("frame")
@@ -550,7 +649,8 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     video_graph, video_run, video_port = build_video_graph(cfg, frame_w, frame_h, fps)
     metadata_sender = build_metadata_sender(cfg)
     print(
-        f"rtsp={cfg.rtsp_url} stream={frame_w}x{frame_h}@{fps} "
+        f"source={cfg.source_url} type={cfg.source_type} codec={cfg.source_codec} "
+        f"stream={frame_w}x{frame_h}@{fps} "
         f"insight={cfg.insight_host} video={video_port} "
         f"metadata={metadata_sender.metadata_port()} channel=0"
     )

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -422,23 +422,13 @@ simaai::neat::InputOptions h264_encoded_input_options() {
 simaai::neat::Graph
 build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOptions& opt) {
   simaai::neat::Graph source("rtsp_encoded_source");
-  const bool use_auto_caps = opt.auto_caps_from_stream &&
-                             (opt.h264_fps <= 0 || opt.h264_width <= 0 || opt.h264_height <= 0);
-  const bool insert_queue = opt.insert_queue && !opt.sync_mode;
-  source.add(simaai::neat::nodes::RTSPInput(opt.url, opt.latency_ms, opt.tcp));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  source.add(simaai::neat::nodes::H264Depacketize(opt.payload_type, opt.h264_parse_config_interval,
-                                                  opt.h264_fps, opt.h264_width, opt.h264_height,
-                                                  /*enforce_h264_caps=*/!use_auto_caps));
-  if (insert_queue) {
-    source.add(simaai::neat::nodes::Queue());
-  }
-  if (use_auto_caps) {
-    source.add(simaai::neat::nodes::H264CapsFixup(opt.fallback_h264_fps, opt.fallback_h264_width,
-                                                  opt.fallback_h264_height));
-  }
+
+  simaai::neat::nodes::groups::RtspEncodedInputOptions encoded_opt;
+  encoded_opt.url = opt.url;
+  encoded_opt.codec = simaai::neat::nodes::groups::RtspCodec::H264;
+  encoded_opt.latency_ms = opt.latency_ms;
+  encoded_opt.tcp = opt.tcp;
+  source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded_opt));
   source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
   return source;
 }

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -412,31 +412,13 @@ def output_caps_enabled(caps) -> bool:
 
 def build_encoded_source_graph(opt) -> pyneat.Graph:
     source = pyneat.Graph("rtsp_encoded_source")
-    use_auto_caps = opt.auto_caps_from_stream and (
-        opt.h264_fps <= 0 or opt.h264_width <= 0 or opt.h264_height <= 0
-    )
-    insert_queue = opt.insert_queue and not opt.sync_mode
-    source.add(pyneat.nodes.rtsp_input(opt.url, opt.latency_ms, opt.tcp))
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    source.add(
-        pyneat.nodes.h264_depacketize(
-            payload_type=opt.payload_type,
-            h264_parse_config_interval=opt.h264_parse_config_interval,
-            h264_fps=opt.h264_fps,
-            h264_width=opt.h264_width,
-            h264_height=opt.h264_height,
-            enforce_h264_caps=not use_auto_caps,
-        )
-    )
-    if insert_queue:
-        source.add(pyneat.nodes.queue())
-    if use_auto_caps:
-        source.add(
-            pyneat.nodes.h264_caps_fixup(
-                opt.fallback_h264_fps, opt.fallback_h264_width, opt.fallback_h264_height
-            )
-        )
+
+    encoded_opt = pyneat.RtspEncodedInputOptions()
+    encoded_opt.url = opt.url
+    encoded_opt.codec = pyneat.RtspCodec.H264
+    encoded_opt.latency_ms = opt.latency_ms
+    encoded_opt.tcp = opt.tcp
+    source.add(pyneat.groups.rtsp_encoded_input(encoded_opt))
     source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
     return source
 


### PR DESCRIPTION
## Summary

Adopt the Core codec-aware input groups in the single-stream Apps examples.

This PR updates the single-stream YOLO26 detector and single-stream instance segmenter so they can ingest:

- RTSP H.264 via `RtspDecodedInput(H264)`
- RTSP MJPEG via `RtspDecodedInput(MJPEG)`
- HTTP MJPEG via `HttpMjpegDecodedInput`

The branch is based on the prior Apps codec-aware input branch, so it also includes the already reviewed `RtspEncodedInput(H264)` adoption for the H.264 multi-stream examples.

## What Changed

- Added `source.type`, `source.codec`, `source.url`, `source.fps`, and `source.ssl_strict` handling to the single-stream detector and segmenter examples.
- Preserved legacy `source.rtsp_url` behavior for existing H.264 RTSP configs when `source.url` is empty.
- Switched single-stream source construction to Core decoded input groups instead of Apps-owned RTSP-only source wiring.
- Added a small Apps-side `ffprobe` pass to resolve source width, height, and FPS when `source.fps: 0`.
- Kept explicit `source.fps` authoritative when provided.
- Kept MJPEG strict: RTSP/HTTP MJPEG must have explicit FPS or probeable FPS metadata; the examples do not invent a default FPS.
- Uses decoded NV12 frames as the source boundary for model input, Insight preview video, and optional frame saving.
- Sends Insight preview video through `VideoSender(H264RtpUdpFromRaw)`, so RTSP MJPEG and HTTP MJPEG inputs still produce H.264 preview output for Insight.
- Updated README/config docs for the supported RTSP H.264, RTSP MJPEG, and HTTP MJPEG input modes.

## User Impact

Users can run the same single-stream detector or segmenter with H.264 RTSP, MJPEG RTSP, or HTTP MJPEG sources by changing config values instead of changing example code.

For FAEs and field users, common streams with valid metadata can work with `source.fps: 0`; MJPEG streams that do not expose FPS fail with a clear message asking for `source.fps`.

Existing H.264 RTSP configs using `source.rtsp_url` continue to work.

## Validation

- Ran `clang-format` on the changed C++ entrypoints.
- Ran `python3 -m py_compile` on the changed Python entrypoints.
- Ran `git diff --check`.

Focused SDK build and Modalix runtime validation are still expected before merge.

Refs #302
Refs #305
