### PR TITLE
Expose inflight limits in multi-stream examples

### DIFF
--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -90,6 +90,8 @@ streams:
 
 inference:
   frames: 0                                            # Frame limit per stream. 0 runs continuously.
+  max_inflight_per_stream: 4                           # Raw frames admitted per stream to the detector.
+  max_inflight_total: 16                               # Raw frames admitted across detector streams.
   min_score: 0.30                                      # Minimum object confidence.
 
 output:
@@ -126,6 +128,7 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-str
 ## Debugging Notes
 - The checked-in `src/common/config.yaml` includes four placeholder stream slots. Replace the RTSP URLs and Insight host before running.
 - This phase supports up to four active streams.
+- `max_inflight_per_stream` and `max_inflight_total` tune raw decoder-backed frame admission at the shared detector fan-in. Set either to `-1` to use Core defaults.
 - On Modalix DevKit, start with `bash /usr/bin/fix_devkit_runtime.sh`. If the runtime still behaves inconsistently, a full board reboot has been a more reliable reset than service restarts alone.
 - `output.debug_dir` and `output.save_every` let you save periodic aligned debug frames locally without changing the Insight output contract.
 - Profiling prints per-stream pull, metadata, output FPS, and detection-count summaries.

--- a/examples/object-detection/multi-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/multi-stream-object-detector/src/common/config.yaml
@@ -18,6 +18,8 @@ runtime:                     # Runtime and profiling settings.
 inference:                   # Detection controls.
   frames: 0                  # Frame limit per stream. 0 means unlimited.
   fps: 0                     # Max per-stream processing and output FPS. 0 means use source FPS.
+  max_inflight_per_stream: 4 # Raw decoder-backed frames admitted per stream to the shared detector.
+  max_inflight_total: 16     # Raw decoder-backed frames admitted across all detector streams.
   min_score: 0.30            # Detection score threshold.
   nms_iou: 0.60              # NMS IoU threshold.
   max_detections: 50         # Max detections to keep per frame after NMS.

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -58,6 +58,8 @@ struct AppConfig {
   bool tcp = true;
   int frames = 0;
   int fps = 0;
+  int max_inflight_per_stream = 4;
+  int max_inflight_total = 16;
   double min_score = 0.55;
   double nms_iou = 0.60;
   int max_detections = 50;
@@ -244,6 +246,10 @@ void validate_config(const AppConfig& cfg) {
   sima_examples::require(cfg.latency_ms >= 0, "input.latency_ms must be >= 0");
   sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
   sima_examples::require(cfg.fps >= 0, "inference.fps must be >= 0");
+  sima_examples::require(cfg.max_inflight_per_stream == -1 || cfg.max_inflight_per_stream > 0,
+                         "inference.max_inflight_per_stream must be -1 or > 0");
+  sima_examples::require(cfg.max_inflight_total == -1 || cfg.max_inflight_total > 0,
+                         "inference.max_inflight_total must be -1 or > 0");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
   sima_examples::require(cfg.nms_iou >= 0.0 && cfg.nms_iou <= 1.0,
@@ -269,6 +275,8 @@ AppConfig load_app_config(const fs::path& config_path) {
   cfg.latency_ms = raw.int_or("input.latency_ms", 100);
   cfg.frames = raw.int_or("inference.frames", 0);
   cfg.fps = raw.int_or("inference.fps", 0);
+  cfg.max_inflight_per_stream = raw.int_or("inference.max_inflight_per_stream", 4);
+  cfg.max_inflight_total = raw.int_or("inference.max_inflight_total", 16);
   cfg.min_score = raw.double_or("inference.min_score", 0.55);
   cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
   cfg.max_detections = raw.int_or("inference.max_detections", 50);
@@ -539,8 +547,8 @@ int stream_index_from_sample(const simaai::neat::Sample& sample, int stream_coun
 }
 
 simaai::neat::GraphLinkOptions realtime_link(int stream_index, int queue_depth,
-                                             int max_inflight_per_stream = 4,
-                                             int max_inflight_total = 16) {
+                                             int max_inflight_per_stream = -1,
+                                             int max_inflight_total = -1) {
   simaai::neat::GraphLinkOptions link;
   link.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   link.queue_depth = queue_depth;
@@ -648,8 +656,10 @@ void connect_stream_graph(AppRuntime& app, const AppConfig& cfg, const StreamRun
   auto decoded_branch =
       save_debug_frames ? simaai::neat::graphs::Branch("decoded", {"detector_frame", "debug_frame"})
                         : simaai::neat::graphs::Branch("decoded", {"detector_frame"});
-  app.graph.connect(decoder, decoded_branch, realtime_link(stream.index, 4));
-  app.graph.connect(decoded_branch, detector_graph, realtime_link(stream.index, 4));
+  app.graph.connect(decoder, decoded_branch);
+  app.graph.connect(
+      decoded_branch, detector_graph,
+      realtime_link(stream.index, 4, cfg.max_inflight_per_stream, cfg.max_inflight_total));
   if (save_debug_frames) {
     app.graph.connect(decoded_branch, build_debug_frame_graph(stream.index),
                       realtime_link(stream.index, 4));
@@ -841,7 +851,8 @@ int main(int argc, char** argv) {
     const AppConfig cfg = load_app_config(cli.config_path);
     if (cli.validate_config_only) {
       std::cout << "Config validated: " << cli.config_path << " (streams=" << cfg.rtsp_urls.size()
-                << ")\n";
+                << ", max_inflight_per_stream=" << cfg.max_inflight_per_stream
+                << ", max_inflight_total=" << cfg.max_inflight_total << ")\n";
       return 0;
     }
     run_app(cfg);

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -30,6 +30,8 @@ class AppConfig:
     tcp: bool = True
     frames: int = 0
     fps: int = 0
+    max_inflight_per_stream: int = 4
+    max_inflight_total: int = 16
     min_score: float = 0.55
     nms_iou: float = 0.60
     max_detections: int = 50
@@ -200,6 +202,10 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("inference.frames must be >= 0")
     if cfg.fps < 0:
         raise ValueError("inference.fps must be >= 0")
+    if cfg.max_inflight_per_stream != -1 and cfg.max_inflight_per_stream <= 0:
+        raise ValueError("inference.max_inflight_per_stream must be -1 or > 0")
+    if cfg.max_inflight_total != -1 and cfg.max_inflight_total <= 0:
+        raise ValueError("inference.max_inflight_total must be -1 or > 0")
     if not 0.0 <= cfg.min_score <= 1.0:
         raise ValueError("inference.min_score must be between 0 and 1")
     if not 0.0 <= cfg.nms_iou <= 1.0:
@@ -246,6 +252,8 @@ def load_app_config(config_path: Path) -> AppConfig:
         tcp=bool_or(input_cfg, "tcp", True),
         frames=int_or(inference, "frames", 0),
         fps=int_or(inference, "fps", 0),
+        max_inflight_per_stream=int_or(inference, "max_inflight_per_stream", 4),
+        max_inflight_total=int_or(inference, "max_inflight_total", 16),
         min_score=float_or(inference, "min_score", 0.55),
         nms_iou=float_or(inference, "nms_iou", 0.60),
         max_detections=int_or(inference, "max_detections", 50),
@@ -530,8 +538,8 @@ def stream_index_from_sample(sample, stream_count: int) -> int:
 def realtime_link(
     stream_index: int,
     queue_depth: int,
-    max_inflight_per_stream: int = 4,
-    max_inflight_total: int = 16,
+    max_inflight_per_stream: int = -1,
+    max_inflight_total: int = -1,
 ):
     link = pyneat.GraphLinkOptions()
     link.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
@@ -637,8 +645,17 @@ def connect_stream_graph(
     save_debug_frames = save_frames_enabled(cfg)
     decoded_outputs = ["detector_frame", "debug_frame"] if save_debug_frames else ["detector_frame"]
     decoded_branch = pyneat.graphs.branch("decoded", decoded_outputs)
-    app.graph.connect(decoder, decoded_branch, realtime_link(stream.index, 4))
-    app.graph.connect(decoded_branch, detector_graph, realtime_link(stream.index, 4))
+    app.graph.connect(decoder, decoded_branch)
+    app.graph.connect(
+        decoded_branch,
+        detector_graph,
+        realtime_link(
+            stream.index,
+            4,
+            cfg.max_inflight_per_stream,
+            cfg.max_inflight_total,
+        ),
+    )
     if save_debug_frames:
         app.graph.connect(
             decoded_branch, build_debug_frame_graph(stream.index), realtime_link(stream.index, 4)
@@ -842,7 +859,11 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         cfg = load_app_config(args.config)
         if args.validate_config_only:
-            print(f"Config validated: {args.config} (streams={len(cfg.rtsp_urls)})")
+            print(
+                f"Config validated: {args.config} (streams={len(cfg.rtsp_urls)}, "
+                f"max_inflight_per_stream={cfg.max_inflight_per_stream}, "
+                f"max_inflight_total={cfg.max_inflight_total})"
+            )
             return 0
 
         load_runtime_dependencies()

--- a/examples/object-detection/multi-stream-object-detector/tests/cpp/test_unit.cpp
+++ b/examples/object-detection/multi-stream-object-detector/tests/cpp/test_unit.cpp
@@ -54,42 +54,47 @@ bool test_missing_config_file_fails_cleanly(const std::string& binary) {
 }
 
 bool test_validate_config_only_accepts_four_streams(const std::string& binary) {
-  const fs::path config_path =
-      write_config("test_validate_config_only_accepts_four_streams",
-                   "model:\n"
-                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
-                   "streams:\n"
-                   "  - rtsp://127.0.0.1:8554/src1\n"
-                   "  - rtsp://127.0.0.1:8554/src2\n"
-                   "  - rtsp://127.0.0.1:8554/src3\n"
-                   "  - rtsp://127.0.0.1:8554/src4\n"
-                   "output:\n"
-                   "  insight:\n"
-                   "    host: 127.0.0.1\n");
+  const fs::path config_path = write_config("test_validate_config_only_accepts_four_streams",
+                                            "model:\n"
+                                            "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                                            "streams:\n"
+                                            "  - rtsp://127.0.0.1:8554/src1\n"
+                                            "  - rtsp://127.0.0.1:8554/src2\n"
+                                            "  - rtsp://127.0.0.1:8554/src3\n"
+                                            "  - rtsp://127.0.0.1:8554/src4\n"
+                                            "inference:\n"
+                                            "  max_inflight_per_stream: 3\n"
+                                            "  max_inflight_total: 12\n"
+                                            "output:\n"
+                                            "  insight:\n"
+                                            "    host: 127.0.0.1\n");
 
   const auto result =
       spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
   const bool ok =
       expect_true(result.exit_code == 0, "four-stream config validates") &&
-      expect_contains(result.stdout_text, "streams=4", "validate output reports stream count");
+      expect_contains(result.stdout_text, "streams=4", "validate output reports stream count") &&
+      expect_contains(result.stdout_text, "max_inflight_per_stream=3",
+                      "validate output reports per-stream inflight limit") &&
+      expect_contains(result.stdout_text, "max_inflight_total=12",
+                      "validate output reports total inflight limit");
   remove_dir(config_path.parent_path().string());
   return ok;
 }
 
 bool test_validate_config_only_rejects_too_many_streams(const std::string& binary) {
-  const fs::path config_path =
-      write_config("test_validate_config_only_rejects_too_many_streams",
-                   "model:\n"
-                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
-                   "streams:\n"
-                   "  - rtsp://127.0.0.1:8554/src1\n"
-                   "  - rtsp://127.0.0.1:8554/src2\n"
-                   "  - rtsp://127.0.0.1:8554/src3\n"
-                   "  - rtsp://127.0.0.1:8554/src4\n"
-                   "  - rtsp://127.0.0.1:8554/src5\n"
-                   "output:\n"
-                   "  insight:\n"
-                   "    host: 127.0.0.1\n");
+  const fs::path config_path = write_config("test_validate_config_only_rejects_too_many_streams",
+                                            "model:\n"
+                                            "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                                            "streams:\n"
+                                            "  - rtsp://127.0.0.1:8554/src1\n"
+                                            "  - rtsp://127.0.0.1:8554/src2\n"
+                                            "  - rtsp://127.0.0.1:8554/src3\n"
+                                            "  - rtsp://127.0.0.1:8554/src4\n"
+                                            "  - rtsp://127.0.0.1:8554/src5\n"
+                                            "output:\n"
+                                            "  insight:\n"
+                                            "    host: 127.0.0.1\n");
 
   const auto result =
       spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
@@ -101,20 +106,41 @@ bool test_validate_config_only_rejects_too_many_streams(const std::string& binar
 }
 
 bool test_validate_config_only_rejects_empty_streams(const std::string& binary) {
-  const fs::path config_path =
-      write_config("test_validate_config_only_rejects_empty_streams",
-                   "model:\n"
-                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
-                   "streams: []\n"
-                   "output:\n"
-                   "  insight:\n"
-                   "    host: 127.0.0.1\n");
+  const fs::path config_path = write_config("test_validate_config_only_rejects_empty_streams",
+                                            "model:\n"
+                                            "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                                            "streams: []\n"
+                                            "output:\n"
+                                            "  insight:\n"
+                                            "    host: 127.0.0.1\n");
 
   const auto result =
       spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
   const bool ok =
       expect_true(result.exit_code == 1, "empty stream config is rejected") &&
       expect_contains(result.stderr_text, "streams", "empty-stream error mentions streams");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+bool test_validate_config_only_rejects_invalid_inflight_limit(const std::string& binary) {
+  const fs::path config_path =
+      write_config("test_validate_config_only_rejects_invalid_inflight_limit",
+                   "model:\n"
+                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                   "streams:\n"
+                   "  - rtsp://127.0.0.1:8554/src1\n"
+                   "inference:\n"
+                   "  max_inflight_per_stream: 0\n"
+                   "output:\n"
+                   "  insight:\n"
+                   "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok = expect_true(result.exit_code == 1, "invalid inflight limit is rejected") &&
+                  expect_contains(result.stderr_text, "max_inflight_per_stream must be -1 or > 0",
+                                  "invalid inflight error names the setting");
   remove_dir(config_path.parent_path().string());
   return ok;
 }
@@ -134,5 +160,6 @@ int main(int argc, char** argv) {
   ok &= test_validate_config_only_accepts_four_streams(binary);
   ok &= test_validate_config_only_rejects_too_many_streams(binary);
   ok &= test_validate_config_only_rejects_empty_streams(binary);
+  ok &= test_validate_config_only_rejects_invalid_inflight_limit(binary);
   return ok ? 0 : 1;
 }

--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import subprocess
 import sys
 import textwrap
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,8 +22,20 @@ if str(PYTHON_DIR) not in sys.path:
 pytestmark = pytest.mark.unit
 
 
-def write_config(tmp_path: Path, streams: list[str]) -> Path:
+def write_config(
+    tmp_path: Path,
+    streams: list[str],
+    max_inflight_per_stream: int | None = None,
+    max_inflight_total: int | None = None,
+) -> Path:
     stream_lines = "\n".join(f"  - {stream}" for stream in streams)
+    inference = []
+    if max_inflight_per_stream is not None or max_inflight_total is not None:
+        inference.append("inference:")
+        if max_inflight_per_stream is not None:
+            inference.append(f"  max_inflight_per_stream: {max_inflight_per_stream}")
+        if max_inflight_total is not None:
+            inference.append(f"  max_inflight_total: {max_inflight_total}")
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         "\n".join(
@@ -31,6 +44,7 @@ def write_config(tmp_path: Path, streams: list[str]) -> Path:
                 "  path: assets/models/yolo26m-det-int8-b1.tar.gz",
                 "streams:",
                 stream_lines,
+                *inference,
                 "output:",
                 "  insight:",
                 "    host: 127.0.0.1",
@@ -88,6 +102,35 @@ class TestConfigLoading:
         assert len(cfg.rtsp_urls) == 4
         assert cfg.insight_host == "127.0.0.1"
         assert cfg.warmup_frames == 30
+        assert cfg.max_inflight_per_stream == 4
+        assert cfg.max_inflight_total == 16
+
+    def test_load_app_config_accepts_custom_inflight_limits(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = write_config(
+            tmp_path,
+            ["rtsp://127.0.0.1:8554/src1"],
+            max_inflight_per_stream=3,
+            max_inflight_total=12,
+        )
+
+        cfg = load_app_config(config_path)
+
+        assert cfg.max_inflight_per_stream == 3
+        assert cfg.max_inflight_total == 12
+
+    def test_load_app_config_rejects_invalid_inflight_limit(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = write_config(
+            tmp_path,
+            ["rtsp://127.0.0.1:8554/src1"],
+            max_inflight_per_stream=0,
+        )
+
+        with pytest.raises(ValueError, match="max_inflight_per_stream must be -1 or > 0"):
+            load_app_config(config_path)
 
     def test_load_app_config_rejects_too_many_streams(self, tmp_path: Path):
         from main import load_app_config
@@ -146,6 +189,27 @@ class TestConfigLoading:
 
         assert result.returncode == 0
         assert "streams=2" in result.stdout
+        assert "max_inflight_per_stream=4" in result.stdout
+        assert "max_inflight_total=16" in result.stdout
+
+
+class TestRuntimeOptions:
+    def test_realtime_link_sets_inflight_limits(self, monkeypatch):
+        import main
+
+        fake_pyneat = SimpleNamespace(
+            GraphLinkOptions=type("GraphLinkOptions", (), {}),
+            GraphLinkPolicy=SimpleNamespace(RealtimeLatestByStream="latest-by-stream"),
+        )
+        monkeypatch.setattr(main, "pyneat", fake_pyneat)
+
+        link = main.realtime_link(2, 4, 3, 12)
+
+        assert link.policy == "latest-by-stream"
+        assert link.queue_depth == 4
+        assert link.stream_id == "stream2"
+        assert link.max_inflight_per_stream == 3
+        assert link.max_inflight_total == 12
 
 
 class FakeMetadataSender:

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -90,6 +90,8 @@ streams:
 
 inference:
   frames: 0                                            # Frame limit per stream. 0 runs continuously.
+  max_inflight_per_stream: 4                           # Raw frames admitted per stream to the detector.
+  max_inflight_total: 16                               # Raw frames admitted across detector streams.
   min_score: 0.30                                      # Minimum person confidence.
 
 tracking:
@@ -121,6 +123,7 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
 - Start with one RTSP stream and confirm the config before scaling to multiple cameras.
 - Confirm `model.path` points to a readable model package.
 - Confirm each RTSP URL is reachable from the board or host running the example.
+- `max_inflight_per_stream` and `max_inflight_total` tune raw decoder-backed frame admission at the shared detector fan-in. Set either to `-1` to use Core defaults.
 - If Insight appears idle, verify `output.insight.host`, `video_port_base`, and `metadata_port_base`.
 - If you want saved overlay frames, set both `output.debug_dir` and `output.save_every`.
 

--- a/examples/tracking/multi-stream-people-tracker/src/common/config.yaml
+++ b/examples/tracking/multi-stream-people-tracker/src/common/config.yaml
@@ -18,6 +18,8 @@ runtime:                     # Runtime and profiling settings.
 inference:                   # Detection controls.
   frames: 0                  # Frame limit per stream. 0 means unlimited.
   fps: 0                     # Max per-stream processing and output FPS. 0 means use source FPS.
+  max_inflight_per_stream: 4 # Raw decoder-backed frames admitted per stream to the shared detector.
+  max_inflight_total: 16     # Raw decoder-backed frames admitted across all detector streams.
   person_class_id: 0         # Class id to track. COCO id 0 is person.
   min_score: 0.30            # Detection score threshold.
   nms_iou: 0.60              # NMS IoU threshold.

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -61,6 +61,8 @@ struct AppConfig {
   bool tcp = true;
   int frames = 0;
   int fps = 0;
+  int max_inflight_per_stream = 4;
+  int max_inflight_total = 16;
   int person_class_id = 0;
   double min_score = 0.55;
   double nms_iou = 0.60;
@@ -253,6 +255,10 @@ void validate_config(const AppConfig& cfg) {
   sima_examples::require(cfg.latency_ms >= 0, "input.latency_ms must be >= 0");
   sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
   sima_examples::require(cfg.fps >= 0, "inference.fps must be >= 0");
+  sima_examples::require(cfg.max_inflight_per_stream == -1 || cfg.max_inflight_per_stream > 0,
+                         "inference.max_inflight_per_stream must be -1 or > 0");
+  sima_examples::require(cfg.max_inflight_total == -1 || cfg.max_inflight_total > 0,
+                         "inference.max_inflight_total must be -1 or > 0");
   sima_examples::require(cfg.person_class_id >= 0, "inference.person_class_id must be >= 0");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
@@ -279,6 +285,8 @@ AppConfig load_app_config(const fs::path& config_path) {
   cfg.latency_ms = raw.int_or("input.latency_ms", 100);
   cfg.frames = raw.int_or("inference.frames", 0);
   cfg.fps = raw.int_or("inference.fps", 0);
+  cfg.max_inflight_per_stream = raw.int_or("inference.max_inflight_per_stream", 4);
+  cfg.max_inflight_total = raw.int_or("inference.max_inflight_total", 16);
   cfg.person_class_id = raw.int_or("inference.person_class_id", 0);
   cfg.min_score = raw.double_or("inference.min_score", 0.55);
   cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
@@ -542,8 +550,8 @@ int stream_index_from_sample(const simaai::neat::Sample& sample, int stream_coun
 }
 
 simaai::neat::GraphLinkOptions realtime_link(int stream_index, int queue_depth,
-                                             int max_inflight_per_stream = 4,
-                                             int max_inflight_total = 16) {
+                                             int max_inflight_per_stream = -1,
+                                             int max_inflight_total = -1) {
   simaai::neat::GraphLinkOptions link;
   link.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
   link.queue_depth = queue_depth;
@@ -650,8 +658,10 @@ void connect_stream_graph(AppRuntime& app, const AppConfig& cfg, const StreamRun
   auto decoded_branch =
       save_debug_frames ? simaai::neat::graphs::Branch("decoded", {"detector_frame", "debug_frame"})
                         : simaai::neat::graphs::Branch("decoded", {"detector_frame"});
-  app.graph.connect(decoder, decoded_branch, realtime_link(stream.index, 4));
-  app.graph.connect(decoded_branch, detector_graph, realtime_link(stream.index, 4));
+  app.graph.connect(decoder, decoded_branch);
+  app.graph.connect(
+      decoded_branch, detector_graph,
+      realtime_link(stream.index, 4, cfg.max_inflight_per_stream, cfg.max_inflight_total));
   if (save_debug_frames) {
     app.graph.connect(decoded_branch, build_debug_frame_graph(stream.index),
                       realtime_link(stream.index, 4));
@@ -851,7 +861,8 @@ int main(int argc, char** argv) {
     const AppConfig cfg = load_app_config(cli.config_path);
     if (cli.validate_config_only) {
       std::cout << "Config validated: " << cli.config_path << " (streams=" << cfg.rtsp_urls.size()
-                << ")\n";
+                << ", max_inflight_per_stream=" << cfg.max_inflight_per_stream
+                << ", max_inflight_total=" << cfg.max_inflight_total << ")\n";
       return 0;
     }
     run_app(cfg);

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -31,6 +31,8 @@ class AppConfig:
     tcp: bool = True
     frames: int = 0
     fps: int = 0
+    max_inflight_per_stream: int = 4
+    max_inflight_total: int = 16
     person_class_id: int = 0
     min_score: float = 0.55
     nms_iou: float = 0.60
@@ -208,6 +210,10 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("inference.frames must be >= 0")
     if cfg.fps < 0:
         raise ValueError("inference.fps must be >= 0")
+    if cfg.max_inflight_per_stream != -1 and cfg.max_inflight_per_stream <= 0:
+        raise ValueError("inference.max_inflight_per_stream must be -1 or > 0")
+    if cfg.max_inflight_total != -1 and cfg.max_inflight_total <= 0:
+        raise ValueError("inference.max_inflight_total must be -1 or > 0")
     if cfg.person_class_id < 0:
         raise ValueError("inference.person_class_id must be >= 0")
     if not 0.0 <= cfg.min_score <= 1.0:
@@ -259,6 +265,8 @@ def load_app_config(config_path: Path) -> AppConfig:
         tcp=bool_or(input_cfg, "tcp", True),
         frames=int_or(inference, "frames", 0),
         fps=int_or(inference, "fps", 0),
+        max_inflight_per_stream=int_or(inference, "max_inflight_per_stream", 4),
+        max_inflight_total=int_or(inference, "max_inflight_total", 16),
         person_class_id=int_or(inference, "person_class_id", 0),
         min_score=float_or(inference, "min_score", 0.55),
         nms_iou=float_or(inference, "nms_iou", 0.60),
@@ -541,8 +549,8 @@ def stream_index_from_sample(sample, stream_count: int) -> int:
 def realtime_link(
     stream_index: int,
     queue_depth: int,
-    max_inflight_per_stream: int = 4,
-    max_inflight_total: int = 16,
+    max_inflight_per_stream: int = -1,
+    max_inflight_total: int = -1,
 ):
     link = pyneat.GraphLinkOptions()
     link.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
@@ -645,8 +653,17 @@ def connect_stream_graph(
     save_debug_frames = save_frames_enabled(cfg)
     decoded_outputs = ["detector_frame", "debug_frame"] if save_debug_frames else ["detector_frame"]
     decoded_branch = pyneat.graphs.branch("decoded", decoded_outputs)
-    app.graph.connect(decoder, decoded_branch, realtime_link(stream.index, 4))
-    app.graph.connect(decoded_branch, detector_graph, realtime_link(stream.index, 4))
+    app.graph.connect(decoder, decoded_branch)
+    app.graph.connect(
+        decoded_branch,
+        detector_graph,
+        realtime_link(
+            stream.index,
+            4,
+            cfg.max_inflight_per_stream,
+            cfg.max_inflight_total,
+        ),
+    )
     if save_debug_frames:
         app.graph.connect(
             decoded_branch, build_debug_frame_graph(stream.index), realtime_link(stream.index, 4)
@@ -858,7 +875,11 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         cfg = load_app_config(args.config)
         if args.validate_config_only:
-            print(f"Config validated: {args.config} (streams={len(cfg.rtsp_urls)})")
+            print(
+                f"Config validated: {args.config} (streams={len(cfg.rtsp_urls)}, "
+                f"max_inflight_per_stream={cfg.max_inflight_per_stream}, "
+                f"max_inflight_total={cfg.max_inflight_total})"
+            )
             return 0
 
         load_runtime_dependencies()

--- a/examples/tracking/multi-stream-people-tracker/tests/cpp/test_unit.cpp
+++ b/examples/tracking/multi-stream-people-tracker/tests/cpp/test_unit.cpp
@@ -57,48 +57,75 @@ bool test_missing_config_file_fails_cleanly(const std::string& binary) {
 }
 
 bool test_validate_config_only_accepts_four_streams(const std::string& binary) {
-  const fs::path config_path =
-      write_config("test_validate_config_only_accepts_four_streams",
-                   "model:\n"
-                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
-                   "streams:\n"
-                   "  - rtsp://127.0.0.1:8554/src1\n"
-                   "  - rtsp://127.0.0.1:8554/src2\n"
-                   "  - rtsp://127.0.0.1:8554/src3\n"
-                   "  - rtsp://127.0.0.1:8554/src4\n"
-                   "output:\n"
-                   "  insight:\n"
-                   "    host: 127.0.0.1\n");
+  const fs::path config_path = write_config("test_validate_config_only_accepts_four_streams",
+                                            "model:\n"
+                                            "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                                            "streams:\n"
+                                            "  - rtsp://127.0.0.1:8554/src1\n"
+                                            "  - rtsp://127.0.0.1:8554/src2\n"
+                                            "  - rtsp://127.0.0.1:8554/src3\n"
+                                            "  - rtsp://127.0.0.1:8554/src4\n"
+                                            "inference:\n"
+                                            "  max_inflight_per_stream: 3\n"
+                                            "  max_inflight_total: 12\n"
+                                            "output:\n"
+                                            "  insight:\n"
+                                            "    host: 127.0.0.1\n");
 
   const auto result =
       spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
   const bool ok =
       expect_true(result.exit_code == 0, "four-stream config validates") &&
-      expect_contains(result.stdout_text, "streams=4", "validate output reports stream count");
+      expect_contains(result.stdout_text, "streams=4", "validate output reports stream count") &&
+      expect_contains(result.stdout_text, "max_inflight_per_stream=3",
+                      "validate output reports per-stream inflight limit") &&
+      expect_contains(result.stdout_text, "max_inflight_total=12",
+                      "validate output reports total inflight limit");
   remove_dir(config_path.parent_path().string());
   return ok;
 }
 
 bool test_validate_config_only_rejects_too_many_streams(const std::string& binary) {
-  const fs::path config_path =
-      write_config("test_validate_config_only_rejects_too_many_streams",
-                   "model:\n"
-                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
-                   "streams:\n"
-                   "  - rtsp://127.0.0.1:8554/src1\n"
-                   "  - rtsp://127.0.0.1:8554/src2\n"
-                   "  - rtsp://127.0.0.1:8554/src3\n"
-                   "  - rtsp://127.0.0.1:8554/src4\n"
-                   "  - rtsp://127.0.0.1:8554/src5\n"
-                   "output:\n"
-                   "  insight:\n"
-                   "    host: 127.0.0.1\n");
+  const fs::path config_path = write_config("test_validate_config_only_rejects_too_many_streams",
+                                            "model:\n"
+                                            "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                                            "streams:\n"
+                                            "  - rtsp://127.0.0.1:8554/src1\n"
+                                            "  - rtsp://127.0.0.1:8554/src2\n"
+                                            "  - rtsp://127.0.0.1:8554/src3\n"
+                                            "  - rtsp://127.0.0.1:8554/src4\n"
+                                            "  - rtsp://127.0.0.1:8554/src5\n"
+                                            "output:\n"
+                                            "  insight:\n"
+                                            "    host: 127.0.0.1\n");
 
   const auto result =
       spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
   const bool ok = expect_true(result.exit_code == 1, "five-stream config is rejected") &&
                   expect_contains(result.stderr_text, "up to four streams",
                                   "too-many-stream error mentions four-stream phase limit");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+bool test_validate_config_only_rejects_invalid_inflight_limit(const std::string& binary) {
+  const fs::path config_path =
+      write_config("test_validate_config_only_rejects_invalid_inflight_limit",
+                   "model:\n"
+                   "  path: assets/models/yolo26m-det-int8-b1.tar.gz\n"
+                   "streams:\n"
+                   "  - rtsp://127.0.0.1:8554/src1\n"
+                   "inference:\n"
+                   "  max_inflight_total: 0\n"
+                   "output:\n"
+                   "  insight:\n"
+                   "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok = expect_true(result.exit_code == 1, "invalid inflight limit is rejected") &&
+                  expect_contains(result.stderr_text, "max_inflight_total must be -1 or > 0",
+                                  "invalid inflight error names the setting");
   remove_dir(config_path.parent_path().string());
   return ok;
 }
@@ -136,6 +163,7 @@ int main(int argc, char** argv) {
   ok &= test_missing_config_file_fails_cleanly(binary);
   ok &= test_validate_config_only_accepts_four_streams(binary);
   ok &= test_validate_config_only_rejects_too_many_streams(binary);
+  ok &= test_validate_config_only_rejects_invalid_inflight_limit(binary);
   ok &= test_tracker_reuses_track_id_for_nearby_detection();
   ok &= test_tracker_drops_track_after_missing_budget();
   return ok ? 0 : 1;

--- a/examples/tracking/multi-stream-people-tracker/tests/python/test_unit.py
+++ b/examples/tracking/multi-stream-people-tracker/tests/python/test_unit.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import subprocess
 import sys
 import textwrap
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,8 +22,20 @@ if str(PYTHON_DIR) not in sys.path:
 pytestmark = pytest.mark.unit
 
 
-def write_config(tmp_path: Path, streams: list[str]) -> Path:
+def write_config(
+    tmp_path: Path,
+    streams: list[str],
+    max_inflight_per_stream: int | None = None,
+    max_inflight_total: int | None = None,
+) -> Path:
     stream_lines = "\n".join(f"  - {stream}" for stream in streams)
+    inference = []
+    if max_inflight_per_stream is not None or max_inflight_total is not None:
+        inference.append("inference:")
+        if max_inflight_per_stream is not None:
+            inference.append(f"  max_inflight_per_stream: {max_inflight_per_stream}")
+        if max_inflight_total is not None:
+            inference.append(f"  max_inflight_total: {max_inflight_total}")
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         "\n".join(
@@ -31,6 +44,7 @@ def write_config(tmp_path: Path, streams: list[str]) -> Path:
                 "  path: assets/models/yolo26m-det-int8-b1.tar.gz",
                 "streams:",
                 stream_lines,
+                *inference,
                 "output:",
                 "  insight:",
                 "    host: 127.0.0.1",
@@ -89,6 +103,35 @@ class TestConfigLoading:
         assert cfg.insight_host == "127.0.0.1"
         assert cfg.warmup_frames == 30
         assert cfg.tracker_max_missing == 15
+        assert cfg.max_inflight_per_stream == 4
+        assert cfg.max_inflight_total == 16
+
+    def test_load_app_config_accepts_custom_inflight_limits(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = write_config(
+            tmp_path,
+            ["rtsp://127.0.0.1:8554/src1"],
+            max_inflight_per_stream=3,
+            max_inflight_total=12,
+        )
+
+        cfg = load_app_config(config_path)
+
+        assert cfg.max_inflight_per_stream == 3
+        assert cfg.max_inflight_total == 12
+
+    def test_load_app_config_rejects_invalid_inflight_limit(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = write_config(
+            tmp_path,
+            ["rtsp://127.0.0.1:8554/src1"],
+            max_inflight_per_stream=0,
+        )
+
+        with pytest.raises(ValueError, match="max_inflight_per_stream must be -1 or > 0"):
+            load_app_config(config_path)
 
     def test_default_config_uses_tracking_threshold(self):
         from main import load_app_config
@@ -154,6 +197,27 @@ class TestConfigLoading:
 
         assert result.returncode == 0
         assert "streams=2" in result.stdout
+        assert "max_inflight_per_stream=4" in result.stdout
+        assert "max_inflight_total=16" in result.stdout
+
+
+class TestRuntimeOptions:
+    def test_realtime_link_sets_inflight_limits(self, monkeypatch):
+        import main
+
+        fake_pyneat = SimpleNamespace(
+            GraphLinkOptions=type("GraphLinkOptions", (), {}),
+            GraphLinkPolicy=SimpleNamespace(RealtimeLatestByStream="latest-by-stream"),
+        )
+        monkeypatch.setattr(main, "pyneat", fake_pyneat)
+
+        link = main.realtime_link(2, 4, 3, 12)
+
+        assert link.policy == "latest-by-stream"
+        assert link.queue_depth == 4
+        assert link.stream_id == "stream2"
+        assert link.max_inflight_per_stream == 3
+        assert link.max_inflight_total == 12
 
 
 class FakeMetadataSender:


### PR DESCRIPTION
## Why

Users running multi-stream detection and tracking need to tune how many decoder-backed raw frames enter the shared detector. These limits were previously hardcoded, requiring source changes to balance throughput and device-buffer pressure.

## What Changed

- Added `inference.max_inflight_per_stream` and `inference.max_inflight_total` to the C++ and Python examples.
- Preserved the existing defaults of `4` per stream and `16` total.
- Allowed `-1` to select the Core defaults.
- Applied these limits only to the realtime link entering the shared detector.
- Added clear validation for unsupported values.
- Updated the example configs, READMEs, and focused tests.

## Validation

- Clean Apps build passed in the Neat SDK.
- Modalix C++ unit tests passed for both examples.
- Python unit tests passed through pyneat:
  - Object detector: 10 passed
  - People tracker: 13 passed
- C++ e2e passed for both examples with 20 sampled frames and valid metadata from both streams.
- Python e2e passed for both examples.
- Representative C++ and Python output frames were inspected and were valid.

## Risk

Existing configurations retain the current `4/16` behavior. Runtime behavior changes only when users provide different limits.

Closes #322