### PR TITLE
fix(genai): fail early for unwritable model paths

### DIFF
--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -93,9 +93,29 @@ Override the default chat/VLM download with an environment variable when needed:
 CHAT_MODEL_REPO=simaai/<chat-model-repo> ./setup.sh
 ```
 
-Downloaded models are stored under `/media/nvme/llima/models` by default. On a
-system without NVMe, set `LLIMA_MODELS_PATH` to another writable location, for
-example:
+Downloaded models use this layout by default:
+
+```text
+/media/nvme/llima/models/
+├── Qwen3-VL-4B-Instruct-GPTQ-a16w4/
+├── whisper-small-a16w8/
+└── gte-small/
+```
+
+On a SoM board, mount NVMe before running setup. If NVMe is mounted but the
+model directory is not writable, create it with ownership for the current
+user:
+
+```bash
+sudo install -d \
+  -o "$(id -u)" \
+  -g "$(id -g)" \
+  /media/nvme/llima/models
+```
+
+On a system without NVMe, set `LLIMA_MODELS_PATH` to another writable
+location. The same three model directories are created under the selected
+path:
 
 ```bash
 LLIMA_MODELS_PATH=/workspace/neat/models_genai ./setup.sh

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -114,12 +114,16 @@ sudo install -d \
 ```
 
 On a system without NVMe, set `LLIMA_MODELS_PATH` to another writable
-location. The same three model directories are created under the selected
-path:
+location. For a full Apps checkout, `assets/models/` is the repo-local model
+convention:
 
 ```bash
-LLIMA_MODELS_PATH=/workspace/neat/models_genai ./setup.sh
+export APPS_ROOT=/path/to/apps
+LLIMA_MODELS_PATH="${APPS_ROOT}/assets/models/genai" ./setup.sh
 ```
+
+The same three model directories are created under the selected path. For a
+standalone example, set `LLIMA_MODELS_PATH` to any writable absolute path.
 
 The UI virtual environment is stored under `./.venv` unless `APP_VENV` is set.
 The generated config is stored at `./config.local.yaml` unless `CONFIG_PATH` is

--- a/examples/genai/multimodal-assistant/setup.sh
+++ b/examples/genai/multimodal-assistant/setup.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MODELS_DIR="${LLIMA_MODELS_PATH:-/media/nvme/llima/models}"
+DEFAULT_MODELS_DIR="/media/nvme/llima/models"
+MODELS_DIR="${LLIMA_MODELS_PATH:-${DEFAULT_MODELS_DIR}}"
 APP_VENV="${APP_VENV:-${EXAMPLE_DIR}/.venv}"
 CONFIG_PATH="${CONFIG_PATH:-${EXAMPLE_DIR}/config.local.yaml}"
 PYNEAT_PYTHON="${PYNEAT_PYTHON:-${HOME}/pyneat/bin/python}"
@@ -50,6 +51,19 @@ if [[ $# -gt 0 ]]; then
   exit 2
 fi
 
+if ! mkdir -p "${MODELS_DIR}" 2>/dev/null ||
+  [[ ! -d "${MODELS_DIR}" || ! -w "${MODELS_DIR}" ]]
+then
+  echo "Model directory is not writable: ${MODELS_DIR}" >&2
+  if [[ -z "${LLIMA_MODELS_PATH:-}" ]]; then
+    echo "Mount NVMe and make ${DEFAULT_MODELS_DIR} writable, or set:" >&2
+  else
+    echo "Set LLIMA_MODELS_PATH to a writable directory and retry:" >&2
+  fi
+  echo "  LLIMA_MODELS_PATH=/writable/path ./setup.sh" >&2
+  exit 1
+fi
+
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 is required." >&2
   exit 1
@@ -90,7 +104,6 @@ install_cpu_torch_if_needed
   -r "${EXAMPLE_DIR}/src/python/requirements.txt" \
   -r "${EXAMPLE_DIR}/src/python/requirements-rag.txt"
 
-mkdir -p "${MODELS_DIR}"
 CHAT_MODEL_DIR="${MODELS_DIR}/${CHAT_MODEL_NAME}"
 ASR_MODEL_DIR="${MODELS_DIR}/whisper-small-a16w8"
 RAG_EMBEDDING_DIR="${MODELS_DIR}/gte-small"


### PR DESCRIPTION
## Why

Multimodal Assistant setup could install its Python dependencies before discovering that the model download directory was unavailable or not writable. Users then received a late permission error without clear NVMe setup or alternative-path guidance.

## What Changed

- Validate the selected model directory before creating the virtual environment or installing dependencies.
- Continue using `LLIMA_MODELS_PATH` when set and `/media/nvme/llima/models` by default.
- Fail early with instructions when the selected directory cannot be created or written.
- Document the default downloaded model layout.
- Document how to create the NVMe model directory with current-user ownership.
- Document `${APPS_ROOT}/assets/models/genai` as the repo-local alternative and support any writable absolute path for standalone examples.

## Validation

- Shell syntax and ShellCheck passed.
- An invalid model path failed before creating a virtual environment or configuration.
- A writable `LLIMA_MODELS_PATH` passed model-directory validation and proceeded to the next setup prerequisite.
- The changed README passed focused validation.
- Catalog generation and whitespace validation passed.

## Notes

Setup does not mount NVMe or elevate privileges automatically. Users must mount NVMe first and may use the documented one-time ownership command when needed.

Model downloads and GenAI runtime tests were not run.

Closes #270
