### PR TITLE
feat(installer): install Insight with Apps

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -159,6 +159,7 @@ package_distribution() {
   if [[ "${neat_core_version}" == "latest" ]]; then
     neat_core_version="$(resolve_latest_version "${neat_core_branch}")"
   fi
+  cp "${APPS_MANIFEST}" "${stage_dir}/manifest.json"
   python3 - <<'PY' "${stage_dir}/neat-core.json" "${neat_core_branch}" "${neat_core_version}"
 import json
 import sys

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -2,6 +2,10 @@
   "neat-core": {
     "policy": "snap"
   },
+  "insight": {
+    "ref": "main",
+    "version": "latest"
+  },
   "sdk": {
     "channel": "develop"
   },

--- a/scripts/ci/validate_apps_runtime_archive.sh
+++ b/scripts/ci/validate_apps_runtime_archive.sh
@@ -9,10 +9,12 @@ fi
 
 members="$(tar -tzf "${archive}")"
 
-if ! grep -qx 'neat-apps-runtime/neat-core.json' <<<"${members}"; then
-  echo "Runtime archive is missing neat-apps-runtime/neat-core.json." >&2
-  exit 1
-fi
+for required_file in neat-core.json manifest.json; do
+  if ! grep -qx "neat-apps-runtime/${required_file}" <<<"${members}"; then
+    echo "Runtime archive is missing neat-apps-runtime/${required_file}." >&2
+    exit 1
+  fi
+done
 
 forbidden='(^|/)(models|portal|tests|test-scope\.yaml|CMakeLists\.txt|CTestTestfile\.cmake|cmake_install\.cmake|Makefile|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(a|pyc|pyo|log|db|lock)$'
 if grep -E "${forbidden}" <<<"${members}"; then

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -10,6 +10,7 @@ DEPS_DIR="${INSTALL_ROOT}/deps"
 DEPS_MARKER="${DEPS_DIR}/.neat-apps-installer-owned"
 DEPS_MARKER_VALUE="sima-neat/apps"
 CORE_INSTALL_DIR="${DEPS_DIR}/core"
+INSIGHT_INSTALL_DIR="${DEPS_DIR}/insight"
 DEPS_WORKSPACE_ACTIVE=0
 
 resolve_sima_cli_bin() {
@@ -101,24 +102,28 @@ prepare_dependency_workspace() {
     return 1
   fi
   DEPS_WORKSPACE_ACTIVE=1
-  mkdir -p "${CORE_INSTALL_DIR}"
 }
 
-run_sima_cli_core_install() {
-  local sima_cli_bin="$1"
-  shift
-  local log_path
-  log_path="$(mktemp ./sima-cli-install.XXXXXX.log)"
-  if ! "${sima_cli_bin}" neat install "$@" 2>&1 | tee "${log_path}"; then
+run_sima_cli_install() {
+  local install_dir="$1"
+  local sima_cli_bin="$2"
+  shift 2
+  mkdir -p "${install_dir}"
+  (
+    cd "${install_dir}"
+    local log_path
+    log_path="$(mktemp ./sima-cli-install.XXXXXX.log)"
+    if ! "${sima_cli_bin}" neat install "$@" 2>&1 | tee "${log_path}"; then
+      rm -f "${log_path}"
+      return 1
+    fi
+    if grep -Fq "Installation script exited" "${log_path}"; then
+      echo "ERROR: sima-cli reported a NEAT installer failure." >&2
+      rm -f "${log_path}"
+      return 1
+    fi
     rm -f "${log_path}"
-    return 1
-  fi
-  if grep -Fq "Installation script exited" "${log_path}"; then
-    echo "ERROR: sima-cli reported a NEAT core installer failure." >&2
-    rm -f "${log_path}"
-    return 1
-  fi
-  rm -f "${log_path}"
+  )
 }
 
 promote_apps_runtime() {
@@ -257,18 +262,21 @@ else
   trap cleanup_dependency_workspace EXIT
   prepare_dependency_workspace
   echo "  Scratch dir: ${CORE_INSTALL_DIR}"
-  INSTALL_STATUS=0
-  (
-    cd "${CORE_INSTALL_DIR}"
-    run_sima_cli_core_install "${SIMA_CLI_RESOLVED}" \
-      --env "${VULCAN_ENV}" \
-      -d . \
-      -t minimal \
-      "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
-  ) || INSTALL_STATUS=$?
-  if [[ "${INSTALL_STATUS}" -ne 0 ]]; then
-    exit "${INSTALL_STATUS}"
-  fi
+  run_sima_cli_install "${CORE_INSTALL_DIR}" "${SIMA_CLI_RESOLVED}" \
+    --env "${VULCAN_ENV}" \
+    -d . \
+    -t minimal \
+    "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
+
+  echo
+  echo "Installing latest Insight from Vulcan:"
+  echo "  Environment: ${VULCAN_ENV}"
+  echo "  Scratch dir: ${INSIGHT_INSTALL_DIR}"
+  run_sima_cli_install "${INSIGHT_INSTALL_DIR}" "${SIMA_CLI_RESOLVED}" \
+    --env "${VULCAN_ENV}" \
+    -d . \
+    insight@latest
+
   cleanup_dependency_workspace
   trap - EXIT
 fi

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -69,6 +69,37 @@ print(version)
 PY
 }
 
+extract_insight_target() {
+  local json_path="$1"
+  python3 - <<'PY' "${json_path}"
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+if not isinstance(data, dict):
+    raise SystemExit(1)
+
+insight = data.get("insight")
+if not isinstance(insight, dict):
+    raise SystemExit(1)
+
+ref = insight.get("branch", insight.get("ref"))
+version = insight.get("version")
+if not isinstance(ref, str) or not isinstance(version, str):
+    raise SystemExit(1)
+
+ref = ref.strip()
+version = version.strip()
+if not ref or not version:
+    raise SystemExit(1)
+
+print(ref)
+print(version)
+PY
+}
+
 dependency_workspace_is_owned() {
   [[ -d "${DEPS_DIR}" && ! -L "${DEPS_DIR}" \
     && -f "${DEPS_MARKER}" && ! -L "${DEPS_MARKER}" ]] \
@@ -231,6 +262,11 @@ if [[ ! -f "${NEAT_CORE_JSON_PATH}" ]]; then
   echo "ERROR: extracted apps package is missing neat-core.json." >&2
   exit 1
 fi
+APPS_MANIFEST_PATH="${RUNTIME_SRC}/manifest.json"
+if [[ ! -f "${APPS_MANIFEST_PATH}" ]]; then
+  echo "ERROR: extracted apps package is missing manifest.json." >&2
+  exit 1
+fi
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "ERROR: python3 is required to parse ${NEAT_CORE_JSON_PATH}." >&2
@@ -244,6 +280,12 @@ fi
 
 NEAT_CORE_BRANCH="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '1p')"
 NEAT_CORE_VERSION="$(printf '%s\n' "${NEAT_CORE_TARGET_OUTPUT}" | sed -n '2p')"
+if ! INSIGHT_TARGET_OUTPUT="$(extract_insight_target "${APPS_MANIFEST_PATH}")"; then
+  echo "ERROR: failed to parse Insight install target from ${APPS_MANIFEST_PATH}." >&2
+  exit 1
+fi
+INSIGHT_REF="$(printf '%s\n' "${INSIGHT_TARGET_OUTPUT}" | sed -n '1p')"
+INSIGHT_VERSION="$(printf '%s\n' "${INSIGHT_TARGET_OUTPUT}" | sed -n '2p')"
 
 if [[ "${NEAT_APPS_SKIP_DEPENDENCIES:-0}" == "1" ]]; then
   echo
@@ -269,13 +311,15 @@ else
     "core@${NEAT_CORE_BRANCH}:${NEAT_CORE_VERSION}"
 
   echo
-  echo "Installing latest Insight from Vulcan:"
+  echo "Installing Insight from Vulcan:"
   echo "  Environment: ${VULCAN_ENV}"
+  echo "  Ref        : ${INSIGHT_REF}"
+  echo "  Version    : ${INSIGHT_VERSION}"
   echo "  Scratch dir: ${INSIGHT_INSTALL_DIR}"
   run_sima_cli_install "${INSIGHT_INSTALL_DIR}" "${SIMA_CLI_RESOLVED}" \
     --env "${VULCAN_ENV}" \
     -d . \
-    insight@latest
+    "insight@${INSIGHT_REF}:${INSIGHT_VERSION}"
 
   cleanup_dependency_workspace
   trap - EXIT

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -206,8 +206,8 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
             """\
             #!/usr/bin/env bash
             set -euo pipefail
-            printf '%s\\n' "$PWD" > "${NEAT_APPS_TEST_SIMA_CLI_CWD}"
-            printf '%s\\n' "$*" > "${NEAT_APPS_TEST_SIMA_CLI_ARGS}"
+            printf '%s\\n' "$PWD" >> "${NEAT_APPS_TEST_SIMA_CLI_CWD}"
+            printf '%s\\n' "$*" >> "${NEAT_APPS_TEST_SIMA_CLI_ARGS}"
             if [[ -n "${NEAT_APPS_TEST_FORBIDDEN_PATH:-}" ]]; then
                 [[ ! -e "${NEAT_APPS_TEST_FORBIDDEN_PATH}" ]]
             fi
@@ -216,6 +216,10 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
                 while true; do sleep 1; done
             fi
             touch sima-cli-ran.txt
+            if [[ -n "${NEAT_APPS_TEST_SIMA_CLI_FAIL_TARGET:-}" \
+                && "$*" == *"${NEAT_APPS_TEST_SIMA_CLI_FAIL_TARGET}"* ]]; then
+                exit 1
+            fi
             exit "${NEAT_APPS_TEST_SIMA_CLI_STATUS:-0}"
             """
         ),
@@ -748,12 +752,18 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
     assert not (install_dir / "neat-apps-runtime").exists()
-    assert (tmp_path / "sima-cli-cwd.txt").read_text(encoding="utf-8").strip() == str(
-        package_dir / "deps" / "core"
-    )
-    assert (tmp_path / "sima-cli-args.txt").read_text(encoding="utf-8").strip() == (
-        "neat install --env production -d . -t minimal core@develop:core-sha"
-    )
+    assert (tmp_path / "sima-cli-cwd.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == [
+        str(package_dir / "deps" / "core"),
+        str(package_dir / "deps" / "insight"),
+    ]
+    assert (tmp_path / "sima-cli-args.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == [
+        "neat install --env production -d . -t minimal core@develop:core-sha",
+        "neat install --env production -d . insight@latest",
+    ]
     assert not (package_dir / "deps").exists()
     assert f"  {install_dir}" in proc.stdout
 
@@ -795,6 +805,33 @@ def test_vulcan_installer_keeps_existing_runtime_when_core_install_fails(tmp_pat
 
     assert proc.returncode != 0
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert not (install_dir.parent / "deps").exists()
+
+
+def test_vulcan_installer_keeps_existing_runtime_when_insight_install_fails(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        install_dir=install_dir,
+        extra_env={"NEAT_APPS_TEST_SIMA_CLI_FAIL_TARGET": "insight@latest"},
+    )
+
+    assert proc.returncode != 0
+    assert (tmp_path / "sima-cli-args.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == [
+        "neat install --env production -d . -t minimal core@develop:core-sha",
+        "neat install --env production -d . insight@latest",
+    ]
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert (runtime_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
     assert not (install_dir.parent / "deps").exists()
 
 

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -24,6 +24,7 @@ def _write_runtime_archive(tmp_path: Path, *members: str) -> Path:
     archive_root = tmp_path / "archive-root" / "neat-apps-runtime"
     archive_root.mkdir(parents=True)
     (archive_root / "neat-core.json").write_text("{}\n", encoding="utf-8")
+    (archive_root / "manifest.json").write_text("{}\n", encoding="utf-8")
     for member in members:
         path = archive_root / member
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -90,12 +91,20 @@ def test_runtime_archive_validator_accepts_cpp_reference_and_prebuilt_binary(tmp
     assert proc.returncode == 0, proc.stderr + proc.stdout
 
 
-def _write_manifest(path: Path, neat_core: object = "", platform_version: str = "2.0.0") -> None:
+def _write_manifest(
+    path: Path,
+    neat_core: object = "",
+    platform_version: str = "2.0.0",
+    insight: object | None = None,
+) -> None:
+    if insight is None:
+        insight = {"ref": "main", "version": "latest"}
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
             {
                 "neat-core": neat_core,
+                "insight": insight,
                 "platform-version": platform_version,
             },
             indent=2,
@@ -229,13 +238,23 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
     return bin_dir
 
 
-def _write_vulcan_runtime(package_dir: Path, neat_core: object | None = None) -> Path:
+def _write_vulcan_runtime(
+    package_dir: Path,
+    neat_core: object | None = None,
+    insight: object | None = None,
+) -> Path:
     runtime_dir = package_dir / "neat-apps-runtime"
     runtime_dir.mkdir(parents=True)
     if neat_core is None:
         neat_core = {"branch": "develop", "version": "core-sha"}
+    if insight is None:
+        insight = {"ref": "main", "version": "latest"}
     (runtime_dir / "neat-core.json").write_text(
         json.dumps({"neat-core": neat_core}),
+        encoding="utf-8",
+    )
+    (runtime_dir / "manifest.json").write_text(
+        json.dumps({"insight": insight}),
         encoding="utf-8",
     )
     return runtime_dir
@@ -762,10 +781,28 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
         encoding="utf-8"
     ).splitlines() == [
         "neat install --env production -d . -t minimal core@develop:core-sha",
-        "neat install --env production -d . insight@latest",
+        "neat install --env production -d . insight@main:latest",
     ]
     assert not (package_dir / "deps").exists()
     assert f"  {install_dir}" in proc.stdout
+
+
+@pytest.mark.parametrize("ref_key", ["branch", "ref"])
+def test_vulcan_installer_uses_insight_manifest_target(tmp_path, ref_key):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(
+        package_dir,
+        insight={ref_key: "v0.0.6", "version": "insight-sha"},
+    )
+
+    proc = _run_vulcan_installer(tmp_path, package_dir)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (tmp_path / "sima-cli-args.txt").read_text(
+        encoding="utf-8"
+    ).splitlines()[-1] == (
+        "neat install --env production -d . insight@v0.0.6:insight-sha"
+    )
 
 
 def test_vulcan_installer_can_skip_dependency_installation(tmp_path):
@@ -820,7 +857,7 @@ def test_vulcan_installer_keeps_existing_runtime_when_insight_install_fails(tmp_
         tmp_path,
         package_dir,
         install_dir=install_dir,
-        extra_env={"NEAT_APPS_TEST_SIMA_CLI_FAIL_TARGET": "insight@latest"},
+        extra_env={"NEAT_APPS_TEST_SIMA_CLI_FAIL_TARGET": "insight@main:latest"},
     )
 
     assert proc.returncode != 0
@@ -828,7 +865,7 @@ def test_vulcan_installer_keeps_existing_runtime_when_insight_install_fails(tmp_
         encoding="utf-8"
     ).splitlines() == [
         "neat install --env production -d . -t minimal core@develop:core-sha",
-        "neat install --env production -d . insight@latest",
+        "neat install --env production -d . insight@main:latest",
     ]
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
     assert (runtime_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"


### PR DESCRIPTION
## Why

Installing prebuilt Apps should also prepare Insight so visualization examples work without a separate installation step. Development builds should follow Insight `main/latest`, while stable Apps releases need the option to record and install a specific Insight release.

## What Changed

- Record the Insight install target in the Apps manifest using a `branch` or `ref` plus `version`. The current target is `main/latest`.
- Package the manifest with prebuilt Apps and use the configured target only during prebuilt Apps installation. Insight is not an Apps build or runtime dependency.
- Install Insight through `sima-cli` after installing the exact Core dependency.
- Use the Apps-owned `deps/insight/` directory only as temporary package workspace and remove it before Apps promotion.
- Abort Apps promotion and preserve the previous Apps installation when Insight installation fails.
- Leave wheel selection, virtual environments, services, and installation behavior to `sima-cli` and the Insight package.

## Validation

- `python3 -m pytest tests/scripts/test_manifest_contract.py -q` — 43 passed
- Shell syntax validation for the build, archive-validation, and package-install scripts
- JSON validation for the Apps dependency manifest
- `git diff --check`
- Confirmed that `insight@main:latest` resolves successfully against production artifacts without installing it
- Vulcan CI passed, including SDK build, packaged runtime installation and tests, artifact publication, and latest-tag promotion

## Risk

Apps installation now fails when the configured Insight target cannot be resolved or installed in the selected Vulcan environment. This prevents promotion of an incomplete Apps installation. Apps preserves the previous Apps runtime but does not roll back Core or Insight-owned state.

Closes #349
Part of #341
