### PR TITLE
feat(release): flatten Apps installation

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -22,6 +22,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  SIMA_CLI_AUTO_ACCEPT_UPDATE: "1"
 
 jobs:
   resolve-vulcan-config:

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -231,11 +231,11 @@ jobs:
           tar -xzf "${runtime_archives[0]}" -C _vulcan-test/package
           (
             cd _vulcan-test/package
-            NEAT_APPS_INSTALL_DIR="${GITHUB_WORKSPACE}/_vulcan-test/install/neat-apps" \
+            NEAT_APPS_INSTALL_DIR="${GITHUB_WORKSPACE}/_vulcan-test/install/prebuilt-apps" \
               NEAT_VULCAN_ENV="${VULCAN_ENV}" \
               bash "${GITHUB_WORKSPACE}/scripts/install-vulcan-apps-package.sh"
           )
-          runtime_dir="${GITHUB_WORKSPACE}/_vulcan-test/install/neat-apps/neat-apps-runtime"
+          runtime_dir="${GITHUB_WORKSPACE}/_vulcan-test/install/prebuilt-apps"
           scripts/ci/overlay_apps_tests.sh "${test_archive}" "${runtime_dir}"
           printf '%s\n' "${runtime_dir}" > _vulcan-test/apps_runtime_dir.txt
           echo "Using apps runtime: ${runtime_dir}"

--- a/scripts/ci/install_apps_runtime_from_vulcan.sh
+++ b/scripts/ci/install_apps_runtime_from_vulcan.sh
@@ -7,7 +7,7 @@ Usage:
   install_apps_runtime_from_vulcan.sh --target <apps-target> --install-dir <dir> [--env <env>] [--force]
 
 Installs an Apps artifact with sima-cli and prints the installed
-neat-apps-runtime directory path.
+prebuilt-apps directory path.
 EOF
 }
 
@@ -76,12 +76,11 @@ fi
 echo "Installing ${target} from Vulcan env ${artifact_env}" >&2
 "${cmd[@]}" >&2
 
-mapfile -t runtime_dirs < <(find "${install_dir}" -type d -path '*/neat-apps/neat-apps-runtime' | sort)
-if [[ "${#runtime_dirs[@]}" -ne 1 ]]; then
-  echo "Expected exactly one installed apps runtime, found ${#runtime_dirs[@]}." >&2
-  printf '  %s\n' "${runtime_dirs[@]}" >&2 || true
+runtime_dir="${install_dir}/prebuilt-apps"
+if [[ ! -d "${runtime_dir}" ]]; then
+  echo "Expected installed Apps runtime at ${runtime_dir}." >&2
   find "${install_dir}" -maxdepth 4 -mindepth 1 -type d -printf '  %p\n' | sort >&2 || true
   exit 1
 fi
 
-printf '%s\n' "${runtime_dirs[0]}"
+printf '%s\n' "${runtime_dir}"

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEST_DIR="${NEAT_APPS_INSTALL_DIR:-neat-apps}"
+DEST_DIR="${NEAT_APPS_INSTALL_DIR:-prebuilt-apps}"
 RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-neat-apps-runtime}"
-RUNTIME_DST="${DEST_DIR}/neat-apps-runtime"
+LEGACY_RUNTIME_DIR="$(dirname "${DEST_DIR}")/neat-apps/neat-apps-runtime"
 VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-production}}"
 NEAT_CORE_INSTALL_DIR=""
 NEAT_CORE_INSTALL_DIR_OWNED=0
@@ -41,9 +41,20 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
 
-neat_core = data.get("neat-core", {})
-branch = str(neat_core.get("branch", "")).strip()
-version = str(neat_core.get("version", "")).strip()
+if not isinstance(data, dict):
+    raise SystemExit(1)
+
+neat_core = data.get("neat-core")
+if not isinstance(neat_core, dict):
+    raise SystemExit(1)
+
+branch = neat_core.get("branch")
+version = neat_core.get("version")
+if not isinstance(branch, str) or not isinstance(version, str):
+    raise SystemExit(1)
+
+branch = branch.strip()
+version = version.strip()
 
 if not branch or not version or version.lower() == "latest":
     raise SystemExit(1)
@@ -95,6 +106,91 @@ run_sima_cli_core_install() {
   rm -f "${log_path}"
 }
 
+promote_apps_runtime() {
+  local source_dir="$1"
+  local dest_dir="$2"
+  local legacy_dir="$3"
+  local dest_parent stage_root staged_runtime backup_dir="" previous_dir=""
+  local models_preserved=0
+
+  dest_parent="$(dirname "${dest_dir}")"
+  if ! mkdir -p "${dest_parent}"; then
+    echo "ERROR: failed to create Apps install parent: ${dest_parent}" >&2
+    return 1
+  fi
+  if ! stage_root="$(mktemp -d "${dest_parent}/.prebuilt-apps-stage.XXXXXX")"; then
+    echo "ERROR: failed to create Apps staging directory under ${dest_parent}." >&2
+    return 1
+  fi
+  staged_runtime="${stage_root}/prebuilt-apps"
+  if ! mv "${source_dir}" "${staged_runtime}"; then
+    echo "ERROR: failed to stage the Apps runtime under ${dest_parent}." >&2
+    rm -rf "${stage_root}"
+    return 1
+  fi
+
+  if [[ -e "${dest_dir}" || -L "${dest_dir}" ]]; then
+    previous_dir="${dest_dir}"
+  elif [[ -e "${legacy_dir}" || -L "${legacy_dir}" ]]; then
+    previous_dir="${legacy_dir}"
+  fi
+
+  if [[ -n "${previous_dir}" ]]; then
+    if ! backup_dir="$(mktemp -d "${dest_parent}/.prebuilt-apps-backup.XXXXXX")"; then
+      echo "ERROR: failed to create an Apps rollback path under ${dest_parent}." >&2
+      rm -rf "${stage_root}"
+      return 1
+    fi
+    if ! rmdir "${backup_dir}"; then
+      echo "ERROR: failed to prepare the Apps rollback path: ${backup_dir}" >&2
+      rm -rf "${stage_root}" "${backup_dir}"
+      return 1
+    fi
+    if ! mv "${previous_dir}" "${backup_dir}"; then
+      echo "ERROR: failed to stage the existing Apps runtime for rollback." >&2
+      rm -rf "${stage_root}"
+      return 1
+    fi
+
+    if [[ -e "${backup_dir}/models" || -L "${backup_dir}/models" ]]; then
+      rm -rf "${staged_runtime}/models"
+      if ! mv "${backup_dir}/models" "${staged_runtime}/models"; then
+        echo "ERROR: failed to preserve the existing Apps models directory." >&2
+        if ! mv "${backup_dir}" "${previous_dir}"; then
+          echo "ERROR: previous Apps runtime remains at ${backup_dir}." >&2
+        fi
+        rm -rf "${stage_root}"
+        return 1
+      fi
+      models_preserved=1
+    fi
+  fi
+
+  if ! mv "${staged_runtime}" "${dest_dir}"; then
+    echo "ERROR: failed to promote the candidate Apps runtime." >&2
+    if [[ "${models_preserved}" == "1" ]]; then
+      if ! mv "${staged_runtime}/models" "${backup_dir}/models"; then
+        echo "ERROR: preserved models remain at ${staged_runtime}/models." >&2
+        return 1
+      fi
+    fi
+    if [[ -n "${backup_dir}" ]] && ! mv "${backup_dir}" "${previous_dir}"; then
+      echo "ERROR: previous Apps runtime remains at ${backup_dir}." >&2
+      return 1
+    fi
+    rm -rf "${stage_root}"
+    return 1
+  fi
+
+  rm -rf "${stage_root}"
+  if [[ -n "${backup_dir}" ]]; then
+    rm -rf "${backup_dir}"
+  fi
+  if [[ -n "${previous_dir}" && "${previous_dir}" != "${dest_dir}" ]]; then
+    rmdir "$(dirname "${previous_dir}")" 2>/dev/null || true
+  fi
+}
+
 if [[ ! -d "${RUNTIME_SRC}" ]]; then
   runtime_candidates=()
   while IFS= read -r candidate; do
@@ -134,10 +230,6 @@ SIMA_CLI_RESOLVED="$(resolve_sima_cli_bin)" || {
 NEAT_CORE_BRANCH="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '1p')"
 NEAT_CORE_VERSION="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '2p')"
 
-rm -rf "${DEST_DIR}"
-mkdir -p "${DEST_DIR}"
-mv "${RUNTIME_SRC}" "${RUNTIME_DST}"
-
 echo
 echo "Installing matching NEAT core from Vulcan:"
 echo "  Environment: ${VULCAN_ENV}"
@@ -159,6 +251,11 @@ if [[ "${INSTALL_STATUS}" -ne 0 ]]; then
   exit "${INSTALL_STATUS}"
 fi
 
+if ! promote_apps_runtime "${RUNTIME_SRC}" "${DEST_DIR}" "${LEGACY_RUNTIME_DIR}"; then
+  exit 1
+fi
+INSTALLED_DIR="$(cd "$(dirname "${DEST_DIR}")" && pwd -P)/$(basename "${DEST_DIR}")"
+
 echo
 echo "Installed apps runtime under:"
-echo "  ${DEST_DIR}"
+echo "  ${INSTALLED_DIR}"

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -135,12 +135,58 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
             printf '%s\\n' "$PWD" > "${NEAT_APPS_TEST_SIMA_CLI_CWD}"
             printf '%s\\n' "$*" > "${NEAT_APPS_TEST_SIMA_CLI_ARGS}"
             touch sima-cli-ran.txt
+            exit "${NEAT_APPS_TEST_SIMA_CLI_STATUS:-0}"
             """
         ),
         encoding="utf-8",
     )
     sima_cli_path.chmod(0o755)
     return bin_dir
+
+
+def _write_vulcan_runtime(package_dir: Path, neat_core: object | None = None) -> Path:
+    runtime_dir = package_dir / "neat-apps-runtime"
+    runtime_dir.mkdir(parents=True)
+    if neat_core is None:
+        neat_core = {"branch": "develop", "version": "core-sha"}
+    (runtime_dir / "neat-core.json").write_text(
+        json.dumps({"neat-core": neat_core}),
+        encoding="utf-8",
+    )
+    return runtime_dir
+
+
+def _run_vulcan_installer(
+    tmp_path: Path,
+    package_dir: Path,
+    *,
+    install_dir: Path | None = None,
+    sima_cli_status: int = 0,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = _write_fake_sima_cli(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {
+            "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(tmp_path / "sima-cli-args.txt"),
+            "NEAT_APPS_TEST_SIMA_CLI_CWD": str(tmp_path / "sima-cli-cwd.txt"),
+            "NEAT_APPS_TEST_SIMA_CLI_STATUS": str(sima_cli_status),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "SIMA_CLI_BIN": str(bin_dir / "sima-cli"),
+        }
+    )
+    if install_dir is not None:
+        env["NEAT_APPS_INSTALL_DIR"] = str(install_dir)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(VULCAN_INSTALLER)],
+        cwd=package_dir,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def _run_build(
@@ -584,3 +630,148 @@ def test_vulcan_installer_rejects_latest_core_before_replacing_runtime(tmp_path)
     assert proc.returncode != 0
     assert sentinel.read_text(encoding="utf-8") == "keep\n"
     assert runtime_dir.is_dir()
+
+
+@pytest.mark.parametrize(
+    "neat_core",
+    [
+        {"branch": None, "version": "core-sha"},
+        {"branch": "develop", "version": []},
+    ],
+)
+def test_vulcan_installer_rejects_non_string_core_target_before_promotion(
+    tmp_path, neat_core
+):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir, neat_core)
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    sentinel = install_dir / "runtime-marker"
+    sentinel.write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
+
+    assert proc.returncode != 0
+    assert sentinel.read_text(encoding="utf-8") == "old\n"
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+
+
+def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_dir = package_dir / "prebuilt-apps"
+
+    proc = _run_vulcan_installer(tmp_path, package_dir)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
+    assert not (install_dir / "neat-apps-runtime").exists()
+    assert f"  {install_dir}" in proc.stdout
+
+
+def test_vulcan_installer_keeps_existing_runtime_when_core_install_fails(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        install_dir=install_dir,
+        sima_cli_status=1,
+    )
+
+    assert proc.returncode != 0
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+
+
+def test_vulcan_installer_preserves_models_during_reinstall(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    models_dir = install_dir / "models"
+    models_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+    (models_dir / "user-model.mpk").write_text("model\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
+    assert (models_dir / "user-model.mpk").read_text(encoding="utf-8") == "model\n"
+
+
+def test_vulcan_installer_migrates_legacy_runtime_and_models(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_root = tmp_path / "installed"
+    install_dir = install_root / "prebuilt-apps"
+    legacy_dir = install_root / "neat-apps" / "neat-apps-runtime"
+    models_dir = legacy_dir / "models"
+    models_dir.mkdir(parents=True)
+    (legacy_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+    (models_dir / "user-model.mpk").write_text("model\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
+    assert (install_dir / "models" / "user-model.mpk").read_text(
+        encoding="utf-8"
+    ) == "model\n"
+    assert not legacy_dir.exists()
+
+
+def test_vulcan_installer_restores_runtime_when_promotion_fails(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_root = tmp_path / "installed"
+    install_dir = install_root / "prebuilt-apps"
+    legacy_dir = install_root / "neat-apps" / "neat-apps-runtime"
+    models_dir = legacy_dir / "models"
+    models_dir.mkdir(parents=True)
+    (legacy_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+    (models_dir / "user-model.mpk").write_text("model\n", encoding="utf-8")
+    failed_file = tmp_path / "mv-failed"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    mv_path = bin_dir / "mv"
+    mv_path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            destination="${!#}"
+            if [[ "${destination}" == "${NEAT_APPS_TEST_MV_FAIL_DEST}" && \
+                  ! -e "${NEAT_APPS_TEST_MV_FAILED_FILE}" ]]; then
+              touch "${NEAT_APPS_TEST_MV_FAILED_FILE}"
+              exit 1
+            fi
+            exec /bin/mv "$@"
+            """
+        ),
+        encoding="utf-8",
+    )
+    mv_path.chmod(0o755)
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        install_dir=install_dir,
+        extra_env={
+            "NEAT_APPS_TEST_MV_FAIL_DEST": str(install_dir),
+            "NEAT_APPS_TEST_MV_FAILED_FILE": str(failed_file),
+        },
+    )
+
+    assert proc.returncode != 0
+    assert failed_file.exists()
+    assert not install_dir.exists()
+    assert (legacy_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert (models_dir / "user-model.mpk").read_text(encoding="utf-8") == "model\n"


### PR DESCRIPTION
## Why

Published Apps packages currently install under `<install-dir>/neat-apps/neat-apps-runtime/`. The extra nesting makes installed commands and paths harder to understand. Reinstalling also replaces the existing runtime before its Core dependency succeeds and can discard user-managed models.

## What Changed

- Install the released bundle directly under `<install-dir>/prebuilt-apps/`.
- Validate the exact Core target and finish Core installation before promoting the Apps candidate.
- Stage the candidate beside the final destination and restore the previous runtime if promotion fails.
- Preserve `models/` during reinstall and migrate it from the previous nested layout during upgrade.
- Update Vulcan runtime validation and the shared Vulcan/Nightly installer helper to use the flattened path.
- Reject malformed non-string Core branch or version fields before dependency installation or runtime promotion.

## Validation

- Script contract suite — 47 passed
- Shell syntax validation for the package installer and shared Vulcan installer helper
- Vulcan workflow YAML parse validation
- Direct shared-helper probe confirmed `<install-dir>/prebuilt-apps/`
- `git diff --check`

## Risk

The Apps bundle is promoted only after Core installation succeeds. If final filesystem promotion fails, the previous Apps bundle and its models are restored, but the successfully installed Core version is not rolled back.

The package archive root remains `neat-apps-runtime/`; archive-layout enforcement remains in #346. The legacy standalone installer and `build.sh --all` are unchanged.

Closes #348
Refs #341
