### PR TITLE
fix(examples): preserve frame timestamps for Insight

### DIFF
--- a/examples/genai/detection-to-vlm-assistant/src/python/detector_app.py
+++ b/examples/genai/detection-to-vlm-assistant/src/python/detector_app.py
@@ -588,13 +588,18 @@ def main() -> int:
             f"interval={cfg.genai_interval_seconds:g}s\n"
         )
 
-        frame_id = 0
-        while cfg.frames <= 0 or frame_id < cfg.frames:
-            tensors = rtsp_run.pull_tensors(timeout_ms=cfg.timeout_ms)
-            if not tensors:
+        processed = 0
+        while cfg.frames <= 0 or processed < cfg.frames:
+            source_sample = rtsp_run.pull(timeout_ms=cfg.timeout_ms)
+            if source_sample is None:
                 print("RTSP stream ended or pull timed out", file=sys.stderr)
                 break
-            decoded_frame = tensors[0]
+            if source_sample.kind == pyneat.SampleKind.Tensor and source_sample.tensor is not None:
+                decoded_frame = source_sample.tensor
+            elif source_sample.kind == pyneat.SampleKind.TensorSet and source_sample.tensors:
+                decoded_frame = source_sample.tensors[0]
+            else:
+                raise RuntimeError("RTSP output did not contain a decoded frame tensor")
             rgb_frame = decoded_tensor_to_rgb(decoded_frame)
             model_input = pyneat.Tensor.from_numpy(
                 rgb_to_bgr(rgb_frame),
@@ -604,22 +609,32 @@ def main() -> int:
             )
             boxes = parse_boxes(detector_run.run([model_input], timeout_ms=cfg.timeout_ms))
             commenter.try_enqueue(rgb_frame, boxes)
-            if not video_run.push(
-                [rgb_frame], copy=True, image_format=pyneat.PixelFormat.RGB
-            ):
+            video_tensor = pyneat.Tensor.from_numpy(
+                rgb_frame,
+                copy=True,
+                image_format=pyneat.PixelFormat.RGB,
+                memory=pyneat.TensorMemory.EV74,
+            )
+            video_sample = pyneat.make_tensor_sample("", video_tensor)
+            video_sample.pts_ns = source_sample.pts_ns
+            video_sample.dts_ns = source_sample.dts_ns
+            video_sample.duration_ns = source_sample.duration_ns
+            video_sample.frame_id = source_sample.frame_id
+            video_sample.stream_id = source_sample.stream_id
+            if not video_run.push([video_sample]):
                 raise RuntimeError("Insight video push failed")
             ok = metadata.send_metadata(
                 "object-detection",
                 metadata_json(boxes, labels, cfg.classes),
-                int(time.time() * 1000),
-                str(frame_id),
+                int(source_sample.pts_ns // 1_000_000) if source_sample.pts_ns >= 0 else -1,
+                str(source_sample.frame_id) if source_sample.frame_id >= 0 else "",
             )
             if not ok:
                 raise RuntimeError("failed to send metadata to Insight")
-            frame_id += 1
+            processed += 1
             if cfg.debug:
-                print(f"[detector] frame={frame_id} detections={len(boxes)}")
-        return 0 if frame_id > 0 else 3
+                print(f"[detector] frame={processed} detections={len(boxes)}")
+        return 0 if processed > 0 else 3
     except KeyboardInterrupt:
         return 130
     except Exception as exc:

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -26,7 +26,6 @@
 #include <opencv2/imgcodecs.hpp>
 
 #include <algorithm>
-#include <chrono>
 #include <cctype>
 #include <csignal>
 #include <cstdint>
@@ -362,11 +361,6 @@ std::vector<sima_examples::MetadataBox> build_metadata_boxes(const std::vector<o
   return metadata_boxes;
 }
 
-int64_t fallback_timestamp_ms() {
-  const auto now = std::chrono::system_clock::now().time_since_epoch();
-  return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-}
-
 simaai::neat::nodes::groups::RtspDecodedInputOptions
 build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, int& width_out,
                      int& height_out) {
@@ -671,12 +665,11 @@ void send_metadata(StreamRuntime& stream, const simaai::neat::Sample& sample,
   const auto metadata_boxes =
       build_metadata_boxes(boxes, stream.labels, stream.frame_w, stream.frame_h);
   const std::string data_json = sima_examples::metadata_boxes_data_json("objects", metadata_boxes);
-  const int64_t timestamp_ms =
-      sample.pts_ns >= 0 ? sample.pts_ns / 1000000 : fallback_timestamp_ms();
-  const int64_t frame_id = sample.frame_id >= 0 ? sample.frame_id : 0;
+  const int64_t timestamp_ms = sample.pts_ns >= 0 ? sample.pts_ns / 1'000'000 : -1;
+  const std::string frame_id = sample.frame_id >= 0 ? std::to_string(sample.frame_id) : "";
   std::string err;
-  if (!stream.metadata_sender->send_metadata("object-detection", data_json, timestamp_ms,
-                                             std::to_string(frame_id), &err)) {
+  if (!stream.metadata_sender->send_metadata("object-detection", data_json, timestamp_ms, frame_id,
+                                             &err)) {
     std::cerr << "[warn] stream " << stream.index << " metadata send failed: " << err << "\n";
   }
 }

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -664,18 +664,13 @@ def connect_stream_graph(
 
 def send_metadata(stream: StreamRuntime, sample, boxes: list[dict]) -> None:
     metadata_boxes = build_metadata_boxes(boxes, stream.labels, stream.frame_w, stream.frame_h)
-    pts_ns = getattr(sample, "pts_ns", -1)
-    if pts_ns is not None and pts_ns >= 0:
-        timestamp_ms = int(pts_ns // 1_000_000)
-    else:
-        timestamp_ms = int(time.time() * 1000)
-    frame_id = getattr(sample, "frame_id", -1)
-    frame_id = int(frame_id) if frame_id is not None and frame_id >= 0 else 0
+    timestamp_ms = int(sample.pts_ns // 1_000_000) if sample.pts_ns >= 0 else -1
+    frame_id = str(sample.frame_id) if sample.frame_id >= 0 else ""
     stream.metadata_sender.send_metadata(
         "object-detection",
         json.dumps({"objects": metadata_boxes}, separators=(",", ":")),
         timestamp_ms,
-        str(frame_id),
+        frame_id,
     )
 
 

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -28,7 +28,6 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
 #include <cmath>
 #include <cctype>
 #include <cstdio>
@@ -673,12 +672,11 @@ void send_metadata(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
   const auto metadata_boxes =
       build_metadata_boxes(boxes, runtime.labels, runtime.frame_w, runtime.frame_h);
   const std::string data_json = sima_examples::metadata_boxes_data_json("objects", metadata_boxes);
-  const auto now = std::chrono::system_clock::now().time_since_epoch();
-  const int64_t ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-  const int64_t frame_id = sample.frame_id >= 0 ? sample.frame_id : 0;
+  const int64_t ts_ms = sample.pts_ns >= 0 ? sample.pts_ns / 1'000'000 : -1;
+  const std::string frame_id = sample.frame_id >= 0 ? std::to_string(sample.frame_id) : "";
   std::string err;
-  if (!runtime.metadata_sender->send_metadata("object-detection", data_json, ts_ms,
-                                              std::to_string(frame_id), &err)) {
+  if (!runtime.metadata_sender->send_metadata("object-detection", data_json, ts_ms, frame_id,
+                                              &err)) {
     std::cerr << "[warn] insight metadata send failed: " << err << "\n";
   }
 }

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -632,14 +632,13 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
 
 def send_metadata(runtime: PipelineRuntime, sample, boxes: list[dict]) -> None:
     metadata_boxes = build_metadata_boxes(boxes, runtime.labels, runtime.frame_w, runtime.frame_h)
-    frame_id = getattr(sample, "frame_id", -1)
-    if frame_id is None or frame_id < 0:
-        frame_id = 0
+    timestamp_ms = int(sample.pts_ns // 1_000_000) if sample.pts_ns >= 0 else -1
+    frame_id = str(sample.frame_id) if sample.frame_id >= 0 else ""
     runtime.metadata_sender.send_metadata(
         "object-detection",
         json.dumps({"objects": metadata_boxes}, separators=(",", ":")),
-        int(time.time() * 1000),
-        str(frame_id),
+        timestamp_ms,
+        frame_id,
     )
 
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -27,7 +27,6 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
 #include <cmath>
 #include <cctype>
 #include <cstdio>
@@ -897,23 +896,29 @@ void send_metadata(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
                    const std::vector<SegmentationDetection>& detections) {
   const auto boxes =
       build_metadata_boxes(detections, runtime.labels, runtime.frame_w, runtime.frame_h);
-  const auto now = std::chrono::system_clock::now().time_since_epoch();
-  const int64_t ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-  const int64_t frame_id = sample.frame_id >= 0 ? sample.frame_id : 0;
+  const int64_t ts_ms = sample.pts_ns >= 0 ? sample.pts_ns / 1'000'000 : -1;
+  const std::string frame_id = sample.frame_id >= 0 ? std::to_string(sample.frame_id) : "";
   std::string err;
   if (!runtime.metadata_sender->send_metadata(
           "instance-segmentation", sima_examples::metadata_boxes_data_json("objects", boxes), ts_ms,
-          std::to_string(frame_id), &err)) {
+          frame_id, &err)) {
     std::cerr << "[warn] insight metadata send failed: " << err << "\n";
   }
 }
 
-void push_annotated_video(PipelineRuntime& runtime, const cv::Mat& annotated_bgr) {
+void push_annotated_video(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
+                          const cv::Mat& annotated_bgr) {
   cv::Mat rgb;
   cv::cvtColor(annotated_bgr, rgb, cv::COLOR_BGR2RGB);
   const auto tensor = simaai::neat::Tensor::from_cv_mat(
       rgb, simaai::neat::ImageSpec::PixelFormat::RGB, simaai::neat::TensorMemory::EV74);
-  if (!runtime.video_run.push(simaai::neat::TensorList{tensor})) {
+  auto video_sample = simaai::neat::make_tensor_sample("", tensor);
+  video_sample.pts_ns = sample.pts_ns;
+  video_sample.dts_ns = sample.dts_ns;
+  video_sample.duration_ns = sample.duration_ns;
+  video_sample.frame_id = sample.frame_id;
+  video_sample.stream_id = sample.stream_id;
+  if (!runtime.video_run.push(video_sample)) {
     throw std::runtime_error("Insight video push failed");
   }
 }
@@ -962,7 +967,7 @@ void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
     const double overlay_end = time_ms();
 
     const double video_start = time_ms();
-    push_annotated_video(runtime, annotated);
+    push_annotated_video(runtime, sample, annotated);
     const double video_end = time_ms();
 
     const double metadata_start = time_ms();

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -873,23 +873,28 @@ def metadata_boxes(detections: list[dict], labels: list[str], frame_w: int, fram
 
 
 def send_metadata(runtime: PipelineRuntime, sample, detections: list[dict]) -> None:
-    frame_id = getattr(sample, "frame_id", -1)
-    if frame_id is None or frame_id < 0:
-        frame_id = 0
+    timestamp_ms = int(sample.pts_ns // 1_000_000) if sample.pts_ns >= 0 else -1
+    frame_id = str(sample.frame_id) if sample.frame_id >= 0 else ""
     runtime.metadata_sender.send_metadata(
         "instance-segmentation",
         json.dumps(
             {"objects": metadata_boxes(detections, runtime.labels, runtime.frame_w, runtime.frame_h)},
             separators=(",", ":"),
         ),
-        int(time.time() * 1000),
-        str(frame_id),
+        timestamp_ms,
+        frame_id,
     )
 
 
-def push_annotated_video(runtime: PipelineRuntime, annotated_bgr) -> None:
+def push_annotated_video(runtime: PipelineRuntime, sample, annotated_bgr) -> None:
     rgb = cv2.cvtColor(annotated_bgr, cv2.COLOR_BGR2RGB)
-    if not runtime.video_run.push([tensor_from_rgb_frame(rgb)]):
+    video_sample = pyneat.make_tensor_sample("", tensor_from_rgb_frame(rgb))
+    video_sample.pts_ns = sample.pts_ns
+    video_sample.dts_ns = sample.dts_ns
+    video_sample.duration_ns = sample.duration_ns
+    video_sample.frame_id = sample.frame_id
+    video_sample.stream_id = sample.stream_id
+    if not runtime.video_run.push([video_sample]):
         raise RuntimeError("Insight video push failed")
 
 
@@ -929,7 +934,7 @@ def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
         overlay_end = time_ms()
 
         video_start = time_ms()
-        push_annotated_video(runtime, annotated)
+        push_annotated_video(runtime, sample, annotated)
         video_end = time_ms()
 
         metadata_start = time_ms()

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -27,7 +27,6 @@
 #include <opencv2/imgcodecs.hpp>
 
 #include <algorithm>
-#include <chrono>
 #include <cctype>
 #include <csignal>
 #include <cstdint>
@@ -365,11 +364,6 @@ build_metadata_tracks(const std::vector<TrackedDetection>& tracks, int frame_w, 
   return metadata_boxes;
 }
 
-int64_t fallback_timestamp_ms() {
-  const auto now = std::chrono::system_clock::now().time_since_epoch();
-  return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-}
-
 simaai::neat::nodes::groups::RtspDecodedInputOptions
 build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, int& width_out,
                      int& height_out) {
@@ -672,12 +666,10 @@ void send_metadata(StreamRuntime& stream, const simaai::neat::Sample& sample,
                    const std::vector<TrackedDetection>& tracks) {
   const auto metadata_tracks = build_metadata_tracks(tracks, stream.frame_w, stream.frame_h);
   const std::string data_json = sima_examples::metadata_boxes_data_json("tracks", metadata_tracks);
-  const int64_t timestamp_ms =
-      sample.pts_ns >= 0 ? sample.pts_ns / 1000000 : fallback_timestamp_ms();
-  const int64_t frame_id = sample.frame_id >= 0 ? sample.frame_id : 0;
+  const int64_t timestamp_ms = sample.pts_ns >= 0 ? sample.pts_ns / 1'000'000 : -1;
+  const std::string frame_id = sample.frame_id >= 0 ? std::to_string(sample.frame_id) : "";
   std::string err;
-  if (!stream.metadata_sender->send_metadata("tracking", data_json, timestamp_ms,
-                                             std::to_string(frame_id), &err)) {
+  if (!stream.metadata_sender->send_metadata("tracking", data_json, timestamp_ms, frame_id, &err)) {
     std::cerr << "[warn] stream " << stream.index << " metadata send failed: " << err << "\n";
   }
 }

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -672,18 +672,13 @@ def connect_stream_graph(
 
 def send_metadata(stream: StreamRuntime, sample, tracks: list[TrackedDetection]) -> None:
     metadata_tracks = build_metadata_tracks(tracks, stream.frame_w, stream.frame_h)
-    pts_ns = getattr(sample, "pts_ns", -1)
-    if pts_ns is not None and pts_ns >= 0:
-        timestamp_ms = int(pts_ns // 1_000_000)
-    else:
-        timestamp_ms = int(time.time() * 1000)
-    frame_id = getattr(sample, "frame_id", -1)
-    frame_id = int(frame_id) if frame_id is not None and frame_id >= 0 else 0
+    timestamp_ms = int(sample.pts_ns // 1_000_000) if sample.pts_ns >= 0 else -1
+    frame_id = str(sample.frame_id) if sample.frame_id >= 0 else ""
     stream.metadata_sender.send_metadata(
         "tracking",
         json.dumps({"tracks": metadata_tracks}, separators=(",", ":")),
         timestamp_ms,
-        str(frame_id),
+        frame_id,
     )
 
 


### PR DESCRIPTION
## Why

Several Insight examples published wall-clock timestamps or fabricated frame IDs instead of the identity carried by the processed Neat `Sample`. Insight therefore could not deterministically associate metadata with the corresponding video frame.

## What Changed

- Publish metadata timestamps from `Sample.pts_ns`.
- Publish the source `frame_id` when available.
- Omit missing timestamps and frame IDs instead of substituting wall-clock time or zero.
- Preserve timing and identity when segmentation and VLM examples create replacement video samples.
- Keep the existing `MetadataSender` and `VideoSender` APIs unchanged.

## Validation

- Changed Python sources compiled successfully.
- Relevant detector, tracker, and VLM Python unit suites passed.
- All four affected C++ application targets built in the Neat SDK.
- Changed C++ sources were formatted with clang-format.

## Risk

This change depends on the companion Insight timestamp-correlation change for exact visualization matching.

Hardware and board validation has not been run.

Refs #326
