### PR TITLE
feat(release): package C++ source and binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -175,6 +175,19 @@ with open(sys.argv[1], "w", encoding="utf-8") as fh:
     fh.write("\n")
 PY
 
+  while IFS= read -r cpp_dir; do
+    local rel target_dir
+    rel="${cpp_dir#"${ROOT_DIR}"/examples/}"
+    target_dir="${stage_dir}/examples/$(dirname "${rel}")"
+    mkdir -p "${target_dir}"
+    cp -a "${cpp_dir}" "${target_dir}/"
+    rm -f "${target_dir}/cpp/CMakeLists.txt"
+    rm -rf "${target_dir}/cpp/pre-built"
+  done < <(
+    find "${ROOT_DIR}/examples" -mindepth 4 -maxdepth 4 \
+      -type d -path '*/src/cpp' | sort
+  )
+
   # Keep production and test executables in separate artifacts while
   # preserving the example layout expected by the test runner.
   while IFS= read -r exe; do
@@ -183,7 +196,12 @@ PY
     if [[ "${exe}" == *_unit_test || "${exe}" == *_e2e_test ]]; then
       target_dir="${test_stage_dir}/$(dirname "${rel}")/tests/cpp"
     else
-      target_dir="${stage_dir}/$(dirname "${rel}")"
+      local example_rel
+      example_rel="$(dirname "${rel}")"
+      example_rel="${example_rel%_cpp}"
+      [[ "$(basename "${exe}")" == "$(basename "${example_rel}")" ]] || continue
+      [[ -d "${ROOT_DIR}/${example_rel}/src/cpp" ]] || continue
+      target_dir="${stage_dir}/${example_rel}/src/cpp/pre-built"
     fi
     mkdir -p "${target_dir}"
     cp "${exe}" "${target_dir}/"

--- a/scripts/ci/validate_apps_runtime_archive.sh
+++ b/scripts/ci/validate_apps_runtime_archive.sh
@@ -14,9 +14,18 @@ if ! grep -qx 'neat-apps-runtime/neat-core.json' <<<"${members}"; then
   exit 1
 fi
 
-forbidden='(^|/)(models|portal|tests|test-scope\.yaml|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(pyc|pyo|log|db|lock)$'
+forbidden='(^|/)(models|portal|tests|test-scope\.yaml|CMakeLists\.txt|CTestTestfile\.cmake|cmake_install\.cmake|Makefile|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(a|pyc|pyo|log|db|lock)$'
 if grep -E "${forbidden}" <<<"${members}"; then
-  echo "Runtime archive contains test or generated files." >&2
+  echo "Runtime archive contains non-runtime or generated files." >&2
+  exit 1
+fi
+
+root_example_binaries="$(
+  awk -F/ 'NF == 5 && $2 == "examples" && ($4 == $5 || $4 == $5 "_cpp")' <<<"${members}"
+)"
+if [[ -n "${root_example_binaries}" ]]; then
+  printf '%s\n' "${root_example_binaries}" >&2
+  echo "Runtime archive contains a root-level example binary." >&2
   exit 1
 fi
 

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -52,9 +52,13 @@ def test_runtime_archive_validator_accepts_shipped_datasets(tmp_path):
         "assets/datasets-test/coco/example.jpg",
         "models/example.tar.gz",
         "portal/assets/examples/example.png",
+        "examples/classification/demo/src/cpp/CMakeLists.txt",
+        "examples/classification/demo/src/cpp/pre-built/CTestTestfile.cmake",
+        "examples/classification/demo/demo",
+        "examples/face-detection/face-detector_cpp/face-detector",
     ],
 )
-def test_runtime_archive_validator_rejects_non_runtime_assets(tmp_path, member):
+def test_runtime_archive_validator_rejects_forbidden_content(tmp_path, member):
     archive = _write_runtime_archive(tmp_path, member)
 
     proc = subprocess.run(
@@ -65,6 +69,23 @@ def test_runtime_archive_validator_rejects_non_runtime_assets(tmp_path, member):
     )
 
     assert proc.returncode != 0
+
+
+def test_runtime_archive_validator_accepts_cpp_reference_and_prebuilt_binary(tmp_path):
+    archive = _write_runtime_archive(
+        tmp_path,
+        "examples/classification/demo/src/cpp/main.cpp",
+        "examples/classification/demo/src/cpp/pre-built/demo",
+    )
+
+    proc = subprocess.run(
+        ["bash", str(RUNTIME_ARCHIVE_VALIDATOR), str(archive)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
 
 
 def _write_manifest(path: Path, neat_core: object = "", platform_version: str = "2.0.0") -> None:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -692,14 +692,11 @@ run_packaged_cpp_tests() {
 
   local test_bin
   for test_bin in "${cpp_test_bins[@]}"; do
-    local example_name test_dir example_bin rc
+    local example_name example_dir example_bin rc
     example_name="$(basename "${test_bin}")"
     example_name="${example_name%${suffix}}"
-    test_dir="$(dirname "${test_bin}")"
-    # Packaged layout:
-    # examples/<category>/<example>[/_cpp]/tests/cpp/<example>_{unit,e2e}_test
-    # examples/<category>/<example>[/_cpp]/<example>
-    example_bin="${test_dir}/../../${example_name}"
+    example_dir="${test_bin%/tests/cpp/*}"
+    example_bin="${example_dir%_cpp}/src/cpp/pre-built/${example_name}"
 
     echo "  [RUN] ${test_bin#${ROOT_DIR}/}"
     echo "[RUN] ${test_bin#${ROOT_DIR}/}" >>"${summary_file}"


### PR DESCRIPTION
## Summary

- package each example's `src/cpp` reference source without CMake or stale pre-built content
- place production executables under `src/cpp/pre-built/<binary>`
- keep tests in the CI-only archive and update packaged tests to use the new executable path
- reject generated build files and legacy root-level executables during archive validation

## Validation

- `python3 -m pytest -q tests/scripts` (62 passed)
- `python3 tests/utils/test_scope.py --scope-file examples validate --quiet`
- shell syntax and `git diff --check`
- SDK C++ build and runtime package creation
- archive inspection: 15 C++ reference files, 11 production binaries, no generated build files or test paths
- all 21 packaged test binaries resolve a production executable

Refs #345