### PR TITLE
Add SSD decode application

### DIFF
--- a/examples/object-detection/CMakeLists.txt
+++ b/examples/object-detection/CMakeLists.txt
@@ -2,6 +2,7 @@ foreach(example IN ITEMS
     high-density-multi-stream-object-detector
     detr-object-detector
     single-stream-object-detector
+    ssd-mobilenet-object-detector
     yolo26-object-detector
 )
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${example}/src/cpp/CMakeLists.txt")

--- a/examples/object-detection/ssd-mobilenet-object-detector/README.md
+++ b/examples/object-detection/ssd-mobilenet-object-detector/README.md
@@ -1,0 +1,134 @@
+# SSD-MobileNetV2 Object Detector
+
+## Metadata
+| Field | Value |
+| --- | --- |
+| Category | object-detection |
+| Difficulty | Intermediate |
+| Tags | ssd, mobilenet, object-detection, folder-input, coco |
+| Languages | C++, Python |
+| Status | experimental |
+| Binary Name | ssd-mobilenet-object-detector |
+| Model | ssd_mobilenet_v2_heads [https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/ssd_mobilenet_v2_heads_mpk.tar.gz] |
+
+## Concept
+This example demonstrates folder-based object detection with a compiled **SSD-MobileNetV2**
+model (the TensorFlow Object Detection API model `ssd_mobilenet_v2_coco_2018_03_29`). Each
+input image is stretched to the 300×300 model frame, normalized to `[-1, 1]`, run through the
+Neat Library pipeline, and then decoded into COCO object boxes on the host.
+
+The compiled pack emits the model's **12 grouped convolution heads** (6 localization + 6
+classification, feature maps `19/10/5/3/2/1` → **1917 priors**). The example reassembles those
+heads in anchor-major layout (`a*4 + coord` for boxes, `a*91 + class` for scores), decodes each
+prior with the recovered `ssd_anchor_generator` priors and the `FasterRcnnBoxCoder`
+(scales `10,10,5,5`), applies **sigmoid** scoring, runs **per-class NMS**, maps detections back
+onto the original image, and writes annotated output images. This host-side decode is bit-exact
+with the reference TensorFlow model.
+
+Unlike DETR (letterbox + ImageNet normalization), this model was trained with a
+`fixed_shape_resizer`, so preprocessing is a **direct stretch** to 300×300 and boxes
+back-project with a simple per-axis scale.
+
+## Supported Models
+Use the SDK platform version wherever `<platform-version>` appears.
+
+Default model: `ssd_mobilenet_v2_heads`.
+
+Download the default model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/ssd_mobilenet_v2_heads_mpk.tar.gz
+
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a repo-local convention. `model.path`
+can point to any readable model package path.
+
+## Prerequisites
+- Installed Neat Development Environment + Neat Library.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the
+  default model, or set `model.path` to another readable model package.
+- The only shipped asset is `src/common/coco_labels.txt` — 91 lines (`0=background`,
+  `1..90` = MS-COCO ids). The 1917 anchor priors are **generated in code** at startup from
+  the per-level prior table (the same table baked into the on-device SSD decode kernel), so
+  no anchor asset is required.
+
+## Get The Apps Repo
+Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
+
+Clone and build the apps repo inside the Neat Development Environment:
+
+```bash
+git clone https://github.com/sima-neat/apps.git
+cd apps
+./build.sh --clean
+```
+
+After building, run the example commands below on the Modalix/DevKit board.
+
+## Configure
+Edit `examples/object-detection/ssd-mobilenet-object-detector/src/common/config.yaml`.
+
+```yaml
+model:
+  path: <model-path>         # Path to the model package.
+  labels: examples/object-detection/ssd-mobilenet-object-detector/src/common/coco_labels.txt
+
+io:
+  input_dir: assets/test_images                       # Folder containing input images.
+  output_dir: sandbox/ssd-mobilenet-object-detector   # Folder for annotated images.
+
+decode:
+  score_threshold: 0.30      # Minimum sigmoid object confidence.
+  nms_iou: 0.60              # Overlap threshold for per-class NMS.
+  max_detections: 100        # Max detections to keep per image.
+
+runtime:
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  num_runs: 1                # Number of repeated runs (profiling).
+  profile: false             # Print profiling summaries.
+```
+
+The `labels` path is repo-relative (resolved from the apps root). If the working directory
+differs, the app falls back to the copy shipped next to the example under `src/common/`.
+
+## Run
+### C++
+```bash
+./build/examples/object-detection/ssd-mobilenet-object-detector/ssd-mobilenet-object-detector \
+  --config examples/object-detection/ssd-mobilenet-object-detector/src/common/config.yaml
+```
+
+### Python
+```bash
+source ~/pyneat/bin/activate
+pip install -r examples/object-detection/ssd-mobilenet-object-detector/src/python/requirements.txt
+python3 examples/object-detection/ssd-mobilenet-object-detector/src/python/main.py \
+  --config examples/object-detection/ssd-mobilenet-object-detector/src/common/config.yaml
+```
+
+## Debugging Notes
+- Confirm `model.path` points to a readable model package.
+- If boxes look vertically squished or shifted toward the frame center, the resize mode is wrong.
+  This model requires a **stretch** (not letterbox) resize; the example already applies it.
+- If detections are missing but the pipeline runs, lower `decode.score_threshold` (int8
+  quantization of the classification heads can drop weak detections).
+- Set `runtime.profile: true` to print graph vs. postprocessing timing for the first image.
+
+## Appendix: On-Device Decode
+This example performs the SSD box decode **on the host**, so it needs no custom kernel. The same
+12-head pack can also be decoded **on-device** by the `neatobjectdecode` kernel's SSD variant
+(model-managed box decode) for a streaming RTSP → Insight deployment; that path is out of scope
+for this folder-input example.
+
+## Source Files
+- Test scope: `tests/test-scope.yaml`
+- C++ source: `src/cpp/main.cpp`
+- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+- Python source: `src/python/main.py`
+- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
+- Shared assets: `src/common/` (`config.yaml`, `coco_labels.txt`)

--- a/examples/object-detection/ssd-mobilenet-object-detector/src/common/coco_labels.txt
+++ b/examples/object-detection/ssd-mobilenet-object-detector/src/common/coco_labels.txt
@@ -1,0 +1,91 @@
+background
+person
+bicycle
+car
+motorcycle
+airplane
+bus
+train
+truck
+boat
+traffic light
+fire hydrant
+N/A
+stop sign
+parking meter
+bench
+bird
+cat
+dog
+horse
+sheep
+cow
+elephant
+bear
+zebra
+giraffe
+N/A
+backpack
+umbrella
+N/A
+N/A
+handbag
+tie
+suitcase
+frisbee
+skis
+snowboard
+sports ball
+kite
+baseball bat
+baseball glove
+skateboard
+surfboard
+tennis racket
+bottle
+N/A
+wine glass
+cup
+fork
+knife
+spoon
+bowl
+banana
+apple
+sandwich
+orange
+broccoli
+carrot
+hot dog
+pizza
+donut
+cake
+chair
+couch
+potted plant
+bed
+N/A
+dining table
+N/A
+N/A
+toilet
+N/A
+tv
+laptop
+mouse
+remote
+keyboard
+cell phone
+microwave
+oven
+toaster
+sink
+refrigerator
+N/A
+book
+clock
+vase
+scissors
+teddy bear
+hair drier
+toothbrush

--- a/examples/object-detection/ssd-mobilenet-object-detector/src/common/config.yaml
+++ b/examples/object-detection/ssd-mobilenet-object-detector/src/common/config.yaml
@@ -1,0 +1,21 @@
+model:                       # SSD-MobileNetV2 detector selection.
+  path: <model-path>         # Example: assets/models/ssd_mobilenet_v2_heads_mpk.tar.gz
+  labels: examples/object-detection/ssd-mobilenet-object-detector/src/common/coco_labels.txt      # 91 lines: 0=background, 1..90 COCO.
+
+io:                          # Input and output paths.
+  input_dir: assets/test_images                       # Folder containing input images.
+  output_dir: sandbox/ssd-mobilenet-object-detector   # Folder for annotated images.
+
+decode:                      # SSD decode settings.
+  score_threshold: 0.30      # Minimum sigmoid object confidence.
+  nms_iou: 0.60              # Overlap threshold for per-class NMS.
+  max_detections: 100        # Max detections to keep per image.
+
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Inference timeout in milliseconds.
+  num_runs: 1                # Number of repeated runs (profiling).
+  profile: false             # Print profiling summaries.
+  verbose: false             # Print verbose runtime output.
+
+output:                      # Output rendering settings.
+  overlay: true              # Draw boxes and labels on output images.

--- a/examples/object-detection/ssd-mobilenet-object-detector/src/cpp/CMakeLists.txt
+++ b/examples/object-detection/ssd-mobilenet-object-detector/src/cpp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(ssd-mobilenet-object-detector LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  include(CTest)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/ExampleModule.cmake")
+sima_neat_apps_module("ssd-mobilenet-object-detector" UNIT_TEST E2E_TEST)

--- a/examples/object-detection/ssd-mobilenet-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/ssd-mobilenet-object-detector/src/cpp/main.cpp
@@ -1,0 +1,740 @@
+/**
+ * @example ssd-mobilenet-object-detector.cpp
+ * SSD-MobileNetV2 (TF COCO) folder detection with host-side box decode.
+ *
+ * The compiled pack emits the 12 grouped convolution heads (6 localization + 6
+ * classification, feature maps 19/10/5/3/2/1 -> 1917 priors). This example reassembles
+ * them in anchor-major layout, decodes with the recovered ssd_anchor_generator priors
+ * (FasterRcnnBoxCoder), applies SIGMOID scoring + per-class NMS, and draws detections.
+ *
+ * Model input is normalized to [-1, 1] via (pixel / 127.5) - 1, with a direct STRETCH
+ * resize to 300x300 (fixed_shape_resizer), so boxes back-project with a per-axis scale.
+ *
+ * Usage: ssd-mobilenet-object-detector [--config <path>]
+ */
+#include "neat.h"
+#include "support/runtime/example_utils.h"
+#include "support/runtime/config_utils.h"
+
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace fs = std::filesystem;
+namespace neat = simaai::neat;
+
+namespace {
+
+constexpr int kModelSize = 300;
+constexpr int kNumClasses = 91;  // index 0 = background, 1..90 = COCO ids.
+constexpr int kDefaultTimeoutMs = 20000;
+constexpr float kScaleY = 10.0f;
+constexpr float kScaleX = 10.0f;
+constexpr float kScaleH = 5.0f;
+constexpr float kScaleW = 5.0f;
+
+// Feature levels largest -> smallest, matching the head/anchor ordering.
+struct Level {
+  int feat;
+  int anchors_per_cell;
+};
+constexpr std::array<Level, 6> kLevels = {
+    Level{19, 3}, Level{10, 6}, Level{5, 6}, Level{3, 6}, Level{2, 6}, Level{1, 6}};
+
+// Per-level SSD priors (w, h) in normalized image coordinates, largest -> smallest
+// feature map. Anchor centers are (cell + 0.5) / feature_size. This reproduces the
+// ssd_anchor_generator anchors of ssd_mobilenet_v2_coco_2018_03_29 -- the same per-level
+// prior table baked into the on-device SSD decode kernel -- so no anchor asset is shipped.
+struct PriorLevel {
+  int feat;
+  std::vector<std::array<float, 2>> priors;  // each entry is (w, h)
+};
+
+std::vector<PriorLevel> prior_levels() {
+  return {
+      PriorLevel{19, {{0.1f, 0.099999994f}, {0.2828427f, 0.14142135f}, {0.14142135f, 0.28284273f}}},
+      PriorLevel{10, {{0.34999999f, 0.35000002f}, {0.49497473f, 0.2474874f}, {0.24748738f, 0.49497464f}, {0.60621786f, 0.20207258f}, {0.20206252f, 0.60624808f}, {0.41833004f, 0.41833001f}}},
+      PriorLevel{5, {{0.5f, 0.49999997f}, {0.70710671f, 0.35355341f}, {0.35355338f, 0.70710677f}, {0.86602533f, 0.28867519f}, {0.28866071f, 0.86606878f}, {0.57008761f, 0.57008779f}}},
+      PriorLevel{3, {{0.64999992f, 0.65000004f}, {0.91923869f, 0.45961937f}, {0.45961937f, 0.91923869f}, {1.1258328f, 0.37527764f}, {0.37525886f, 1.1258892f}, {0.72111022f, 0.72111011f}}},
+      PriorLevel{2, {{0.79999995f, 0.79999995f}, {1.131371f, 0.56568551f}, {0.56568539f, 1.131371f}, {1.3856405f, 0.46188015f}, {0.46185714f, 1.3857099f}, {0.87177998f, 0.87177974f}}},
+      PriorLevel{1, {{0.95000011f, 0.94999999f}, {1.343503f, 0.67175144f}, {0.67175162f, 1.343503f}, {1.6454482f, 0.54848289f}, {0.54845542f, 1.6455302f}, {0.97467947f, 0.97467953f}}},
+  };
+}
+
+struct Config {
+  std::string model = "assets/models/ssd_mobilenet_v2_heads_mpk.tar.gz";
+  fs::path labels;
+  fs::path input_dir;
+  fs::path output_dir;
+  float score_threshold = 0.30f;
+  float nms_iou = 0.60f;
+  int max_detections = 100;
+  int timeout_ms = kDefaultTimeoutMs;
+  int num_runs = 1;
+  bool profile = false;
+};
+
+struct Detection {
+  float x1 = 0.0f;
+  float y1 = 0.0f;
+  float x2 = 0.0f;
+  float y2 = 0.0f;
+  float score = 0.0f;
+  int class_id = -1;
+};
+
+struct Stats {
+  double mean = 0.0;
+  double min = 0.0;
+  double max = 0.0;
+  double sum = 0.0;
+};
+
+Stats compute_stats(const std::vector<double>& values) {
+  Stats s;
+  if (values.empty()) {
+    return s;
+  }
+  s.min = values.front();
+  s.max = values.front();
+  for (double x : values) {
+    s.sum += x;
+    s.min = std::min(s.min, x);
+    s.max = std::max(s.max, x);
+  }
+  s.mean = s.sum / static_cast<double>(values.size());
+  return s;
+}
+
+float sigmoid(float x) {
+  return 1.0f / (1.0f + std::exp(-x));
+}
+
+bool is_image_file(const fs::path& path) {
+  std::string ext = path.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp";
+}
+
+std::vector<fs::path> image_paths_in_dir(const fs::path& input_dir) {
+  std::vector<fs::path> images;
+  for (const auto& entry : fs::directory_iterator(input_dir)) {
+    if (entry.is_regular_file() && is_image_file(entry.path())) {
+      images.push_back(entry.path());
+    }
+  }
+  std::sort(images.begin(), images.end());
+  return images;
+}
+
+// Resolve a labels/anchors asset: use the configured path if it exists, otherwise fall
+// back to the copy shipped next to this example under src/common.
+fs::path resolve_asset(const std::string& configured, const char* default_name) {
+  if (!configured.empty() && fs::exists(configured)) {
+    return configured;
+  }
+  const fs::path fallback =
+      fs::path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR) / ".." / "common" / default_name;
+  if (fs::exists(fallback)) {
+    return fallback;
+  }
+  return configured;
+}
+
+Config load_config(const fs::path& path) {
+  const auto raw = sima_examples::ScalarConfig::load(path);
+  Config cfg;
+  cfg.model = raw.string_or("model.path", "assets/models/ssd_mobilenet_v2_heads_mpk.tar.gz");
+  cfg.labels = resolve_asset(raw.string_or("model.labels", ""), "coco_labels.txt");
+  cfg.input_dir = raw.string_or("io.input_dir", "assets/test_images");
+  cfg.output_dir = raw.string_or("io.output_dir", "sandbox/ssd-mobilenet-object-detector");
+  cfg.score_threshold = static_cast<float>(raw.double_or("decode.score_threshold", 0.30));
+  cfg.nms_iou = static_cast<float>(raw.double_or("decode.nms_iou", 0.60));
+  cfg.max_detections = raw.int_or("decode.max_detections", 100);
+  cfg.timeout_ms = raw.int_or("runtime.timeout_ms", kDefaultTimeoutMs);
+  cfg.num_runs = raw.int_or("runtime.num_runs", 1);
+  cfg.profile = raw.bool_or("runtime.profile", false);
+  if (cfg.score_threshold < 0.0f || cfg.score_threshold > 1.0f) {
+    throw std::runtime_error("decode.score_threshold must be in [0.0, 1.0]");
+  }
+  if (cfg.num_runs < 1) {
+    throw std::runtime_error("runtime.num_runs must be >= 1");
+  }
+  if (cfg.timeout_ms <= 0) {
+    throw std::runtime_error("runtime.timeout_ms must be > 0");
+  }
+  return cfg;
+}
+
+Config parse_config(int argc, char** argv) {
+  fs::path config_path = sima_examples::default_config_path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR);
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--config") {
+      if (i + 1 >= argc) {
+        throw std::runtime_error("--config requires a path");
+      }
+      config_path = argv[++i];
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: " << argv[0] << " [--config <path>]\n";
+      std::exit(0);
+    } else {
+      throw std::runtime_error("unknown argument: " + arg);
+    }
+  }
+  return load_config(config_path);
+}
+
+std::vector<std::string> load_labels(const fs::path& path) {
+  std::ifstream in(path);
+  if (!in) {
+    throw std::runtime_error("failed to open labels file: " + path.string());
+  }
+  std::vector<std::string> labels;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    labels.push_back(line);
+  }
+  if (labels.empty()) {
+    throw std::runtime_error("labels file is empty: " + path.string());
+  }
+  return labels;
+}
+
+// Build the flat 1917x4 SSD priors (ycenter, xcenter, h, w) from the prior table.
+std::vector<float> generate_anchors() {
+  std::vector<float> anchors;
+  for (const PriorLevel& level : prior_levels()) {
+    const int feat = level.feat;
+    for (int y = 0; y < feat; ++y) {
+      const float cy = (static_cast<float>(y) + 0.5f) / static_cast<float>(feat);
+      for (int x = 0; x < feat; ++x) {
+        const float cx = (static_cast<float>(x) + 0.5f) / static_cast<float>(feat);
+        for (const std::array<float, 2>& wh : level.priors) {
+          anchors.push_back(cy);      // ycenter
+          anchors.push_back(cx);      // xcenter
+          anchors.push_back(wh[1]);   // h
+          anchors.push_back(wh[0]);   // w
+        }
+      }
+    }
+  }
+  return anchors;
+}
+
+std::string class_name(const std::vector<std::string>& labels, int class_id) {
+  if (class_id >= 0 && static_cast<size_t>(class_id) < labels.size()) {
+    const std::string& name = labels[static_cast<size_t>(class_id)];
+    if (!name.empty() && name != "N/A") {
+      return name;
+    }
+  }
+  return "class_" + std::to_string(class_id);
+}
+
+cv::Scalar class_color(int class_id) {
+  static const std::array<cv::Scalar, 8> kColors = {
+      cv::Scalar(0, 255, 0),   cv::Scalar(255, 0, 0),   cv::Scalar(0, 0, 255),
+      cv::Scalar(255, 255, 0), cv::Scalar(255, 0, 255), cv::Scalar(0, 255, 255),
+      cv::Scalar(128, 255, 0), cv::Scalar(255, 128, 0),
+  };
+  const size_t idx = static_cast<size_t>(class_id >= 0 ? class_id : -class_id) % kColors.size();
+  return kColors[idx];
+}
+
+cv::Mat preprocess_to_tensor_input(const cv::Mat& bgr_u8) {
+  if (bgr_u8.empty()) {
+    throw std::runtime_error("preprocess_to_tensor_input: empty image");
+  }
+  cv::Mat resized;
+  cv::resize(bgr_u8, resized, cv::Size(kModelSize, kModelSize), 0.0, 0.0, cv::INTER_LINEAR);
+  cv::Mat rgb;
+  cv::cvtColor(resized, rgb, cv::COLOR_BGR2RGB);
+  cv::Mat normalized;
+  // (pixel / 127.5) - 1.0
+  rgb.convertTo(normalized, CV_32FC3, 1.0 / 127.5, -1.0);
+  return normalized;
+}
+
+neat::Tensor tensor_from_hwc_f32(const cv::Mat& hwc_f32) {
+  if (hwc_f32.empty() || hwc_f32.type() != CV_32FC3) {
+    throw std::runtime_error("tensor_from_hwc_f32: expected non-empty CV_32FC3");
+  }
+  const int h = hwc_f32.rows;
+  const int w = hwc_f32.cols;
+  const int c = 3;
+  const size_t elems = static_cast<size_t>(h) * static_cast<size_t>(w) * static_cast<size_t>(c);
+  std::vector<float> data(elems);
+  std::memcpy(data.data(), hwc_f32.ptr<float>(), elems * sizeof(float));
+
+  neat::Tensor t = neat::Tensor::from_vector(data, {h, w, c}, neat::TensorMemory::EV74);
+  t.layout = neat::TensorLayout::HWC;
+  t.strides_bytes = {static_cast<int64_t>(w * c * sizeof(float)),
+                     static_cast<int64_t>(c * sizeof(float)), static_cast<int64_t>(sizeof(float))};
+  return t;
+}
+
+std::vector<neat::Tensor> collect_tensors(const neat::Sample& sample) {
+  if (sample.kind == neat::SampleKind::Tensor) {
+    if (!sample.tensor.has_value()) {
+      throw std::runtime_error("tensor sample missing payload");
+    }
+    return {*sample.tensor};
+  }
+  if (sample.kind == neat::SampleKind::TensorSet) {
+    return sample.tensors;
+  }
+  if (sample.kind == neat::SampleKind::Bundle) {
+    std::vector<neat::Tensor> out;
+    for (const auto& field : sample.fields) {
+      auto child = collect_tensors(field);
+      out.insert(out.end(), child.begin(), child.end());
+    }
+    return out;
+  }
+  throw std::runtime_error("unexpected sample kind");
+}
+
+std::vector<float> tensor_to_f32(const neat::Tensor& t) {
+  if (t.dtype != neat::TensorDType::Float32) {
+    throw std::runtime_error("expected Float32 tensor");
+  }
+  const std::vector<uint8_t> raw = t.copy_dense_bytes_tight();
+  if (raw.size() % sizeof(float) != 0) {
+    throw std::runtime_error("tensor raw byte size is not float-aligned");
+  }
+  std::vector<float> out(raw.size() / sizeof(float));
+  std::memcpy(out.data(), raw.data(), raw.size());
+  return out;
+}
+
+// A single decoded head, resolved to logical (feature map size, channels, layout).
+struct HeadView {
+  int feat = 0;
+  int channels = 0;
+  bool nhwc = true;  // true: data laid out [H,W,C]; false: [C,H,W].
+  std::vector<float> data;
+
+  float at(int y, int x, int ch) const {
+    if (nhwc) {
+      return data[(static_cast<size_t>(y) * feat + x) * channels + ch];
+    }
+    return data[(static_cast<size_t>(ch) * feat + y) * feat + x];
+  }
+};
+
+std::string shape_string(const std::vector<int64_t>& shape) {
+  std::string s = "[";
+  for (size_t i = 0; i < shape.size(); ++i) {
+    s += std::to_string(shape[i]);
+    if (i + 1 < shape.size()) {
+      s += ",";
+    }
+  }
+  return s + "]";
+}
+
+// Interpret a head tensor as HWC, tolerating whatever layout the runtime reports:
+// NHWC, NCHW, or NDHWC with unit N/D dims (the detess/dequant node emits NDHWC). Heads
+// have square feature maps (H == W); after dropping size-1 dims the channel axis is the
+// odd one out, and the smallest 1x1 level collapses to a single [C] vector.
+HeadView make_head_view(const neat::Tensor& t) {
+  std::vector<int> dims;
+  for (int64_t d : t.shape) {
+    if (d != 1) {
+      dims.push_back(static_cast<int>(d));
+    }
+  }
+  HeadView view;
+  view.data = tensor_to_f32(t);
+  if (dims.size() == 1) {  // 1x1 feature map -> [C]
+    view.nhwc = true;
+    view.feat = 1;
+    view.channels = dims[0];
+    return view;
+  }
+  if (dims.size() == 3) {
+    const int d0 = dims[0];
+    const int d1 = dims[1];
+    const int d2 = dims[2];
+    if (d0 == d1 && d0 != d2) {  // HWC
+      view.nhwc = true;
+      view.feat = d0;
+      view.channels = d2;
+      return view;
+    }
+    if (d1 == d2 && d1 != d0) {  // CHW
+      view.nhwc = false;
+      view.feat = d1;
+      view.channels = d0;
+      return view;
+    }
+  }
+  throw std::runtime_error("cannot infer head layout from shape " + shape_string(t.shape));
+}
+
+// Reassemble the 12 heads into anchor-major encodings [N*4] and class logits [N*91].
+void reassemble_heads(const std::vector<neat::Tensor>& tensors, std::vector<float>& encodings,
+                      std::vector<float>& logits, int num_priors) {
+  std::unordered_map<int, std::pair<int, int>> level_of;  // feat -> (anchors_per_cell, offset)
+  int off = 0;
+  for (const Level& lvl : kLevels) {
+    level_of[lvl.feat] = {lvl.anchors_per_cell, off};
+    off += lvl.feat * lvl.feat * lvl.anchors_per_cell;
+  }
+  encodings.assign(static_cast<size_t>(num_priors) * 4, 0.0f);
+  logits.assign(static_cast<size_t>(num_priors) * kNumClasses, 0.0f);
+
+  std::string all_shapes;
+  for (const neat::Tensor& t : tensors) {
+    all_shapes += (all_shapes.empty() ? "" : " ") + shape_string(t.shape);
+  }
+  const std::string context =
+      "; received " + std::to_string(tensors.size()) + " tensor(s) with shapes " + all_shapes;
+
+  int loc_heads = 0;
+  int conf_heads = 0;
+  for (const neat::Tensor& t : tensors) {
+    const HeadView head = make_head_view(t);
+    auto it = level_of.find(head.feat);
+    if (it == level_of.end()) {
+      throw std::runtime_error("unexpected head feature map size" + context);
+    }
+    const int anchors_per_cell = it->second.first;
+    const int base = it->second.second;
+
+    if (head.channels % kNumClasses == 0) {  // classification head
+      if (head.channels / kNumClasses != anchors_per_cell) {
+        throw std::runtime_error("conf head channel/anchor mismatch" + context);
+      }
+      for (int y = 0; y < head.feat; ++y) {
+        for (int x = 0; x < head.feat; ++x) {
+          for (int a = 0; a < anchors_per_cell; ++a) {
+            const int idx = base + (y * head.feat + x) * anchors_per_cell + a;
+            for (int c = 0; c < kNumClasses; ++c) {
+              logits[static_cast<size_t>(idx) * kNumClasses + c] = head.at(y, x, a * kNumClasses + c);
+            }
+          }
+        }
+      }
+      ++conf_heads;
+    } else if (head.channels % 4 == 0) {  // localization head
+      if (head.channels / 4 != anchors_per_cell) {
+        throw std::runtime_error("loc head channel/anchor mismatch" + context);
+      }
+      for (int y = 0; y < head.feat; ++y) {
+        for (int x = 0; x < head.feat; ++x) {
+          for (int a = 0; a < anchors_per_cell; ++a) {
+            const int idx = base + (y * head.feat + x) * anchors_per_cell + a;
+            for (int k = 0; k < 4; ++k) {
+              encodings[static_cast<size_t>(idx) * 4 + k] = head.at(y, x, a * 4 + k);
+            }
+          }
+        }
+      }
+      ++loc_heads;
+    } else {
+      throw std::runtime_error("unrecognized head channel depth " +
+                               std::to_string(head.channels) + context);
+    }
+  }
+  if (loc_heads != static_cast<int>(kLevels.size()) ||
+      conf_heads != static_cast<int>(kLevels.size())) {
+    throw std::runtime_error("expected 6 localization and 6 classification heads" + context);
+  }
+}
+
+// NMS over corner boxes (ymin,xmin,ymax,xmax); returns kept indices into `order` inputs.
+std::vector<int> nms(const std::vector<std::array<float, 4>>& boxes,
+                     const std::vector<float>& scores, float iou_thr) {
+  std::vector<int> order(boxes.size());
+  for (size_t i = 0; i < order.size(); ++i) {
+    order[i] = static_cast<int>(i);
+  }
+  std::sort(order.begin(), order.end(),
+            [&](int a, int b) { return scores[a] > scores[b]; });
+
+  std::vector<char> removed(boxes.size(), 0);
+  std::vector<int> keep;
+  for (size_t oi = 0; oi < order.size(); ++oi) {
+    const int i = order[oi];
+    if (removed[i]) {
+      continue;
+    }
+    keep.push_back(i);
+    const auto& bi = boxes[i];
+    const float ai =
+        std::max(0.0f, bi[2] - bi[0]) * std::max(0.0f, bi[3] - bi[1]);
+    for (size_t oj = oi + 1; oj < order.size(); ++oj) {
+      const int j = order[oj];
+      if (removed[j]) {
+        continue;
+      }
+      const auto& bj = boxes[j];
+      const float yy1 = std::max(bi[0], bj[0]);
+      const float xx1 = std::max(bi[1], bj[1]);
+      const float yy2 = std::min(bi[2], bj[2]);
+      const float xx2 = std::min(bi[3], bj[3]);
+      const float inter = std::max(0.0f, yy2 - yy1) * std::max(0.0f, xx2 - xx1);
+      const float aj =
+          std::max(0.0f, bj[2] - bj[0]) * std::max(0.0f, bj[3] - bj[1]);
+      const float iou = inter / (ai + aj - inter + 1e-9f);
+      if (iou > iou_thr) {
+        removed[j] = 1;
+      }
+    }
+  }
+  return keep;
+}
+
+std::vector<Detection> decode_ssd_outputs(const std::vector<float>& encodings,
+                                          const std::vector<float>& logits,
+                                          const std::vector<float>& anchors, int num_priors,
+                                          int orig_w, int orig_h, const Config& cfg) {
+  // Decode all priors to normalized corner boxes once.
+  std::vector<std::array<float, 4>> boxes(static_cast<size_t>(num_priors));
+  for (int j = 0; j < num_priors; ++j) {
+    const float ty = encodings[static_cast<size_t>(j) * 4 + 0];
+    const float tx = encodings[static_cast<size_t>(j) * 4 + 1];
+    const float th = encodings[static_cast<size_t>(j) * 4 + 2];
+    const float tw = encodings[static_cast<size_t>(j) * 4 + 3];
+    const float ay = anchors[static_cast<size_t>(j) * 4 + 0];
+    const float ax = anchors[static_cast<size_t>(j) * 4 + 1];
+    const float ah = anchors[static_cast<size_t>(j) * 4 + 2];
+    const float aw = anchors[static_cast<size_t>(j) * 4 + 3];
+    const float yc = ty / kScaleY * ah + ay;
+    const float xc = tx / kScaleX * aw + ax;
+    const float h = std::exp(th / kScaleH) * ah;
+    const float w = std::exp(tw / kScaleW) * aw;
+    boxes[j] = {yc - h / 2.0f, xc - w / 2.0f, yc + h / 2.0f, xc + w / 2.0f};
+  }
+
+  std::vector<Detection> dets;
+  const int foreground = kNumClasses - 1;  // drop background
+  for (int c = 0; c < foreground; ++c) {
+    std::vector<std::array<float, 4>> cand_boxes;
+    std::vector<float> cand_scores;
+    std::vector<int> cand_priors;
+    for (int j = 0; j < num_priors; ++j) {
+      const float score = sigmoid(logits[static_cast<size_t>(j) * kNumClasses + (c + 1)]);
+      if (score >= cfg.score_threshold) {
+        cand_boxes.push_back(boxes[j]);
+        cand_scores.push_back(score);
+        cand_priors.push_back(j);
+      }
+    }
+    if (cand_boxes.empty()) {
+      continue;
+    }
+    const std::vector<int> keep = nms(cand_boxes, cand_scores, cfg.nms_iou);
+    for (int k : keep) {
+      const auto& b = cand_boxes[static_cast<size_t>(k)];
+      float x1 = std::clamp(b[1] * orig_w, 0.0f, static_cast<float>(orig_w));
+      float y1 = std::clamp(b[0] * orig_h, 0.0f, static_cast<float>(orig_h));
+      float x2 = std::clamp(b[3] * orig_w, 0.0f, static_cast<float>(orig_w));
+      float y2 = std::clamp(b[2] * orig_h, 0.0f, static_cast<float>(orig_h));
+      if (x2 <= x1 || y2 <= y1) {
+        continue;
+      }
+      dets.push_back(Detection{x1, y1, x2, y2, cand_scores[static_cast<size_t>(k)], c + 1});
+    }
+  }
+
+  std::sort(dets.begin(), dets.end(),
+            [](const Detection& a, const Detection& b) { return a.score > b.score; });
+  if (cfg.max_detections > 0 && static_cast<int>(dets.size()) > cfg.max_detections) {
+    dets.resize(static_cast<size_t>(cfg.max_detections));
+  }
+  return dets;
+}
+
+void draw_detections(cv::Mat& bgr, const std::vector<Detection>& dets,
+                     const std::vector<std::string>& labels) {
+  for (const Detection& d : dets) {
+    const int x1 = std::max(0, std::min(bgr.cols - 1, static_cast<int>(std::lround(d.x1))));
+    const int y1 = std::max(0, std::min(bgr.rows - 1, static_cast<int>(std::lround(d.y1))));
+    const int x2 = std::max(0, std::min(bgr.cols - 1, static_cast<int>(std::lround(d.x2))));
+    const int y2 = std::max(0, std::min(bgr.rows - 1, static_cast<int>(std::lround(d.y2))));
+    if (x2 <= x1 || y2 <= y1) {
+      continue;
+    }
+    const cv::Scalar color = class_color(d.class_id);
+    const std::string text = class_name(labels, d.class_id) + " " + cv::format("%.2f", d.score);
+    cv::rectangle(bgr, cv::Point(x1, y1), cv::Point(x2, y2), color, 2);
+    cv::putText(bgr, text, cv::Point(x1, std::max(0, y1 - 4)), cv::FONT_HERSHEY_SIMPLEX, 0.5, color,
+                2, cv::LINE_AA);
+  }
+}
+
+int num_priors_total() {
+  int total = 0;
+  for (const Level& lvl : kLevels) {
+    total += lvl.feat * lvl.feat * lvl.anchors_per_cell;
+  }
+  return total;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  std::cout.setf(std::ios::unitbuf);
+  std::cerr.setf(std::ios::unitbuf);
+
+  try {
+    const Config cfg = parse_config(argc, argv);
+    if (!fs::is_directory(cfg.input_dir)) {
+      throw std::runtime_error("input_dir does not exist: " + cfg.input_dir.string());
+    }
+    if (!fs::exists(cfg.model)) {
+      throw std::runtime_error("model does not exist: " + cfg.model);
+    }
+
+    const std::vector<std::string> labels = load_labels(cfg.labels);
+    const std::vector<float> anchors = generate_anchors();
+    const int num_priors = num_priors_total();
+    if (static_cast<int>(anchors.size()) != num_priors * 4) {
+      throw std::runtime_error("generated anchors count does not match expected priors");
+    }
+
+    const std::vector<fs::path> image_paths = image_paths_in_dir(cfg.input_dir);
+    if (image_paths.empty()) {
+      throw std::runtime_error("no images found in: " + cfg.input_dir.string());
+    }
+
+    neat::Model::Options model_opt;
+    model_opt.preprocess.kind = neat::InputKind::Tensor;
+    model_opt.preprocess.input_max_width = kModelSize;
+    model_opt.preprocess.input_max_height = kModelSize;
+    model_opt.preprocess.input_max_depth = 3;
+
+    neat::Model model(cfg.model, model_opt);
+
+    neat::Graph graph;
+    graph.add(neat::nodes::Input(model.input_appsrc_options(true)));
+    graph.add(neat::nodes::QuantTess(neat::QuantTessOptions(model)));
+    graph.add(neat::nodes::groups::MLA(model));
+    graph.add(neat::nodes::DetessDequant(neat::DetessDequantOptions(model)));
+    graph.add(neat::nodes::Output());
+
+    cv::Mat dummy(kModelSize, kModelSize, CV_32FC3, cv::Scalar(0.0f, 0.0f, 0.0f));
+    auto run = graph.build(neat::TensorList{tensor_from_hwc_f32(dummy)});
+
+    if (cfg.profile) {
+      const fs::path& image_path = image_paths.front();
+      cv::Mat bgr_u8 = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+      if (bgr_u8.empty()) {
+        throw std::runtime_error("failed to read image: " + image_path.string());
+      }
+      cv::Mat input_f32 = preprocess_to_tensor_input(bgr_u8);
+      neat::Tensor input_t = tensor_from_hwc_f32(input_f32);
+
+      const int runs = std::max(1, cfg.num_runs);
+      std::vector<double> graph_times;
+      std::vector<double> post_times;
+      std::vector<Detection> last_dets;
+      std::vector<float> encodings;
+      std::vector<float> logits;
+
+      for (int i = 0; i < runs; ++i) {
+        const auto t0 = std::chrono::steady_clock::now();
+        if (!run.push(neat::TensorList{input_t})) {
+          throw std::runtime_error("run.push failed during profiling");
+        }
+        auto out_sample = run.pull(cfg.timeout_ms);
+        const auto t1 = std::chrono::steady_clock::now();
+        if (!out_sample.has_value()) {
+          throw std::runtime_error("run.pull returned no sample during profiling");
+        }
+        const std::vector<neat::Tensor> tensors = collect_tensors(*out_sample);
+        reassemble_heads(tensors, encodings, logits, num_priors);
+        last_dets = decode_ssd_outputs(encodings, logits, anchors, num_priors, bgr_u8.cols,
+                                       bgr_u8.rows, cfg);
+        const auto t2 = std::chrono::steady_clock::now();
+        graph_times.push_back(std::chrono::duration<double>(t1 - t0).count());
+        post_times.push_back(std::chrono::duration<double>(t2 - t1).count());
+      }
+
+      const Stats graph_stats = compute_stats(graph_times);
+      const Stats post = compute_stats(post_times);
+      const double runs_d = static_cast<double>(graph_times.size());
+      std::cout << "Profiling over " << graph_times.size() << " runs (image='"
+                << image_path.string() << "'):\n";
+      std::cout << "  Graph run (push+pull): mean=" << graph_stats.mean
+                << "s, min=" << graph_stats.min << "s, max=" << graph_stats.max
+                << "s, FPS=" << (runs_d / graph_stats.sum) << "\n";
+      std::cout << "  Postprocessing (decode+NMS): mean=" << post.mean << "s, min=" << post.min
+                << "s, max=" << post.max << "s, FPS=" << (runs_d / post.sum) << "\n";
+      std::cout << "Last run detections: " << last_dets.size() << "\n";
+      for (size_t i = 0; i < std::min<size_t>(last_dets.size(), 20); ++i) {
+        const auto& d = last_dets[i];
+        std::cout << "  [" << i << "] class=" << class_name(labels, d.class_id) << "("
+                  << d.class_id << ") score=" << d.score << " box=[" << d.x1 << "," << d.y1 << ","
+                  << d.x2 << "," << d.y2 << "]\n";
+      }
+      run.close();
+      return 0;
+    }
+
+    fs::create_directories(cfg.output_dir);
+    std::vector<float> encodings;
+    std::vector<float> logits;
+    int processed = 0;
+    for (const fs::path& image_path : image_paths) {
+      cv::Mat bgr_u8 = cv::imread(image_path.string(), cv::IMREAD_COLOR);
+      if (bgr_u8.empty()) {
+        throw std::runtime_error("failed to read image: " + image_path.string());
+      }
+      cv::Mat input_f32 = preprocess_to_tensor_input(bgr_u8);
+      neat::Tensor input_t = tensor_from_hwc_f32(input_f32);
+
+      if (!run.push(neat::TensorList{input_t})) {
+        throw std::runtime_error("run.push failed");
+      }
+      auto out_sample = run.pull(cfg.timeout_ms);
+      if (!out_sample.has_value()) {
+        throw std::runtime_error("run.pull returned no sample");
+      }
+
+      const std::vector<neat::Tensor> tensors = collect_tensors(*out_sample);
+      reassemble_heads(tensors, encodings, logits, num_priors);
+      const std::vector<Detection> dets = decode_ssd_outputs(
+          encodings, logits, anchors, num_priors, bgr_u8.cols, bgr_u8.rows, cfg);
+
+      cv::Mat overlay = bgr_u8.clone();
+      draw_detections(overlay, dets, labels);
+      const fs::path output_path = cfg.output_dir / (image_path.stem().string() + "_ssd.png");
+      if (!cv::imwrite(output_path.string(), overlay)) {
+        throw std::runtime_error("failed to write: " + output_path.string());
+      }
+      ++processed;
+      std::cout << "[" << processed << "/" << image_paths.size() << "] "
+                << image_path.filename().string() << ": " << dets.size() << " detections -> "
+                << output_path.filename().string() << "\n";
+    }
+    std::cout << "Done: " << processed << " images processed\n";
+
+    run.close();
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 2;
+  }
+}

--- a/examples/object-detection/ssd-mobilenet-object-detector/src/python/main.py
+++ b/examples/object-detection/ssd-mobilenet-object-detector/src/python/main.py
@@ -1,0 +1,580 @@
+"""SSD-MobileNetV2 (TF COCO) folder object detection with host-side box decode.
+
+The compiled pack emits the 12 grouped convolution heads of the TF Object Detection
+API model ``ssd_mobilenet_v2_coco_2018_03_29`` (6 localization + 6 classification,
+feature maps 19/10/5/3/2/1 -> 1917 priors). This example reassembles those heads in
+anchor-major layout, applies the ``FasterRcnnBoxCoder`` anchor decode with the
+recovered ``ssd_anchor_generator`` priors, SIGMOID class scoring, per-class NMS, and
+draws the detections onto the original image.
+
+Model input is normalized to ``[-1, 1]`` via ``(pixel / 127.5) - 1`` and the resize is
+a direct STRETCH to 300x300 (the model was trained with ``fixed_shape_resizer``), so
+boxes back-project onto the source with a simple per-axis scale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+VERBOSE = False
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_PATH = "assets/models/ssd_mobilenet_v2_heads_mpk.tar.gz"
+DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
+COMMON_DIR = Path(__file__).resolve().parents[1] / "common"
+
+MODEL_SIZE = 300
+NUM_CLASSES = 91  # index 0 = background, 1..90 = COCO ids.
+# FasterRcnnBoxCoder scales: (y, x, h, w).
+SCALE_Y, SCALE_X, SCALE_H, SCALE_W = 10.0, 10.0, 5.0, 5.0
+
+# Per-level SSD priors, largest -> smallest feature map. Each (w, h) is a prior box
+# size in normalized image coordinates; anchor centers are (cell + 0.5) / feature_size.
+# This reproduces the ssd_anchor_generator anchors of ssd_mobilenet_v2_coco_2018_03_29 --
+# the same per-level prior table baked into the on-device SSD decode kernel -- so no
+# anchor asset needs to be shipped. Anchors are (ycenter, xcenter, h, w).
+PRIOR_LEVELS: list[tuple[int, list[tuple[float, float]]]] = [
+    (19, [(0.1, 0.099999994), (0.2828427, 0.14142135), (0.14142135, 0.28284273)]),
+    (10, [(0.34999999, 0.35000002), (0.49497473, 0.2474874), (0.24748738, 0.49497464),
+          (0.60621786, 0.20207258), (0.20206252, 0.60624808), (0.41833004, 0.41833001)]),
+    (5, [(0.5, 0.49999997), (0.70710671, 0.35355341), (0.35355338, 0.70710677),
+         (0.86602533, 0.28867519), (0.28866071, 0.86606878), (0.57008761, 0.57008779)]),
+    (3, [(0.64999992, 0.65000004), (0.91923869, 0.45961937), (0.45961937, 0.91923869),
+         (1.1258328, 0.37527764), (0.37525886, 1.1258892), (0.72111022, 0.72111011)]),
+    (2, [(0.79999995, 0.79999995), (1.131371, 0.56568551), (0.56568539, 1.131371),
+         (1.3856405, 0.46188015), (0.46185714, 1.3857099), (0.87177998, 0.87177974)]),
+    (1, [(0.95000011, 0.94999999), (1.343503, 0.67175144), (0.67175162, 1.343503),
+         (1.6454482, 0.54848289), (0.54845542, 1.6455302), (0.97467947, 0.97467953)]),
+]
+
+# Feature levels as (feature_map_size, anchors_per_cell), derived from PRIOR_LEVELS.
+LEVELS = [(feat, len(priors)) for feat, priors in PRIOR_LEVELS]
+
+BOX_COLORS = [
+    (0, 255, 0),
+    (255, 0, 0),
+    (0, 0, 255),
+    (255, 255, 0),
+    (255, 0, 255),
+    (0, 255, 255),
+    (128, 255, 0),
+    (255, 128, 0),
+]
+
+
+def _feature_offsets() -> dict[int, tuple[int, int]]:
+    """Map feature-map size -> (anchors_per_cell, flat prior offset)."""
+    offsets: dict[int, tuple[int, int]] = {}
+    off = 0
+    for feat, anchors_per_cell in LEVELS:
+        offsets[feat] = (anchors_per_cell, off)
+        off += feat * feat * anchors_per_cell
+    return offsets
+
+
+FEATURE_OFFSETS = _feature_offsets()
+NUM_PRIORS = sum(feat * feat * a for feat, a in LEVELS)  # 1917
+
+
+def is_image(path: Path) -> bool:
+    return path.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
+
+
+def _log(msg: str) -> None:
+    if VERBOSE:
+        print(f"[ssd-debug] {msg}", flush=True)
+
+
+def _resolve_asset(configured: str, default_name: str) -> Path:
+    """Resolve a labels/anchors asset path, falling back to the packaged copy.
+
+    ``config.yaml`` stores repo-relative paths (resolved from the apps root when run
+    per the README). When the working directory differs (e.g. under the test harness),
+    fall back to the copy that ships next to this example under ``src/common``.
+    """
+    candidate = Path(configured)
+    if candidate.is_file():
+        return candidate
+    fallback = COMMON_DIR / default_name
+    if fallback.is_file():
+        return fallback
+    return candidate
+
+
+@dataclass(frozen=True)
+class PreprocMeta:
+    orig_h: int
+    orig_w: int
+
+
+def sigmoid(x: "np.ndarray") -> "np.ndarray":
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def generate_anchors() -> "np.ndarray":
+    """Build the 1917x4 SSD priors (ycenter, xcenter, h, w) from PRIOR_LEVELS."""
+    anchors = np.empty((NUM_PRIORS, 4), dtype=np.float32)
+    idx = 0
+    for feat, priors in PRIOR_LEVELS:
+        for y in range(feat):
+            cy = (y + 0.5) / feat
+            for x in range(feat):
+                cx = (x + 0.5) / feat
+                for w, h in priors:
+                    anchors[idx] = (cy, cx, h, w)
+                    idx += 1
+    return anchors
+
+
+def load_labels(path: Path) -> list[str]:
+    if not path.is_file():
+        raise FileNotFoundError(f"labels file does not exist: {path}")
+    labels = [line.rstrip("\n") for line in path.read_text(encoding="utf-8").splitlines()]
+    if not labels:
+        raise ValueError(f"labels file is empty: {path}")
+    return labels
+
+
+def class_name(labels: list[str], class_idx: int) -> str:
+    if 0 <= class_idx < len(labels):
+        name = labels[class_idx]
+        if name and name != "N/A":
+            return name
+    return f"class_{class_idx}"
+
+
+def class_color(class_idx: int) -> tuple[int, int, int]:
+    return BOX_COLORS[abs(class_idx) % len(BOX_COLORS)]
+
+
+def tensor_to_numpy(t: "pyneat.Tensor") -> "np.ndarray":
+    return np.asarray(t.to_numpy(copy=True))
+
+
+def iter_tensors(sample: "pyneat.Sample"):
+    if sample.kind == pyneat.SampleKind.Tensor and sample.tensor is not None:
+        yield sample.tensor
+    elif sample.kind == pyneat.SampleKind.TensorSet:
+        yield from sample.tensors
+    for field in sample.fields:
+        yield from iter_tensors(field)
+
+
+def collect_tensors(sample: "pyneat.Sample") -> list["pyneat.Tensor"]:
+    return list(iter_tensors(sample))
+
+
+def tensor_from_hwc_f32(array: "np.ndarray") -> "pyneat.Tensor":
+    if array.ndim != 3 or array.shape[2] != 3:
+        raise ValueError(f"expected HWC float32 image tensor, got {array.shape}")
+    arr = np.ascontiguousarray(array, dtype=np.float32)
+    return pyneat.Tensor.from_numpy(
+        arr,
+        copy=True,
+        layout=pyneat.TensorLayout.HWC,
+        memory=pyneat.TensorMemory.EV74,
+    )
+
+
+def preprocess_image_bgr(image_bgr: "np.ndarray") -> tuple["np.ndarray", PreprocMeta]:
+    """STRETCH resize to 300x300, BGR->RGB, normalize to [-1, 1]."""
+    orig_h, orig_w = image_bgr.shape[:2]
+    resized = cv2.resize(
+        image_bgr, (MODEL_SIZE, MODEL_SIZE), interpolation=cv2.INTER_LINEAR
+    )
+    rgb = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB).astype(np.float32)
+    normalized = np.ascontiguousarray(rgb / 127.5 - 1.0, dtype=np.float32)
+    return normalized, PreprocMeta(orig_h=orig_h, orig_w=orig_w)
+
+
+def head_to_hwc(array: "np.ndarray") -> "np.ndarray":
+    """Return a single detection head as HWC float32, tolerating whatever layout the
+    runtime reports: NHWC, NCHW, or NDHWC with unit N/D dims (the detess/dequant node
+    emits NDHWC). Heads have square feature maps (H == W), so after dropping size-1 dims
+    the channel axis is the odd one out; the smallest 1x1 level collapses to a [C] vector.
+    """
+    arr = np.asarray(array, dtype=np.float32)
+    dims = [int(d) for d in arr.shape if d != 1]
+    if len(dims) == 1:  # 1x1 feature map -> [C]
+        return arr.reshape(1, 1, dims[0])
+    if len(dims) == 3:
+        squeezed = arr.reshape(dims)
+        d0, d1, d2 = dims
+        if d0 == d1 and d0 != d2:
+            return np.ascontiguousarray(squeezed)  # HWC
+        if d1 == d2 and d1 != d0:
+            return np.ascontiguousarray(np.transpose(squeezed, (1, 2, 0)))  # CHW -> HWC
+    raise ValueError(f"cannot infer head layout from shape {tuple(arr.shape)}")
+
+
+def reassemble_heads(
+    arrays: list["np.ndarray"],
+) -> tuple["np.ndarray", "np.ndarray"]:
+    """Reassemble the 12 conv heads into [N,4] encodings and [N,91] class logits.
+
+    Localization channel layout is anchor-major ``a*4 + coord`` (coord = ty,tx,th,tw);
+    classification is ``a*91 + class``. Priors are ordered largest->smallest feature
+    map, then row-major cell, then anchor -- matching the anchor file.
+    """
+    shapes = [tuple(int(d) for d in np.asarray(a).shape) for a in arrays]
+    encodings = np.zeros((NUM_PRIORS, 4), dtype=np.float32)
+    logits = np.zeros((NUM_PRIORS, NUM_CLASSES), dtype=np.float32)
+    seen_loc: set[int] = set()
+    seen_conf: set[int] = set()
+
+    try:
+        for raw in arrays:
+            hwc = head_to_hwc(raw)
+            feat, feat_w, channels = hwc.shape
+            if feat != feat_w or feat not in FEATURE_OFFSETS:
+                raise ValueError(f"unexpected head feature map {hwc.shape}")
+            anchors_per_cell, off = FEATURE_OFFSETS[feat]
+            count = feat * feat * anchors_per_cell
+
+            if channels % NUM_CLASSES == 0:  # classification head
+                if channels // NUM_CLASSES != anchors_per_cell:
+                    raise ValueError(f"conf head channel/anchor mismatch: {hwc.shape}")
+                block = hwc.reshape(feat, feat, anchors_per_cell, NUM_CLASSES).reshape(-1, NUM_CLASSES)
+                logits[off : off + count] = block
+                seen_conf.add(feat)
+            elif channels % 4 == 0:  # localization head
+                if channels // 4 != anchors_per_cell:
+                    raise ValueError(f"loc head channel/anchor mismatch: {hwc.shape}")
+                block = hwc.reshape(feat, feat, anchors_per_cell, 4).reshape(-1, 4)
+                encodings[off : off + count] = block
+                seen_loc.add(feat)
+            else:
+                raise ValueError(f"unrecognized head channel depth {channels}")
+    except Exception as exc:
+        raise ValueError(
+            f"{exc}; received {len(arrays)} model output tensor(s) with shapes {shapes}"
+        ) from exc
+
+    expected = {feat for feat, _ in LEVELS}
+    if seen_loc != expected or seen_conf != expected:
+        raise ValueError(
+            f"missing heads: loc={sorted(seen_loc)} conf={sorted(seen_conf)} "
+            f"expected {sorted(expected)}; received {len(arrays)} tensor(s) with shapes {shapes}"
+        )
+    return encodings, logits
+
+
+def decode_boxes(encodings: "np.ndarray", anchors: "np.ndarray") -> "np.ndarray":
+    """encodings [N,4] (ty,tx,th,tw) -> normalized corners [N,4] (ymin,xmin,ymax,xmax)."""
+    ty, tx, th, tw = encodings.T
+    ay, ax, ah, aw = anchors.T
+    yc = ty / SCALE_Y * ah + ay
+    xc = tx / SCALE_X * aw + ax
+    h = np.exp(th / SCALE_H) * ah
+    w = np.exp(tw / SCALE_W) * aw
+    return np.stack([yc - h / 2, xc - w / 2, yc + h / 2, xc + w / 2], axis=1)
+
+
+def nms(boxes: "np.ndarray", scores: "np.ndarray", iou_thr: float) -> list[int]:
+    """Single-class NMS on corner boxes [M,4] (ymin,xmin,ymax,xmax)."""
+    if len(boxes) == 0:
+        return []
+    y1, x1, y2, x2 = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    area = np.maximum(0.0, y2 - y1) * np.maximum(0.0, x2 - x1)
+    order = scores.argsort()[::-1]
+    keep: list[int] = []
+    while order.size > 0:
+        i = order[0]
+        keep.append(int(i))
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy2 = np.minimum(y2[i], y2[order[1:]])
+        xx2 = np.minimum(x2[i], x2[order[1:]])
+        inter = np.maximum(0.0, yy2 - yy1) * np.maximum(0.0, xx2 - xx1)
+        iou = inter / (area[i] + area[order[1:]] - inter + 1e-9)
+        order = order[1:][iou <= iou_thr]
+    return keep
+
+
+def process_ssd_output(
+    encodings: "np.ndarray",
+    logits: "np.ndarray",
+    anchors: "np.ndarray",
+    meta: PreprocMeta,
+    *,
+    score_threshold: float,
+    nms_iou: float,
+    max_detections: int,
+) -> list[dict[str, Any]]:
+    """Full SSD decode -> detections in original-image pixel coordinates."""
+    boxes = decode_boxes(encodings, anchors)  # normalized corners
+    scores = sigmoid(logits)[:, 1:]  # drop background -> [N,90]
+
+    detections: list[dict[str, Any]] = []
+    for cls in range(scores.shape[1]):
+        cls_scores = scores[:, cls]
+        mask = cls_scores >= score_threshold
+        if not np.any(mask):
+            continue
+        idx = np.where(mask)[0]
+        keep = nms(boxes[idx], cls_scores[idx], nms_iou)
+        for k in keep:
+            j = idx[k]
+            ymin, xmin, ymax, xmax = boxes[j]
+            x1 = float(np.clip(xmin * meta.orig_w, 0.0, meta.orig_w))
+            y1 = float(np.clip(ymin * meta.orig_h, 0.0, meta.orig_h))
+            x2 = float(np.clip(xmax * meta.orig_w, 0.0, meta.orig_w))
+            y2 = float(np.clip(ymax * meta.orig_h, 0.0, meta.orig_h))
+            if x2 <= x1 or y2 <= y1:
+                continue
+            detections.append(
+                {
+                    "box": np.array([x1, y1, x2, y2], dtype=np.float32),
+                    "score": float(cls_scores[j]),
+                    "class_id": cls + 1,  # foreground index -> COCO id (1..90)
+                }
+            )
+
+    detections.sort(key=lambda d: d["score"], reverse=True)
+    if max_detections > 0:
+        detections = detections[:max_detections]
+    return detections
+
+
+def visualize_detections(
+    image_bgr: "np.ndarray",
+    detections: list[dict[str, Any]],
+    labels: list[str],
+) -> "np.ndarray":
+    image_copy = image_bgr.copy()
+    for det in detections:
+        x1, y1, x2, y2 = det["box"].astype(np.int32)
+        color = class_color(det["class_id"])
+        text = f"{class_name(labels, det['class_id'])} {det['score']:.2f}"
+        cv2.rectangle(image_copy, (x1, y1), (x2, y2), color, 2)
+        cv2.putText(
+            image_copy,
+            text,
+            (x1, max(0, y1 - 4)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            color,
+            2,
+        )
+    return image_copy
+
+
+def build_graph_runner(model: "pyneat.Model") -> "pyneat.Run":
+    graph = pyneat.Graph()
+    graph.add(pyneat.nodes.input(model.input_appsrc_options(True)))
+    graph.add(pyneat.nodes.quant_tess(pyneat.QuantTessOptions(model)))
+    graph.add(pyneat.groups.mla(model))
+    graph.add(pyneat.nodes.detess_dequant(pyneat.DetessDequantOptions(model)))
+    graph.add(pyneat.nodes.output())
+
+    dummy = tensor_from_hwc_f32(np.zeros((MODEL_SIZE, MODEL_SIZE, 3), dtype=np.float32))
+    return graph.build([dummy])
+
+
+def load_tensor_model(model_path: Path) -> "pyneat.Model":
+    opt = pyneat.ModelOptions()
+    opt.preprocess.kind = pyneat.InputKind.Tensor
+    opt.preprocess.input_max_width = MODEL_SIZE
+    opt.preprocess.input_max_height = MODEL_SIZE
+    opt.preprocess.input_max_depth = 3
+    return pyneat.Model(str(model_path), opt)
+
+
+def run_model_inference(
+    runner: "pyneat.Run", preprocessed: "np.ndarray", timeout_ms: int
+) -> list["np.ndarray"]:
+    tensor = tensor_from_hwc_f32(preprocessed)
+    if not runner.push([tensor]):
+        raise RuntimeError("Run.push() failed")
+    sample = runner.pull(timeout_ms=timeout_ms)
+    if sample is None:
+        raise RuntimeError("Run.pull() returned no sample")
+    return [tensor_to_numpy(t) for t in collect_tensors(sample)]
+
+
+def prepare_input(image_path: Path) -> tuple["np.ndarray", "np.ndarray", PreprocMeta]:
+    _log(f"Reading image: {image_path}")
+    bgr = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+    if bgr is None:
+        raise RuntimeError(f"Failed to read image: {image_path}")
+    preprocessed, meta = preprocess_image_bgr(bgr)
+    return bgr, preprocessed, meta
+
+
+def format_profile_stats(name: str, values: list[float]) -> str:
+    arr = np.array(values, dtype=np.float64)
+    fps = float(len(arr)) / arr.sum() if arr.sum() > 0 else 0.0
+    return (
+        f"  {name}: mean={arr.mean():.8f}s, min={arr.min():.8f}s, "
+        f"max={arr.max():.8f}s, FPS={fps:.3f}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="SSD-MobileNetV2 folder object detection example")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to YAML configuration")
+    args = parser.parse_args()
+
+    global cv2, np, pyneat
+    import cv2  # noqa: F401
+    import numpy as np  # noqa: F401
+    import pyneat  # noqa: F401
+
+    with args.config.open("r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+    model_cfg = raw.get("model", {})
+    io_cfg = raw.get("io", {})
+    decode_cfg = raw.get("decode", {})
+    runtime_cfg = raw.get("runtime", {})
+
+    model_path = Path(model_cfg.get("path", DEFAULT_MODEL_PATH))
+    labels_path = _resolve_asset(model_cfg.get("labels", ""), "coco_labels.txt")
+    input_dir = Path(io_cfg.get("input_dir", "assets/test_images"))
+    output_dir = Path(io_cfg.get("output_dir", "sandbox/ssd-mobilenet-object-detector"))
+    score_threshold = float(decode_cfg.get("score_threshold", 0.30))
+    nms_iou = float(decode_cfg.get("nms_iou", 0.60))
+    max_detections = int(decode_cfg.get("max_detections", 100))
+    profile = bool(runtime_cfg.get("profile", False))
+    num_runs = int(runtime_cfg.get("num_runs", 1))
+    timeout_ms = int(runtime_cfg.get("timeout_ms", 20000))
+
+    global VERBOSE
+    VERBOSE = bool(runtime_cfg.get("verbose", False))
+
+    if not (0.0 <= score_threshold <= 1.0):
+        print("decode.score_threshold must be in [0.0, 1.0]", file=sys.stderr)
+        return 2
+    if not model_path.is_file():
+        print(f"Model file does not exist: {model_path}", file=sys.stderr)
+        return 2
+    if not input_dir.is_dir():
+        print(f"Input directory does not exist: {input_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        labels = load_labels(labels_path)
+    except Exception as exc:
+        print(f"Error loading assets: {exc}", file=sys.stderr)
+        return 2
+    anchors = generate_anchors()
+
+    image_paths = sorted(p for p in input_dir.iterdir() if p.is_file() and is_image(p))
+    if not image_paths:
+        print(f"No images found in {input_dir}", file=sys.stderr)
+        return 3
+
+    try:
+        model = load_tensor_model(model_path)
+        runner = build_graph_runner(model)
+    except Exception as exc:
+        logger.debug("Model/graph build failure", exc_info=exc)
+        print(f"Error loading model: {exc}", file=sys.stderr)
+        return 3
+
+    if profile:
+        try:
+            image_path = image_paths[0]
+            _, preprocessed, meta = prepare_input(image_path)
+            tensor = tensor_from_hwc_f32(preprocessed)
+            graph_times: list[float] = []
+            post_times: list[float] = []
+            last_detections: list[dict[str, Any]] = []
+
+            for _ in range(max(1, num_runs)):
+                t0 = time.perf_counter()
+                if not runner.push([tensor]):
+                    print("Profiling failed: runner.push returned False", file=sys.stderr)
+                    break
+                sample = runner.pull(timeout_ms=timeout_ms)
+                t1 = time.perf_counter()
+                if sample is None:
+                    print("Profiling failed: runner.pull returned no sample", file=sys.stderr)
+                    break
+                arrays = [tensor_to_numpy(t) for t in collect_tensors(sample)]
+                encodings, logits = reassemble_heads(arrays)
+                detections = process_ssd_output(
+                    encodings, logits, anchors, meta,
+                    score_threshold=score_threshold, nms_iou=nms_iou,
+                    max_detections=max_detections,
+                )
+                t2 = time.perf_counter()
+                graph_times.append(t1 - t0)
+                post_times.append(t2 - t1)
+                last_detections = detections
+
+            if not graph_times:
+                print("Profiling aborted: no successful runs", file=sys.stderr)
+                return 4
+
+            print(f"Profiling over {len(graph_times)} runs (image='{image_path}'):")
+            print(format_profile_stats("Graph run (push+pull)", graph_times))
+            print(format_profile_stats("Postprocessing (decode+NMS)", post_times))
+            print(f"Last run detections: {len(last_detections)}")
+            for i, det in enumerate(last_detections[:20]):
+                box = det["box"]
+                print(
+                    f"  [{i}] class={class_name(labels, det['class_id'])}({det['class_id']}) "
+                    f"score={det['score']:.4f} box=[{box[0]:.1f},{box[1]:.1f},{box[2]:.1f},{box[3]:.1f}]"
+                )
+            return 0
+        except Exception as exc:
+            logger.debug("Profiling failure", exc_info=exc)
+            print(f"Error during profiling: {exc}", file=sys.stderr)
+            return 4
+        finally:
+            runner.close()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    processed = 0
+    try:
+        for image_path in image_paths:
+            try:
+                orig_bgr, preprocessed, meta = prepare_input(image_path)
+                arrays = run_model_inference(runner, preprocessed, timeout_ms)
+            except Exception as exc:
+                logger.debug("Inference failure", exc_info=exc)
+                print(f"Error during inference for {image_path}: {exc}", file=sys.stderr)
+                return 3
+
+            if not arrays:
+                print(f"No tensors found in model output for {image_path}", file=sys.stderr)
+                return 4
+
+            try:
+                encodings, logits = reassemble_heads(arrays)
+                detections = process_ssd_output(
+                    encodings, logits, anchors, meta,
+                    score_threshold=score_threshold, nms_iou=nms_iou,
+                    max_detections=max_detections,
+                )
+            except Exception as exc:
+                logger.debug("Decode failure", exc_info=exc)
+                print(f"Error during decode for {image_path}: {exc}", file=sys.stderr)
+                return 4
+
+            output_path = output_dir / f"{image_path.stem}_ssd.png"
+            out_img = visualize_detections(orig_bgr, detections, labels)
+            cv2.imwrite(str(output_path), out_img)
+            processed += 1
+            print(
+                f"[{processed}/{len(image_paths)}] {image_path.name}: "
+                f"{len(detections)} detections -> {output_path.name}"
+            )
+    finally:
+        runner.close()
+
+    print(f"Done: {processed} images processed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/object-detection/ssd-mobilenet-object-detector/src/python/requirements.txt
+++ b/examples/object-detection/ssd-mobilenet-object-detector/src/python/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+opencv-python
+pyyaml

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/cpp/test_e2e.cpp
@@ -1,0 +1,78 @@
+// E2E test for ssd-mobilenet-object-detector.
+// Runs the binary with a real SSD-MobileNetV2 model and a local image folder, and
+// verifies it exits successfully and produces annotated output images.
+#include "support/testing/test_process.h"
+#include "support/testing/test_config.h"
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace sima_examples::testing;
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+  const std::string binary = argv[1];
+
+  const char* models_dir_raw = env_or_null("SIMANEAT_APPS_TEST_MODELS_DIR");
+  const std::string models_dir = models_dir_raw ? models_dir_raw : "assets/models";
+
+  const std::string model_path = configured_model_path("ssd-mobilenet-object-detector", models_dir);
+
+  if (model_path.empty() || !fs::exists(model_path)) {
+    return skip_or_fail("SSD-MobileNetV2 model (.tar.gz) not found under SIMANEAT_APPS_TEST_MODELS_DIR");
+  }
+
+  const char* input_dir_raw = env_or_null("SIMANEAT_APPS_TEST_INPUT_DIR");
+  const std::string input_dir = input_dir_raw ? input_dir_raw : "assets/test_images";
+
+  if (!fs::exists(input_dir) || fs::is_empty(input_dir)) {
+    env_or_skip("SIMANEAT_APPS_TEST_INPUT_DIR",
+                "directory containing test images (defaults to assets/test_images)");
+    return kSkipCode;
+  }
+
+  const std::string out_dir =
+      create_test_output_dir("ssd-mobilenet-object-detector", "test_full_pipeline");
+  if (out_dir.empty()) {
+    return 1;
+  }
+
+  const fs::path config_path = fs::path(out_dir).parent_path() / "config.yaml";
+  write_e2e_config("ssd-mobilenet-object-detector", config_path,
+                   {{"model.path", model_path},
+                    {"io.input_dir", input_dir},
+                    {"io.output_dir", out_dir},
+                    {"runtime.num_runs", "1"}});
+  int timeout = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 30000);
+
+  auto r = spawn_and_wait(binary, {"--config", config_path.string()}, timeout);
+
+  if (r.exit_code != 0) {
+    std::cerr << "[FAIL] exit code " << r.exit_code << "\n";
+    std::cerr << "stderr:\n" << r.stderr_text << "\n";
+    remove_dir(out_dir);
+    return 1;
+  }
+
+  const int output_files = count_output_files(out_dir);
+  if (output_files == 0) {
+    std::cerr << "[FAIL] expected annotated output images but output directory is empty\n";
+    remove_dir(out_dir);
+    return 1;
+  }
+  if (!all_output_files_nonempty(out_dir)) {
+    std::cerr << "[FAIL] some annotated output images are empty\n";
+    remove_dir(out_dir);
+    return 1;
+  }
+
+  remove_dir(out_dir);
+  std::cout << "[OK] ssd-mobilenet-object-detector pipeline produced " << output_files
+            << " output files\n";
+  return 0;
+}

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/cpp/test_unit.cpp
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/cpp/test_unit.cpp
@@ -1,0 +1,72 @@
+// Unit test for ssd-mobilenet-object-detector: validates CLI arg handling.
+#include "support/testing/test_process.h"
+
+#include <iostream>
+#include <string>
+
+using sima_examples::testing::ProcessResult;
+using sima_examples::testing::spawn_and_wait;
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+
+  const std::string binary = argv[1];
+  int failures = 0;
+
+  {
+    ProcessResult r = spawn_and_wait(binary, {"--help"}, 20000);
+    if (r.exit_code != 0) {
+      std::cerr << "[FAIL] help: expected exit 0, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stdout_text.find("Usage") == std::string::npos) {
+      std::cerr << "[FAIL] help: stdout does not contain usage hint\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] help prints usage\n";
+    }
+  }
+
+  {
+    ProcessResult r = spawn_and_wait(binary, {"--bogus"}, 20000);
+    if (r.exit_code != 2) {
+      std::cerr << "[FAIL] unknown flag: expected exit 2, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stderr_text.find("unknown argument") == std::string::npos) {
+      std::cerr << "[FAIL] unknown flag: stderr does not mention unknown argument\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] unknown flag correctly rejected\n";
+    }
+  }
+
+  {
+    ProcessResult r = spawn_and_wait(binary, {"--config"}, 20000);
+    if (r.exit_code != 2) {
+      std::cerr << "[FAIL] missing config path: expected exit 2, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stderr_text.find("--config requires a path") == std::string::npos) {
+      std::cerr << "[FAIL] missing config path: stderr does not explain failure\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] missing config path correctly rejected\n";
+    }
+  }
+
+  {
+    ProcessResult r = spawn_and_wait(binary, {"--config", "/nonexistent/ssd-config.yaml"}, 20000);
+    if (r.exit_code != 2) {
+      std::cerr << "[FAIL] bad config: expected exit 2, got " << r.exit_code << "\n";
+      ++failures;
+    } else if (r.stderr_text.find("failed to open config") == std::string::npos) {
+      std::cerr << "[FAIL] bad config: stderr does not explain failure\n";
+      ++failures;
+    } else {
+      std::cout << "[OK] bad config path correctly rejected\n";
+    }
+  }
+
+  return failures > 0 ? 1 : 0;
+}

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/python/test_e2e.py
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/python/test_e2e.py
@@ -1,0 +1,54 @@
+"""E2E tests for ssd-mobilenet-object-detector (Python)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+
+
+@pytest.mark.e2e
+class TestE2E:
+    def test_full_pipeline(
+        self,
+        e2e_model_path,
+        test_images_dir,
+        tmp_output_dir,
+        test_timeout_ms,
+        skip_unless_e2e_ready,
+        e2e_config_writer,
+    ):
+        skip_unless_e2e_ready(
+            test_images_dir.exists() and any(test_images_dir.iterdir()),
+            f"test_images_dir is missing or empty: {test_images_dir}",
+        )
+
+        config_path = e2e_config_writer(
+            {
+                "io": {"input_dir": str(test_images_dir), "output_dir": str(tmp_output_dir)},
+                "runtime": {"num_runs": 1},
+            }
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(MAIN_PY),
+                "--config",
+                str(config_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=test_timeout_ms / 1000,
+            cwd=str(EXAMPLE_DIR),
+        )
+
+        assert result.returncode == 0, (
+            f"main.py exited with code {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        output_files = [path for path in tmp_output_dir.iterdir() if path.is_file()]
+        assert output_files, "Expected annotated output images to be written"
+        assert all(path.stat().st_size > 0 for path in output_files), "Output image is empty"

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/python/test_unit.py
@@ -1,0 +1,46 @@
+"""Unit tests for ssd-mobilenet-object-detector (Python)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+
+
+@pytest.mark.unit
+class TestArgParsing:
+    """Validate CLI argument parsing for the SSD example."""
+
+    def test_help(self):
+        r = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert r.returncode == 0
+        assert "--config" in r.stdout
+
+    def test_bad_config_path(self):
+        r = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--config", "/nonexistent/ssd-config.yaml"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            cwd=str(EXAMPLE_DIR),
+        )
+        assert r.returncode != 0
+
+    def test_unknown_flag(self):
+        r = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--bogus"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            cwd=str(EXAMPLE_DIR),
+        )
+        assert r.returncode == 2
+        assert "unrecognized" in r.stderr.lower() or "error" in r.stderr.lower()

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
@@ -1,0 +1,17 @@
+models:
+  ssd_mobilenet_v2_heads:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/ssd_mobilenet_v2_heads_mpk.tar.gz
+    file: ssd_mobilenet_v2_heads_mpk.tar.gz
+unit:
+  python: true
+  cpp: true
+e2e:
+  python:
+    enabled: true
+    models:
+    - ssd_mobilenet_v2_heads
+  cpp:
+    enabled: true
+    models:
+    - ssd_mobilenet_v2_heads


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR adds SSD object detection example applications to the repository. The examples demonstrate how to run SSD-based models using the NEAT SDK with SSD box decoding support, providing an end-to-end inference pipeline similar to the existing YOLO detection examples.

The changes include SSD detection applications, associated configuration files, and integration with the existing example workflow.

Fixes #329

---

## Type of Change
Please mark the relevant options with an `x`:

- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Refactor / code cleanup  
- [ ] Tests / CI improvements  

---

## Testing & Verification
Describe how you tested your changes:  
- [x] Unit tests added/updated  
- [x] Built successfully on hardware (e.g., Modalix, Davinci DevKit)  
- [x] Verified with Yocto/SDK build  
- [x] Manual functional tests (describe below)  

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Comments/documentation updated where needed  
- [x] New dependencies documented in README or `requirements.txt`  
- [x] Related issues linked in PR description  
- [x] Planned merge method matches the target branch policy in `CONTRIBUTING.md`
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)  

---

## Additional Notes
Add any other relevant details, screenshots, or context here.
