### PR TITLE
feat(installer): isolate Apps dependencies

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -236,6 +236,10 @@ jobs:
               NEAT_VULCAN_ENV="${VULCAN_ENV}" \
               bash "${GITHUB_WORKSPACE}/scripts/install-vulcan-apps-package.sh"
           )
+          if [[ -e "${GITHUB_WORKSPACE}/_vulcan-test/install/deps" ]]; then
+            echo "Apps dependency workspace was not cleaned." >&2
+            exit 1
+          fi
           runtime_dir="${GITHUB_WORKSPACE}/_vulcan-test/install/prebuilt-apps"
           scripts/ci/overlay_apps_tests.sh "${test_archive}" "${runtime_dir}"
           printf '%s\n' "${runtime_dir}" > _vulcan-test/apps_runtime_dir.txt

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -3,10 +3,14 @@ set -euo pipefail
 
 DEST_DIR="${NEAT_APPS_INSTALL_DIR:-prebuilt-apps}"
 RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-neat-apps-runtime}"
-LEGACY_RUNTIME_DIR="$(dirname "${DEST_DIR}")/neat-apps/neat-apps-runtime"
+INSTALL_ROOT="$(dirname "${DEST_DIR}")"
+LEGACY_RUNTIME_DIR="${INSTALL_ROOT}/neat-apps/neat-apps-runtime"
 VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-production}}"
-NEAT_CORE_INSTALL_DIR=""
-NEAT_CORE_INSTALL_DIR_OWNED=0
+DEPS_DIR="${INSTALL_ROOT}/deps"
+DEPS_MARKER="${DEPS_DIR}/.neat-apps-installer-owned"
+DEPS_MARKER_VALUE="sima-neat/apps"
+CORE_INSTALL_DIR="${DEPS_DIR}/core"
+DEPS_WORKSPACE_ACTIVE=0
 
 resolve_sima_cli_bin() {
   if [[ -n "${SIMA_CLI_BIN:-}" && -x "${SIMA_CLI_BIN}" ]]; then
@@ -64,36 +68,47 @@ print(version)
 PY
 }
 
-prepare_vulcan_core_install_dir() {
-  NEAT_CORE_INSTALL_DIR_OWNED=0
-  if [[ -z "${NEAT_APPS_CORE_INSTALL_DIR:-}" ]]; then
-    NEAT_CORE_INSTALL_DIR="$(mktemp -d /tmp/neat-apps-core-install.XXXXXX)"
-    NEAT_CORE_INSTALL_DIR_OWNED=1
-    return 0
-  fi
-
-  NEAT_CORE_INSTALL_DIR="${NEAT_APPS_CORE_INSTALL_DIR}"
-  if [[ -z "${NEAT_CORE_INSTALL_DIR}" || "${NEAT_CORE_INSTALL_DIR}" == "/" ]]; then
-    echo "ERROR: unsafe NEAT_APPS_CORE_INSTALL_DIR: ${NEAT_CORE_INSTALL_DIR}" >&2
-    exit 1
-  fi
-  rm -rf "${NEAT_CORE_INSTALL_DIR}"
-  mkdir -p "${NEAT_CORE_INSTALL_DIR}"
+dependency_workspace_is_owned() {
+  [[ -d "${DEPS_DIR}" && ! -L "${DEPS_DIR}" \
+    && -f "${DEPS_MARKER}" && ! -L "${DEPS_MARKER}" ]] \
+    && grep -Fqx "${DEPS_MARKER_VALUE}" "${DEPS_MARKER}"
 }
 
-cleanup_vulcan_core_install_dir() {
-  if [[ "${NEAT_CORE_INSTALL_DIR_OWNED}" == "1" && -n "${NEAT_CORE_INSTALL_DIR}" ]]; then
-    rm -rf "${NEAT_CORE_INSTALL_DIR}"
+cleanup_dependency_workspace() {
+  if [[ "${DEPS_WORKSPACE_ACTIVE}" != "1" ]]; then
+    return 0
   fi
-  NEAT_CORE_INSTALL_DIR=""
-  NEAT_CORE_INSTALL_DIR_OWNED=0
+  if ! dependency_workspace_is_owned; then
+    echo "ERROR: refusing to remove dependency workspace without its ownership marker: ${DEPS_DIR}" >&2
+    return 1
+  fi
+  rm -rf "${DEPS_DIR}"
+  DEPS_WORKSPACE_ACTIVE=0
+}
+
+prepare_dependency_workspace() {
+  if [[ -e "${DEPS_DIR}" || -L "${DEPS_DIR}" ]]; then
+    if ! dependency_workspace_is_owned; then
+      echo "ERROR: refusing to replace unowned dependency workspace: ${DEPS_DIR}" >&2
+      return 1
+    fi
+    rm -rf "${DEPS_DIR}"
+  fi
+
+  mkdir -p "${DEPS_DIR}"
+  if ! printf '%s\n' "${DEPS_MARKER_VALUE}" >"${DEPS_MARKER}"; then
+    rmdir "${DEPS_DIR}" 2>/dev/null || true
+    return 1
+  fi
+  DEPS_WORKSPACE_ACTIVE=1
+  mkdir -p "${CORE_INSTALL_DIR}"
 }
 
 run_sima_cli_core_install() {
   local sima_cli_bin="$1"
   shift
   local log_path
-  log_path="$(mktemp /tmp/neat-apps-sima-cli-install.XXXXXX.log)"
+  log_path="$(mktemp ./sima-cli-install.XXXXXX.log)"
   if ! "${sima_cli_bin}" neat install "$@" 2>&1 | tee "${log_path}"; then
     rm -f "${log_path}"
     return 1
@@ -222,33 +237,40 @@ if ! NEAT_CORE_TARGET_OUTPUT="$(extract_neat_core_target "${NEAT_CORE_JSON_PATH}
   exit 1
 fi
 
-SIMA_CLI_RESOLVED="$(resolve_sima_cli_bin)" || {
-  echo "ERROR: sima-cli is required to install matching NEAT core." >&2
-  exit 1
-}
-
 NEAT_CORE_BRANCH="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '1p')"
 NEAT_CORE_VERSION="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '2p')"
 
-echo
-echo "Installing matching NEAT core from Vulcan:"
-echo "  Environment: ${VULCAN_ENV}"
-echo "  Branch     : ${NEAT_CORE_BRANCH}"
-echo "  Version    : ${NEAT_CORE_VERSION}"
-prepare_vulcan_core_install_dir
-echo "  Scratch dir: ${NEAT_CORE_INSTALL_DIR}"
-INSTALL_STATUS=0
-(
-  cd "${NEAT_CORE_INSTALL_DIR}"
-  run_sima_cli_core_install "${SIMA_CLI_RESOLVED}" \
-    --env "${VULCAN_ENV}" \
-    -d . \
-    -t minimal \
-    "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
-) || INSTALL_STATUS=$?
-cleanup_vulcan_core_install_dir
-if [[ "${INSTALL_STATUS}" -ne 0 ]]; then
-  exit "${INSTALL_STATUS}"
+if [[ "${NEAT_APPS_SKIP_DEPENDENCIES:-0}" == "1" ]]; then
+  echo
+  echo "WARNING: Skipping Core and Insight dependency installation."
+else
+  SIMA_CLI_RESOLVED="$(resolve_sima_cli_bin)" || {
+    echo "ERROR: sima-cli is required to install matching NEAT core." >&2
+    exit 1
+  }
+
+  echo
+  echo "Installing matching NEAT core from Vulcan:"
+  echo "  Environment: ${VULCAN_ENV}"
+  echo "  Branch     : ${NEAT_CORE_BRANCH}"
+  echo "  Version    : ${NEAT_CORE_VERSION}"
+  trap cleanup_dependency_workspace EXIT
+  prepare_dependency_workspace
+  echo "  Scratch dir: ${CORE_INSTALL_DIR}"
+  INSTALL_STATUS=0
+  (
+    cd "${CORE_INSTALL_DIR}"
+    run_sima_cli_core_install "${SIMA_CLI_RESOLVED}" \
+      --env "${VULCAN_ENV}" \
+      -d . \
+      -t minimal \
+      "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
+  ) || INSTALL_STATUS=$?
+  if [[ "${INSTALL_STATUS}" -ne 0 ]]; then
+    exit "${INSTALL_STATUS}"
+  fi
+  cleanup_dependency_workspace
+  trap - EXIT
 fi
 
 if ! promote_apps_runtime "${RUNTIME_SRC}" "${DEST_DIR}" "${LEGACY_RUNTIME_DIR}"; then

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import tarfile
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -206,6 +208,13 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
             set -euo pipefail
             printf '%s\\n' "$PWD" > "${NEAT_APPS_TEST_SIMA_CLI_CWD}"
             printf '%s\\n' "$*" > "${NEAT_APPS_TEST_SIMA_CLI_ARGS}"
+            if [[ -n "${NEAT_APPS_TEST_FORBIDDEN_PATH:-}" ]]; then
+                [[ ! -e "${NEAT_APPS_TEST_FORBIDDEN_PATH}" ]]
+            fi
+            if [[ -n "${NEAT_APPS_TEST_SIMA_CLI_READY:-}" ]]; then
+                touch "${NEAT_APPS_TEST_SIMA_CLI_READY}"
+                while true; do sleep 1; done
+            fi
             touch sima-cli-ran.txt
             exit "${NEAT_APPS_TEST_SIMA_CLI_STATUS:-0}"
             """
@@ -739,7 +748,34 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
     assert not (install_dir / "neat-apps-runtime").exists()
+    assert (tmp_path / "sima-cli-cwd.txt").read_text(encoding="utf-8").strip() == str(
+        package_dir / "deps" / "core"
+    )
+    assert (tmp_path / "sima-cli-args.txt").read_text(encoding="utf-8").strip() == (
+        "neat install --env production -d . -t minimal core@develop:core-sha"
+    )
+    assert not (package_dir / "deps").exists()
     assert f"  {install_dir}" in proc.stdout
+
+
+def test_vulcan_installer_can_skip_dependency_installation(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_dir = package_dir / "prebuilt-apps"
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        sima_cli_status=1,
+        extra_env={"NEAT_APPS_SKIP_DEPENDENCIES": "1"},
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+    assert not (package_dir / "deps").exists()
+    assert "Skipping Core and Insight dependency installation" in proc.stdout
 
 
 def test_vulcan_installer_keeps_existing_runtime_when_core_install_fails(tmp_path):
@@ -758,6 +794,96 @@ def test_vulcan_installer_keeps_existing_runtime_when_core_install_fails(tmp_pat
     )
 
     assert proc.returncode != 0
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert not (install_dir.parent / "deps").exists()
+
+
+def test_vulcan_installer_refuses_unowned_dependency_workspace(tmp_path):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir)
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+    unowned_file = install_dir.parent / "deps" / "user-file"
+    unowned_file.parent.mkdir()
+    unowned_file.write_text("keep\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
+
+    assert proc.returncode != 0
+    assert unowned_file.read_text(encoding="utf-8") == "keep\n"
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+    assert "refusing to replace unowned dependency workspace" in proc.stderr
+
+
+def test_vulcan_installer_recreates_owned_dependency_workspace(tmp_path):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir)
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    deps_dir = install_dir.parent / "deps"
+    stale_file = deps_dir / "core" / "stale-resource"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale\n", encoding="utf-8")
+    (deps_dir / ".neat-apps-installer-owned").write_text(
+        "sima-neat/apps\n", encoding="utf-8"
+    )
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        install_dir=install_dir,
+        extra_env={"NEAT_APPS_TEST_FORBIDDEN_PATH": str(stale_file)},
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert install_dir.is_dir()
+    assert not deps_dir.exists()
+
+
+def test_vulcan_installer_cleans_dependency_workspace_on_termination(tmp_path):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir)
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+    ready_file = tmp_path / "sima-cli-ready"
+    bin_dir = _write_fake_sima_cli(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {
+            "NEAT_APPS_INSTALL_DIR": str(install_dir),
+            "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(tmp_path / "sima-cli-args.txt"),
+            "NEAT_APPS_TEST_SIMA_CLI_CWD": str(tmp_path / "sima-cli-cwd.txt"),
+            "NEAT_APPS_TEST_SIMA_CLI_READY": str(ready_file),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "SIMA_CLI_BIN": str(bin_dir / "sima-cli"),
+        }
+    )
+    proc = subprocess.Popen(
+        ["bash", str(VULCAN_INSTALLER)],
+        cwd=package_dir,
+        env=env,
+        start_new_session=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    for _ in range(100):
+        if ready_file.exists():
+            break
+        time.sleep(0.02)
+    else:
+        os.killpg(proc.pid, signal.SIGTERM)
+        proc.communicate(timeout=5)
+        pytest.fail("sima-cli did not start")
+
+    os.killpg(proc.pid, signal.SIGTERM)
+    proc.communicate(timeout=5)
+
+    assert proc.returncode != 0
+    assert not (install_dir.parent / "deps").exists()
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
 
 


### PR DESCRIPTION
## Why

Installing Apps should leave a clean `prebuilt-apps/` directory without temporary dependency resources. It must also avoid deleting unrelated user data when an existing `deps/` directory is present.

The installer also needs an internal Apps-only mode for quickly testing prebuilt Apps without reinstalling Core or Insight.

## What Changed

- Stage the pinned Core installation under `<install-dir>/deps/core/`.
- Mark `deps/` as installer-owned.
- Safely recreate stale installer-owned dependency state.
- Refuse to modify an existing unowned or linked `deps/` path.
- Keep nested `sima-cli` resources and logs inside the dependency workspace.
- Remove the dependency workspace after success, failure, or termination and before promoting `prebuilt-apps/`.
- Add the internal `NEAT_APPS_SKIP_DEPENDENCIES=1` option for Apps-only installation.
- Gate Vulcan installation on successful dependency-workspace cleanup.

The Apps-only option is not enabled in CI or promoted in user documentation.

## Validation

- `python3 -m pytest -q tests/scripts` — 66 passed
- Shell syntax and ShellCheck
- Ruff lint
- Vulcan workflow YAML parsing
- Test-scope validation
- `git diff --check`
- PR sanitization — passed
- Vulcan SDK build — passed
- Vulcan runtime tests — in progress

## Risk

An existing `<install-dir>/deps/` without the Apps ownership marker now causes installation to fail instead of being deleted.

`NEAT_APPS_SKIP_DEPENDENCIES=1` can install Apps without compatible Core or Insight packages. It is intended only for controlled internal testing.

## Follow-up

[#349](https://github.com/sima-neat/apps/issues/349) will install Insight under `deps/insight/` using the same cleanup lifecycle.

Closes #350
Refs #341
