### PR TITLE
Align Apps examples with source_fps

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -391,6 +391,7 @@ build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out,
     height_out = probe.height;
   }
   if (probe.fps > 0) {
+    opt.source_fps = probe.fps;
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
@@ -425,6 +426,7 @@ build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOp
   encoded_opt.codec = simaai::neat::nodes::groups::RtspCodec::H264;
   encoded_opt.latency_ms = opt.latency_ms;
   encoded_opt.tcp = opt.tcp;
+  encoded_opt.source_fps = opt.source_fps;
   source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded_opt));
   source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
   return source;
@@ -437,7 +439,9 @@ build_decode_model_graph(const std::string& input_name, const std::string& outpu
   simaai::neat::Graph decode("decode_model");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps;
+  const int dec_fps = (opt.source_fps > 0)
+                          ? opt.source_fps
+                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
 
   decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
@@ -477,7 +481,9 @@ build_save_frame_graph(const std::string& input_name,
   simaai::neat::Graph save("save_frame");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps;
+  const int dec_fps = (opt.source_fps > 0)
+                          ? opt.source_fps
+                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
 
   save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -439,9 +439,7 @@ build_decode_model_graph(const std::string& input_name, const std::string& outpu
   simaai::neat::Graph decode("decode_model");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.source_fps > 0)
-                          ? opt.source_fps
-                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
+  const int dec_fps = opt.source_fps;
 
   decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
@@ -481,9 +479,7 @@ build_save_frame_graph(const std::string& input_name,
   simaai::neat::Graph save("save_frame");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.source_fps > 0)
-                          ? opt.source_fps
-                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
+  const int dec_fps = opt.source_fps;
 
   save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -392,7 +392,6 @@ build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out,
   }
   if (probe.fps > 0) {
     opt.source_fps = probe.fps;
-    opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
   if (width_out > 0 && height_out > 0 && fps_out > 0) {
@@ -439,12 +438,11 @@ build_decode_model_graph(const std::string& input_name, const std::string& outpu
   simaai::neat::Graph decode("decode_model");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = opt.source_fps;
 
   decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
                                              opt.decoder_name, opt.decoder_raw_output,
-                                             opt.decoder_next_element, dec_w, dec_h, dec_fps));
+                                             opt.decoder_next_element, dec_w, dec_h));
   if (opt.use_videoconvert) {
     decode.add(simaai::neat::nodes::VideoConvert());
   }
@@ -479,12 +477,11 @@ build_save_frame_graph(const std::string& input_name,
   simaai::neat::Graph save("save_frame");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = opt.source_fps;
 
   save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
                                            opt.decoder_name, opt.decoder_raw_output,
-                                           opt.decoder_next_element, dec_w, dec_h, dec_fps));
+                                           opt.decoder_next_element, dec_w, dec_h));
   if (output_caps_enabled(opt.output_caps)) {
     const auto& caps = opt.output_caps;
     save.add(

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -386,7 +386,6 @@ def build_source_options(cfg: AppConfig, url: str, fps: int, width: int, height:
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.source_fps = fps
-    opt.fallback_h264_fps = fps
     opt.output_caps.enable = True
     opt.output_caps.format = pyneat.Format.NV12
     opt.output_caps.width = width
@@ -424,7 +423,6 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
     decode = pyneat.Graph("decode_model")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps
 
     decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     decode.add(
@@ -436,7 +434,6 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
             next_element=opt.decoder_next_element,
             dec_width=dec_w,
             dec_height=dec_h,
-            dec_fps=dec_fps,
         )
     )
     if opt.use_videoconvert:
@@ -471,7 +468,6 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
     save = pyneat.Graph("save_frame")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps
 
     save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     save.add(
@@ -483,7 +479,6 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
             next_element=opt.decoder_next_element,
             dec_width=dec_w,
             dec_height=dec_h,
-            dec_fps=dec_fps,
         )
     )
     if output_caps_enabled(opt.output_caps):

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -385,6 +385,7 @@ def build_source_options(cfg: AppConfig, url: str, fps: int, width: int, height:
     opt.auto_caps_from_stream = True
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
+    opt.source_fps = fps
     opt.fallback_h264_fps = fps
     opt.output_caps.enable = True
     opt.output_caps.format = pyneat.Format.NV12
@@ -407,6 +408,7 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
     encoded_opt.codec = pyneat.RtspCodec.H264
     encoded_opt.latency_ms = opt.latency_ms
     encoded_opt.tcp = opt.tcp
+    encoded_opt.source_fps = opt.source_fps
     source.add(pyneat.groups.rtsp_encoded_input(encoded_opt))
     source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
     return source
@@ -422,7 +424,9 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
     decode = pyneat.Graph("decode_model")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    dec_fps = opt.source_fps if opt.source_fps > 0 else (
+        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    )
 
     decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     decode.add(
@@ -469,7 +473,9 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
     save = pyneat.Graph("save_frame")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    dec_fps = opt.source_fps if opt.source_fps > 0 else (
+        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    )
 
     save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     save.add(

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -424,9 +424,7 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
     decode = pyneat.Graph("decode_model")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps if opt.source_fps > 0 else (
-        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
-    )
+    dec_fps = opt.source_fps
 
     decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     decode.add(
@@ -473,9 +471,7 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
     save = pyneat.Graph("save_frame")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps if opt.source_fps > 0 else (
-        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
-    )
+    dec_fps = opt.source_fps
 
     save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     save.add(

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -417,18 +417,17 @@ make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
   opt.decoder_name = "decoder";
   opt.decoder_raw_output = true;
   opt.auto_caps_from_stream = true;
+  opt.source_fps = geometry.fps;
   opt.codec = cfg.source_codec == SourceCodec::H264 ? simaai::neat::nodes::groups::RtspCodec::H264
                                                     : simaai::neat::nodes::groups::RtspCodec::MJPEG;
   if (cfg.source_codec == SourceCodec::H264) {
     opt.payload_type = 96;
     opt.fallback_h264_width = geometry.width;
     opt.fallback_h264_height = geometry.height;
-    opt.fallback_h264_fps = geometry.fps;
   } else {
     opt.mjpeg_payload_type = 26;
     opt.dec_width = geometry.width;
     opt.dec_height = geometry.height;
-    opt.dec_fps = geometry.fps;
   }
   if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
     opt.output_caps.enable = true;
@@ -447,7 +446,7 @@ make_http_mjpeg_source_options(const AppConfig& cfg, const SourceGeometry& geome
   opt.url = cfg.source_url;
   opt.decoder_name = "decoder";
   opt.decoder_raw_output = true;
-  opt.dec_fps = geometry.fps;
+  opt.source_fps = geometry.fps;
   opt.ssl_strict = cfg.ssl_strict;
   if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
     opt.output_caps.enable = true;

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -433,18 +433,17 @@ def make_rtsp_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt.insert_queue = True
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
+    opt.source_fps = fps
     opt.codec = pyneat.RtspCodec.H264 if cfg.source_codec == "h264" else pyneat.RtspCodec.MJPEG
     if cfg.source_codec == "h264":
         opt.payload_type = 96
         opt.auto_caps_from_stream = True
         opt.fallback_h264_width = width
         opt.fallback_h264_height = height
-        opt.fallback_h264_fps = fps
     else:
         opt.mjpeg_payload_type = 26
         opt.dec_width = width
         opt.dec_height = height
-        opt.dec_fps = fps
     set_output_caps(opt.output_caps, fps, width, height)
     return opt
 
@@ -454,7 +453,7 @@ def make_http_mjpeg_source_options(cfg: AppConfig, fps: int, width: int, height:
     opt.url = cfg.source_url
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
-    opt.dec_fps = fps
+    opt.source_fps = fps
     opt.ssl_strict = cfg.ssl_strict
     set_output_caps(opt.output_caps, fps, width, height)
     return opt
@@ -548,6 +547,11 @@ def make_model(cfg: AppConfig, frame_w: int, frame_h: int):
 
 def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     frame_w, frame_h, fps = resolve_source_geometry(cfg)
+    if fps <= 0:
+        raise RuntimeError(
+            "failed to resolve source frame rate; set source.fps or use a source with "
+            "probeable FPS metadata"
+        )
     model = make_model(cfg, frame_w, frame_h)
     labels = load_labels(cfg.labels_path)
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -477,17 +477,16 @@ make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
   opt.decoder_raw_output = true;
   opt.codec = cfg.source_codec == SourceCodec::H264 ? simaai::neat::nodes::groups::RtspCodec::H264
                                                     : simaai::neat::nodes::groups::RtspCodec::MJPEG;
+  opt.source_fps = geometry.fps;
   if (cfg.source_codec == SourceCodec::H264) {
     opt.payload_type = 96;
     opt.auto_caps_from_stream = true;
     opt.fallback_h264_width = geometry.width;
     opt.fallback_h264_height = geometry.height;
-    opt.fallback_h264_fps = geometry.fps;
   } else {
     opt.mjpeg_payload_type = 26;
     opt.dec_width = geometry.width;
     opt.dec_height = geometry.height;
-    opt.dec_fps = geometry.fps;
   }
   if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
     opt.output_caps.enable = true;
@@ -506,7 +505,7 @@ make_http_mjpeg_source_options(const AppConfig& cfg, const SourceGeometry& geome
   opt.url = cfg.source_url;
   opt.decoder_name = "decoder";
   opt.decoder_raw_output = true;
-  opt.dec_fps = geometry.fps;
+  opt.source_fps = geometry.fps;
   opt.ssl_strict = cfg.ssl_strict;
   if (geometry.width > 0 && geometry.height > 0 && geometry.fps > 0) {
     opt.output_caps.enable = true;

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -536,17 +536,16 @@ def make_rtsp_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
     opt.codec = pyneat.RtspCodec.H264 if cfg.source_codec == "h264" else pyneat.RtspCodec.MJPEG
+    opt.source_fps = fps
     if cfg.source_codec == "h264":
         opt.payload_type = 96
         opt.auto_caps_from_stream = True
         opt.fallback_h264_width = width
         opt.fallback_h264_height = height
-        opt.fallback_h264_fps = fps
     else:
         opt.mjpeg_payload_type = 26
         opt.dec_width = width
         opt.dec_height = height
-        opt.dec_fps = fps
     set_output_caps(opt.output_caps, fps, width, height)
     return opt
 
@@ -556,7 +555,7 @@ def make_http_mjpeg_source_options(cfg: AppConfig, fps: int, width: int, height:
     opt.url = cfg.source_url
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
-    opt.dec_fps = fps
+    opt.source_fps = fps
     opt.ssl_strict = cfg.ssl_strict
     set_output_caps(opt.output_caps, fps, width, height)
     return opt
@@ -652,11 +651,11 @@ def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
     input_opt.width = width
     input_opt.height = height
     input_opt.depth = 3
-    input_opt.fps_n = max(1, fps)
+    input_opt.fps_n = fps
     input_opt.fps_d = 1
     input_opt.memory_policy = pyneat.InputMemoryPolicy.Ev74
 
-    sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, max(1, fps))
+    sender_opt = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, fps)
     sender_opt.host = cfg.insight_host
     sender_opt.channel = 0
     sender_opt.video_port_base = cfg.video_port
@@ -677,6 +676,11 @@ def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
 
 def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     frame_w, frame_h, fps = resolve_source_geometry(cfg)
+    if fps <= 0:
+        raise RuntimeError(
+            "failed to resolve source frame rate; set source.fps or use a source with "
+            "probeable FPS metadata"
+        )
     model = make_model(cfg, frame_w, frame_h)
     labels = load_labels(cfg.labels_path)
 

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -394,6 +394,7 @@ build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out,
     height_out = probe.height;
   }
   if (probe.fps > 0) {
+    opt.source_fps = probe.fps;
     opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
@@ -428,6 +429,7 @@ build_encoded_source_graph(const simaai::neat::nodes::groups::RtspDecodedInputOp
   encoded_opt.codec = simaai::neat::nodes::groups::RtspCodec::H264;
   encoded_opt.latency_ms = opt.latency_ms;
   encoded_opt.tcp = opt.tcp;
+  encoded_opt.source_fps = opt.source_fps;
   source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded_opt));
   source.add(simaai::neat::nodes::Output("encoded", simaai::neat::OutputOptions::EveryFrame(3)));
   return source;
@@ -440,7 +442,9 @@ build_decode_model_graph(const std::string& input_name, const std::string& outpu
   simaai::neat::Graph decode("decode_model");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps;
+  const int dec_fps = (opt.source_fps > 0)
+                          ? opt.source_fps
+                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
 
   decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
@@ -480,7 +484,9 @@ build_save_frame_graph(const std::string& input_name,
   simaai::neat::Graph save("save_frame");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps;
+  const int dec_fps = (opt.source_fps > 0)
+                          ? opt.source_fps
+                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
 
   save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -442,9 +442,7 @@ build_decode_model_graph(const std::string& input_name, const std::string& outpu
   simaai::neat::Graph decode("decode_model");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.source_fps > 0)
-                          ? opt.source_fps
-                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
+  const int dec_fps = opt.source_fps;
 
   decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
@@ -484,9 +482,7 @@ build_save_frame_graph(const std::string& input_name,
   simaai::neat::Graph save("save_frame");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = (opt.source_fps > 0)
-                          ? opt.source_fps
-                          : ((opt.h264_fps > 0) ? opt.h264_fps : opt.fallback_h264_fps);
+  const int dec_fps = opt.source_fps;
 
   save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -395,7 +395,6 @@ build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out,
   }
   if (probe.fps > 0) {
     opt.source_fps = probe.fps;
-    opt.fallback_h264_fps = probe.fps;
     fps_out = probe.fps;
   }
   if (width_out > 0 && height_out > 0 && fps_out > 0) {
@@ -442,12 +441,11 @@ build_decode_model_graph(const std::string& input_name, const std::string& outpu
   simaai::neat::Graph decode("decode_model");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = opt.source_fps;
 
   decode.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   decode.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
                                              opt.decoder_name, opt.decoder_raw_output,
-                                             opt.decoder_next_element, dec_w, dec_h, dec_fps));
+                                             opt.decoder_next_element, dec_w, dec_h));
   if (opt.use_videoconvert) {
     decode.add(simaai::neat::nodes::VideoConvert());
   }
@@ -482,12 +480,11 @@ build_save_frame_graph(const std::string& input_name,
   simaai::neat::Graph save("save_frame");
   const int dec_w = (opt.h264_width > 0) ? opt.h264_width : opt.fallback_h264_width;
   const int dec_h = (opt.h264_height > 0) ? opt.h264_height : opt.fallback_h264_height;
-  const int dec_fps = opt.source_fps;
 
   save.add(simaai::neat::nodes::Input(input_name, h264_encoded_input_options()));
   save.add(simaai::neat::nodes::H264Decode(opt.sima_allocator_type, opt.out_format,
                                            opt.decoder_name, opt.decoder_raw_output,
-                                           opt.decoder_next_element, dec_w, dec_h, dec_fps));
+                                           opt.decoder_next_element, dec_w, dec_h));
   if (output_caps_enabled(opt.output_caps)) {
     const auto& caps = opt.output_caps;
     save.add(

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -396,6 +396,7 @@ def build_source_options(cfg: AppConfig, url: str, fps: int, width: int, height:
     opt.auto_caps_from_stream = True
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
+    opt.source_fps = fps
     opt.fallback_h264_fps = fps
     opt.output_caps.enable = True
     opt.output_caps.format = pyneat.Format.NV12
@@ -418,6 +419,7 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
     encoded_opt.codec = pyneat.RtspCodec.H264
     encoded_opt.latency_ms = opt.latency_ms
     encoded_opt.tcp = opt.tcp
+    encoded_opt.source_fps = opt.source_fps
     source.add(pyneat.groups.rtsp_encoded_input(encoded_opt))
     source.add(pyneat.nodes.output("encoded", pyneat.OutputOptions.every_frame(3)))
     return source
@@ -433,7 +435,9 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
     decode = pyneat.Graph("decode_model")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    dec_fps = opt.source_fps if opt.source_fps > 0 else (
+        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    )
 
     decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     decode.add(
@@ -480,7 +484,9 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
     save = pyneat.Graph("save_frame")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    dec_fps = opt.source_fps if opt.source_fps > 0 else (
+        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
+    )
 
     save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     save.add(

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -435,9 +435,7 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
     decode = pyneat.Graph("decode_model")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps if opt.source_fps > 0 else (
-        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
-    )
+    dec_fps = opt.source_fps
 
     decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     decode.add(
@@ -484,9 +482,7 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
     save = pyneat.Graph("save_frame")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps if opt.source_fps > 0 else (
-        opt.h264_fps if opt.h264_fps > 0 else opt.fallback_h264_fps
-    )
+    dec_fps = opt.source_fps
 
     save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     save.add(

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -397,7 +397,6 @@ def build_source_options(cfg: AppConfig, url: str, fps: int, width: int, height:
     opt.fallback_h264_width = width
     opt.fallback_h264_height = height
     opt.source_fps = fps
-    opt.fallback_h264_fps = fps
     opt.output_caps.enable = True
     opt.output_caps.format = pyneat.Format.NV12
     opt.output_caps.width = width
@@ -435,7 +434,6 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
     decode = pyneat.Graph("decode_model")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps
 
     decode.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     decode.add(
@@ -447,7 +445,6 @@ def build_decode_model_graph(input_name: str, output_name: str, opt, model) -> p
             next_element=opt.decoder_next_element,
             dec_width=dec_w,
             dec_height=dec_h,
-            dec_fps=dec_fps,
         )
     )
     if opt.use_videoconvert:
@@ -482,7 +479,6 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
     save = pyneat.Graph("save_frame")
     dec_w = opt.h264_width if opt.h264_width > 0 else opt.fallback_h264_width
     dec_h = opt.h264_height if opt.h264_height > 0 else opt.fallback_h264_height
-    dec_fps = opt.source_fps
 
     save.add(pyneat.nodes.input(input_name, h264_encoded_input_options()))
     save.add(
@@ -494,7 +490,6 @@ def build_save_frame_graph(input_name: str, opt) -> pyneat.Graph:
             next_element=opt.decoder_next_element,
             dec_width=dec_w,
             dec_height=dec_h,
-            dec_fps=dec_fps,
         )
     )
     if output_caps_enabled(opt.output_caps):


### PR DESCRIPTION
## Why

Apps users should see the current Core codec input contract in the examples. Core exposes `source_fps` as the source cadence field for RTSP encoded, RTSP decoded, and HTTP MJPEG decoded inputs. Decoder FPS fields and H.264 fallback FPS are no longer the normal way to declare source cadence.

The Python single-stream examples also need to fail clearly when source FPS cannot be resolved, instead of building a raw video sender with `0` FPS or silently substituting `1` FPS.

## What Changed

- Pass resolved source FPS through `source_fps` in the single-stream detector and segmenter for RTSP H.264, RTSP MJPEG, and HTTP MJPEG inputs.
- Keep `output_caps.fps` as tail caps only when output caps are enabled.
- Pass `source_fps` into `RtspEncodedInput(H264)` in the H.264 multi-stream detector and tracker source graphs.
- Stop passing decoder FPS manually in the multi-stream H.264 decode/save branches; the decoder consumes FPS from the encoded source caps.
- Add Python FPS guards matching the C++ examples before constructing raw video sender graphs.

## Validation

- `python3 -m py_compile examples/object-detection/single-stream-object-detector/src/python/main.py examples/segmentation/single-stream-instance-segmenter/src/python/main.py examples/object-detection/multi-stream-object-detector/src/python/main.py examples/tracking/multi-stream-people-tracker/src/python/main.py`
- `clang-format --dry-run --Werror examples/object-detection/single-stream-object-detector/src/cpp/main.cpp examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp`
- `git diff --check`

## Notes

This PR does not change graph topology, configs, README content, or runtime test coverage. It is a focused follow-up to align Apps examples with the final Core FPS contract.

Refs #309
