### PR TITLE
docs: prioritize installed Apps workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,120 @@
 # Contributing to Neat Apps
 
-This repo hosts runnable application examples for the Neat Library. Contributions
-should preserve that purpose: clear examples, current commands, explicit runtime
-configuration, and tests that match the supported behavior.
+Neat Apps contains runnable application examples for the Neat Library.
+Contributions must keep the public examples readable, executable, testable, and
+consistent with the installed `prebuilt-apps/` bundle.
 
-## Example Contract
+## Example Layout
 
 Every example lives under `examples/<category>/<example>/`.
 
-Required for each example:
+Required:
+
 - `README.md`
 - `tests/test-scope.yaml`
-- `src/common/` when shared config, labels, or assets are needed
-- `src/cpp/` when the example has a C++ implementation
-- `src/python/` when the example has a Python implementation
-- `tests/cpp/` or `tests/python/` when the matching coverage is enabled
+- `src/common/` when C++ and Python share configuration or runtime data
+- `src/cpp/` for C++ implementations
+- `src/python/` for Python implementations
+- matching files under `tests/cpp/` or `tests/python/` for enabled coverage
 
-Use the current `src/` and `tests/` layout. Do not add legacy root-level paths
-such as `main.py`, `main.cpp`, `common/`, `python/`, or `cpp/`.
+Do not add legacy root-level paths such as `main.py`, `main.cpp`, `common/`,
+`python/`, or `cpp/`.
 
 ## Implementation
 
 Prefer both C++ and Python for standard runtime examples. Python-only examples
-are acceptable when the example is inherently Python-first, such as GenAI UI,
-benchmarking, orchestration, or tooling.
+are appropriate for GenAI UI, benchmarking, orchestration, and tooling.
 
-Keep the Neat Library flow visible in the entrypoint. A contributor should be
-able to read `src/cpp/main.cpp` or `src/python/main.py` and identify setup,
-model loading, preprocessing, inference, postprocessing, and teardown without
-chasing opaque wrappers.
+Keep the Neat Library flow visible in each entrypoint. Readers should be able to
+identify setup, model loading, preprocessing, inference, postprocessing, and
+teardown without following opaque wrappers.
 
 Keep runtime inputs explicit:
-- no local-only absolute paths
-- no hardcoded board, RTSP, or Insight host values
-- no hidden model defaults that differ from the README
-- no stale product names in user-facing documentation
 
-Use official names in documentation:
-- Neat Library
-- Neat Development Environment
-- Model Compiler
-- LLiMa
+- no local absolute paths
+- no hardcoded board, RTSP, or Insight hosts
+- no hidden model defaults that disagree with the README
+- no stale product names in user-facing text
+
+Use the official product names: Neat Library, Neat Development Environment,
+Model Compiler, and LLiMa.
+
+## README Contract
+
+Start from `examples/TEMPLATE_README.md`. Write the README as one path from
+release installation to a successful run. Keep source development secondary.
+
+The validator requires these sections in order:
+
+1. `Metadata`
+2. `Concept`
+3. `Prerequisites`
+4. `Install Apps`
+5. `Prepare the Model`
+6. `Run`
+7. `Source Files`
+8. `Development From Source`
+
+Optional sections such as `Preview`, `Configure`, `Expected Result`, and
+`Troubleshooting` belong where they support that sequence.
+
+The installed workflow must:
+
+- link to the [Neat Apps releases](https://github.com/sima-neat/apps/releases)
+- install `apps@<release-version>`
+- run subsequent commands from `prebuilt-apps/`
+- use `src/cpp/pre-built/<binary>` for C++
+- use packaged `src/python/` entrypoints or supported wrappers for Python
+- keep clone, CMake, build, and test commands out of the primary workflow
+
+The installed package excludes CMake files and tests. List only packaged files
+under `Source Files`, and describe C++ source as implementation reference.
+Link `Development From Source` back to this guide instead of copying build and
+test instructions into every example.
+
+## Model Documentation
+
+Each example README must identify:
+
+- its default model
+- every additional model explicitly supported by its preprocessing and
+  postprocessing path
+- whether each model comes from Model Zoo, a direct artifact, or an
+  example-specific installer
+- the corresponding `sima-cli` command when that source supports it
+- the downloaded package selected by `model.path`
+
+Use `models/` for user-managed packages. The platform version used by model
+downloads is recorded in the installed `manifest.json`.
+
+Do not infer application support from every model declared in
+`tests/test-scope.yaml`. That file owns test acquisition. Confirm supported
+models against the config and implementation, and distinguish them from the
+default model.
+
+GenAI examples may use their own setup scripts for Hugging Face model
+directories. Do not document a `sima-cli` model download when the command is
+not supported.
+
+## Portal Metadata
+
+README metadata fields are:
+
+- `Category`
+- `Difficulty`
+- `Tags`
+- `Languages`
+- `Status`
+- `Binary Name`
+- `Model`
+
+For portal-facing examples, add `Preview` after `Concept` and store the image
+under `portal/assets/examples/<category>/<example>/image.*`.
 
 ## Test Scope
 
-`tests/test-scope.yaml` is the source of truth for enabled tests and e2e model
-artifacts.
-
-Use this shape:
+`tests/test-scope.yaml` is the source of truth for enabled tests and model
+artifacts required by e2e coverage.
 
 ```yaml
 models:
@@ -69,39 +136,17 @@ e2e:
       - model_id
 ```
 
-If a language or e2e path is not supported, disable it in `test-scope.yaml`.
-For disabled e2e coverage, include a short `reason`. Do not add placeholder
-tests and enable them as real coverage.
+Disable unsupported coverage in `test-scope.yaml` and include a short reason
+for disabled e2e paths. Enabled coverage must have the matching test file:
 
-Enabled coverage must have the matching files:
 - Python unit: `tests/python/test_unit.py`
 - Python e2e: `tests/python/test_e2e.py`
 - C++ unit: `tests/cpp/test_unit.cpp`
 - C++ e2e: `tests/cpp/test_e2e.cpp`
 
-## README
-
-Start from `examples/TEMPLATE_README.md`. Every example README must stay aligned
-with the current source, config, supported models, and commands.
-
-The README validator enforces:
-- metadata fields: `Category`, `Difficulty`, `Tags`, `Languages`, `Status`,
-  `Binary Name`, `Model`
-- sections: `Metadata`, `Concept`, `Prerequisites`, `Get The Apps Repo`, `Run`,
-  `Source Files`
-
-For portal-facing examples, add a `## Preview` section after `## Concept` and
-store the image at `portal/assets/examples/<category>/<example>/image.*`.
-
-Use `models/` for model artifact examples. When documenting model
-downloads, use the platform version placeholder and tell users to use the
-platform version.
-
 ## Build and Test
 
-`build.sh` builds. `tests/test.sh` tests. Keep those responsibilities separate.
-
-Standard validation from the apps repo:
+`build.sh` builds. `tests/test.sh` tests.
 
 ```bash
 ./build.sh --clean
@@ -110,42 +155,35 @@ python3 scripts/validate_readmes.py
 python3 scripts/generate_catalog.py >/tmp/apps-catalog.json
 ```
 
-Run e2e validation when the required hardware, model, RTSP, and service
-prerequisites are available:
+Run e2e validation when its hardware, model, RTSP, and service prerequisites are
+available:
 
 ```bash
 ./tests/test.sh --e2e
 ./tests/test.sh --e2e --strict
 ```
 
-Compile C++ examples in the Neat Development Environment. Run Neat runtime and
-e2e checks on SiMa hardware such as Modalix or DevKit. Host checks are useful
-for documentation, source inspection, and light static validation only.
+Compile C++ examples in the Neat Development Environment. Run runtime and e2e
+checks on supported SiMa hardware. Host checks cover documentation, source
+hygiene, and lightweight static validation.
 
-## CMake and Scripts
+When adding C++:
 
-When adding a C++ implementation:
 - add `src/cpp/CMakeLists.txt`
-- register the example through the category `CMakeLists.txt`
+- register the example through its category `CMakeLists.txt`
 - keep C++ test filenames aligned with `cmake/ExampleModule.cmake`
 
-When changing layout, commands, models, or test behavior, check the affected
-repo contracts:
-- `build.sh`
-- `tests/test.sh`
-- `tests/utils/test_scope.py`
-- `scripts/validate_readmes.py`
-- `scripts/generate_catalog.py`
-- `.github/workflows/*.yml`
+When changing layout, commands, models, or tests, inspect `build.sh`,
+`tests/test.sh`, `tests/utils/test_scope.py`, README validation, catalog
+generation, and affected CI workflows.
 
 ## Review Checklist
 
-Before asking for review:
-- README commands match the source and runtime behavior.
-- `tests/test-scope.yaml` matches implemented coverage.
-- Enabled tests have real test files.
-- Disabled e2e paths have a reason.
-- Model names, paths, and download commands are current.
-- Portal examples have `## Preview` and `portal/assets/examples/.../image.*`.
-- `./build.sh --clean` succeeds when source changes require a build.
-- README validation and catalog generation pass for documentation changes.
+- Installed README commands match the packaged runtime.
+- Default and supported models match the implementation and configuration.
+- Every model has an accurate acquisition path.
+- `tests/test-scope.yaml` matches enabled coverage.
+- Disabled e2e paths explain why.
+- Portal examples include their preview asset.
+- Source changes build successfully.
+- README validation and catalog generation pass.

--- a/README.md
+++ b/README.md
@@ -4,115 +4,81 @@
 ![Neat Development Environment](https://img.shields.io/badge/Neat%20Development%20Environment-2.1.2-green)
 ![Language](https://img.shields.io/badge/C%2B%2B-20-informational)
 
-SiMa Neat Apps is a source-first collection of editable applications and reference
-examples for real Modalix workflows: detection, segmentation, streaming,
-tracking, benchmarking, and GenAI.
+SiMa Neat Apps provides runnable C++ and Python examples for detection,
+segmentation, streaming, tracking, benchmarking, and GenAI. Install a release
+to run the packaged examples. Clone this repository only when modifying or
+building their source.
 
-Use this repo when you want runnable examples that keep the important Neat
-Library C++ and Python API calls visible in the source. Use the Neat Library
-docs for the runtime API contract, and use this repo for working application
-patterns.
+## Install a Release
 
-`core` owns the Neat Library runtime and tooling. `apps` owns customer-facing
-examples and sample application code.
-
-## Start
-
-Install the Neat Development Environment and Neat Library first:
-
-- [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/install-the-environment)
-- [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/install-or-update)
-- [sima-cli](https://developer.sima.ai/software/tools/sima-cli/)
-
-For Neat Development Environment 2.1.2:
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. On a supported Modalix or DevKit target, install that version:
 
 ```bash
-sima-cli install ghcr:sima-neat/sdk:v2.1.2
-sima-cli sdk neat
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
 ```
 
-Clone and build this repo from the SDK shell:
+The Apps package installs its configured Core and Insight dependencies. The
+installed bundle is placed under `prebuilt-apps/`. Run the remaining commands
+from that directory.
+
+## Run an Example
+
+Each example README identifies its model, inputs, configuration, and exact run
+commands.
+
+C++ applications use the packaged executable:
 
 ```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
+./examples/<category>/<example>/src/cpp/pre-built/<binary> \
+  --config examples/<category>/<example>/src/common/config.yaml
 ```
 
-Python examples use the PyNeat environment installed with the Neat Library:
+Python applications use their packaged entrypoint:
 
 ```bash
 source ~/pyneat/bin/activate
+pip install -r examples/<category>/<example>/src/python/requirements.txt
+python3 examples/<category>/<example>/src/python/main.py \
+  --config examples/<category>/<example>/src/common/config.yaml
 ```
 
-For the public examples index, use the
-[Neat Apps Portal](https://developer.sima.ai/examples). For broader application
-development docs, use [Develop Apps](https://developer.sima.ai/software/develop-apps/).
+Some Python applications provide `setup.sh` and `run.sh` wrappers instead.
+Follow the selected example README.
 
-## Fetch One Example
+Browse the [Neat Apps Portal](https://developer.sima.ai/examples) or the
+[examples directory](./examples) to choose an example.
 
-To fetch one example without cloning the full repo:
+## Models and Datasets
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-example.sh | bash -s -- <example>
-```
+Models are user-managed and are not included in the Apps package. Store them
+under `models/`, or set `model.path` to another readable package. Each
+example README lists its default and additional supported models with the
+corresponding `sima-cli` download command.
 
-Example:
+The platform version required by model downloads is recorded in the installed
+`manifest.json`. Runtime sample data is included under `assets/datasets/`.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-example.sh | bash -s -- multimodal-assistant
-cd multimodal-assistant
-./setup.sh
-./run.sh
-```
-
-## Repo Layout
+## Installed Layout
 
 | Path | Purpose |
 | --- | --- |
-| `examples/` | Application examples organized by category |
-| `assets/` | Runtime assets, including models and test media |
-| `tests/` | Test runner, fixtures, and test documentation |
-| `deps/manifest.json` | Neat Library and platform dependency declaration |
-| `portal/` | Source for the examples portal |
+| `examples/<category>/<example>/README.md` | Example setup and run instructions |
+| `examples/<category>/<example>/src/cpp/pre-built/` | Packaged C++ executables |
+| `examples/<category>/<example>/src/cpp/` | C++ implementation reference |
+| `examples/<category>/<example>/src/python/` | Python implementation and dependencies |
+| `examples/<category>/<example>/src/common/` | Shared runtime configuration and data |
+| `assets/datasets/` | Shipped runtime sample data |
+| `models/` | User-managed model packages |
+| `manifest.json` | Apps dependency and platform metadata |
 
-## Examples
-
-Examples live under `examples/<category>/<example>/`.
-
-The common shape is:
-
-| Path | Purpose |
-| --- | --- |
-| `README.md` | Example-specific setup and run instructions |
-| `src/common/` | Shared config, labels, and assets |
-| `src/cpp/main.cpp` | C++ entrypoint, when present |
-| `src/python/main.py` | Python entrypoint, when present |
-| `tests/` | Example-specific unit and e2e tests |
-
-Start with the example README. It is the source for model downloads, runtime
-inputs, config edits, and run commands for that example.
-
-Contributor details live in [CONTRIBUTING.md](./CONTRIBUTING.md). The README
-template lives at [examples/TEMPLATE_README.md](./examples/TEMPLATE_README.md).
-
-## Build
-
-`build.sh` builds the repo. It does not run tests.
-
-Common commands:
-
-```bash
-./build.sh          # configure and build
-./build.sh --clean  # clean build directory first
-```
-
-Compile C++ examples in the Neat Development Environment. Run Neat runtime and
-e2e checks on SiMa hardware such as Modalix or DevKit.
+The installed bundle does not contain CMake files or tests. Clone the repository
+to compile source or run the Apps test suite.
 
 ## RTSP Streams
 
-For quick RTSP sources, use
+For local RTSP sources, use
 [`tool-mediasources`](https://github.com/SiMa-ai/tool-mediasources):
 
 ```bash
@@ -120,33 +86,52 @@ sima-cli install gh:sima-ai/tool-mediasources
 ./mediasrc.sh <video-dir>
 ```
 
-If a board or DevKit consumes host-streamed RTSP sources, use the host IP in the
-RTSP URL instead of `127.0.0.1`.
+If a board consumes host-streamed RTSP sources, use the host IP in the RTSP URL
+instead of `127.0.0.1`.
 
-For fixed 16-, 24-, and 48-stream RTSP-to-Insight profiles, see the
-[high-density multi-stream object detector](examples/object-detection/high-density-multi-stream-object-detector/README.md).
+## Development From Source
 
-## Neat Library Dependency
+Clone and build Apps inside the Neat Development Environment:
 
-`deps/manifest.json` declares the Neat Library dependency and platform version.
-
-The normal branch value is:
-
-```json
-{
-  "neat-core": {
-    "policy": "snap"
-  }
-}
+```bash
+git clone https://github.com/sima-neat/apps.git
+cd apps
+./build.sh --clean
 ```
 
-`snap` resolves from the dependency branch: `main` uses `main-latest`, `develop`
-uses `develop-latest`, and custom branches use a matching core branch when one
-exists or fall back to `develop-latest`.
+`build.sh` builds the repository; it does not run tests. Contributor,
+scaffolding, build, and test instructions live in
+[CONTRIBUTING.md](./CONTRIBUTING.md).
+
+To fetch one standalone example without cloning the complete repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-example.sh | bash -s -- <example>
+```
+
+## Repository Layout
+
+| Path | Purpose |
+| --- | --- |
+| `examples/` | Application examples organized by category |
+| `assets/datasets/` | Runtime datasets shipped with Apps |
+| `assets/datasets-test/` | Repository-only test fixtures |
+| `models/` | Ignored user-managed model packages |
+| `tests/` | Test runner and repository test support |
+| `deps/manifest.json` | Source dependency and platform declaration |
+| `portal/` | Examples portal source |
+
+## Dependency Selection
+
+`deps/manifest.json` declares the Core and Insight targets used when building
+an Apps package. Release branches can record exact dependency versions;
+development branches may follow their configured latest targets. It is
+packaged as `manifest.json`, while `neat-core.json` records the resolved Core
+target.
 
 ## Support
 
-Use GitHub issues for bug reports and feature requests. Include the exact
-example, command, inputs, environment, and logs needed to reproduce the issue.
+Use GitHub issues for bug reports and feature requests. Include the example,
+command, inputs, environment, and logs required to reproduce the problem.
 
 For direct help, contact `support@sima.ai`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Browse the [Neat Apps Portal](https://developer.sima.ai/examples) or the
 Models are user-managed and are not included in the Apps package. Store them
 under `models/`, or set `model.path` to another readable package. Each
 example README lists its default and additional supported models with the
-corresponding `sima-cli` download command.
+corresponding `sima-cli` or example-specific installation command.
 
 The platform version required by model downloads is recorded in the installed
 `manifest.json`. Runtime sample data is included under `assets/datasets/`.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ under `models/`, or set `model.path` to another readable package. Each
 example README lists its default and additional supported models with the
 corresponding `sima-cli` or example-specific installation command.
 
-The platform version required by model downloads is recorded in the installed
-`manifest.json`. Runtime sample data is included under `assets/datasets/`.
+Before downloading a model, set `PLATFORM_VERSION` to the `platform-version` value recorded in the installed `manifest.json`. Runtime sample data is included under `assets/datasets/`.
 
 ## Installed Layout
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ under `models/`, or set `model.path` to another readable package. Each
 example README lists its default and additional supported models with the
 corresponding `sima-cli` or example-specific installation command.
 
-Before downloading a model, set `PLATFORM_VERSION` to the `platform-version` value recorded in the installed `manifest.json`. Runtime sample data is included under `assets/datasets/`.
+Check the installed platform version:
+
+```bash
+cat /etc/buildinfo
+```
+
+Before downloading a model, set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Runtime sample data is included under `assets/datasets/`.
 
 ## Installed Layout
 

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -26,7 +26,7 @@ Optional. Place portal images under `portal/assets/examples/<category>/<example>
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - <Example-specific input, service, or hardware requirements.>
 
 ## Install Apps

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -10,7 +10,7 @@
 | Languages | C++, Python |
 | Status | <experimental / stable> |
 | Binary Name | <binary> |
-| Model | <default-model> [https://example.com/path/to/<default-model>.tar.gz] |
+| Model | <default-model> |
 
 ## Concept
 

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -50,14 +50,15 @@ The default model is `<default-model>`.
 | `<default-model>` | Default | <Model Zoo / direct artifact> |
 | `<supported-model>` | Supported | <Model Zoo / direct artifact> |
 
-The platform version required by model downloads is recorded in `manifest.json`. Use the command that matches the model source and delete the other command.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli modelzoo -v <platform-version> get <model-name>
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get <model-name>
 cd ..
 ```
 

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -50,11 +50,12 @@ The default model is `<default-model>`.
 | `<default-model>` | Default | <Model Zoo / direct artifact> |
 | `<supported-model>` | Supported | <Model Zoo / direct artifact> |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Use the command that matches the model source and delete the other command.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -50,8 +50,7 @@ The default model is `<default-model>`.
 | `<default-model>` | Default | <Model Zoo / direct artifact> |
 | `<supported-model>` | Supported | <Model Zoo / direct artifact> |
 
-The platform version required by model downloads is recorded in `manifest.json`.
-Use the command that matches the model source and delete the other command.
+The platform version required by model downloads is recorded in `manifest.json`. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
@@ -115,10 +114,8 @@ python3 examples/<category>/<example>/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared runtime files: `src/common/`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -32,7 +32,7 @@ Optional. Place portal images under `portal/assets/examples/<category>/<example>
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -1,6 +1,7 @@
 # <Example Name>
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | <benchmarking / classification / object-detection / tracking / face-detection / segmentation / depth-estimation / genai / throughput> |
@@ -8,95 +9,116 @@
 | Tags | <comma-separated tags> |
 | Languages | C++, Python |
 | Status | <experimental / stable> |
-| Binary Name | <cmake_target_name> |
-| Model | <default_model_name> [https://example.com/path/to/<default_model_name>_mpk.tar.gz] |
+| Binary Name | <binary> |
+| Model | <default-model> [https://example.com/path/to/<default-model>.tar.gz] |
 
 ## Concept
-<1-2 paragraphs: what this example demonstrates and which Neat Library capabilities it exercises.>
+
+<Explain what the example demonstrates and which Neat Library capabilities it uses.>
 
 ## Preview
-Optional. If you have a demo screenshot for the portal detail page, place it here immediately after `Concept`.
+
+Optional. Place portal images under `portal/assets/examples/<category>/<example>/`.
 
 ```md
 ![Demo screenshot](../../../portal/assets/examples/<category>/<example>/image.png)
 ```
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Default model: `<default-model>`.
+- `sima-cli` on a supported Modalix or DevKit target.
+- <Example-specific input, service, or hardware requirements.>
 
-Download the default model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+The default model is `<default-model>`.
+
+| Model | Role | Source |
+| --- | --- | --- |
+| `<default-model>` | Default | <Model Zoo / direct artifact> |
+| `<supported-model>` | Supported | <Model Zoo / direct artifact> |
+
+The platform version required by model downloads is recorded in `manifest.json`.
+Use the command that matches the model source and delete the other command.
+
+Model Zoo:
 
 ```bash
 mkdir -p models
 cd models
-
-sima-cli modelzoo -v <platform-version> get <default-model>
-
+sima-cli modelzoo -v <platform-version> get <model-name>
 cd ..
 ```
 
-For another supported model, replace `<default-model>` in the download command and config path.
-The command stores models under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-- If the model is not available through modelzoo, add a direct download URL in the `Model` metadata field using the `[https://...]` suffix.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
+Direct artifact:
 
 ```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
+mkdir -p models
+cd models
+sima-cli download <model-url>
+cd ..
 ```
 
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the example config to the downloaded package.
 
 ## Configure
-Edit `examples/<category>/<name>/src/common/config.yaml`.
+
+Edit `examples/<category>/<example>/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>             # Path to the model package.
+  path: <model-path>
 
 io:
-  input_dir: assets/datasets/coco           # Folder containing input images.
-  output_dir: sandbox/<name>              # Folder for generated outputs.
+  input_dir: assets/datasets/coco
+  output_dir: sandbox/<example>
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/<category>/<name>/<binary> \
-  --config examples/<category>/<name>/src/common/config.yaml
+./examples/<category>/<example>/src/cpp/pre-built/<binary> \
+  --config examples/<category>/<example>/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
-pip install -r examples/<category>/<name>/src/python/requirements.txt
-python3 examples/<category>/<name>/src/python/main.py \
-  --config examples/<category>/<name>/src/common/config.yaml
+pip install -r examples/<category>/<example>/src/python/requirements.txt
+python3 examples/<category>/<example>/src/python/main.py \
+  --config examples/<category>/<example>/src/common/config.yaml
 ```
 
-## Debugging Notes
-- Confirm `model.path` points to a readable model package.
-- Confirm input paths exist and are readable.
-- Confirm output directories are writable.
+## Troubleshooting
 
-## Appendix: Additional Models
-This example can also run with `<model_variant_1>` or `<model_variant_2>`. Replace the default model name in the download command and config path.
+- Confirm `model.path` points to a readable model package.
+- Confirm input paths exist and output directories are writable.
 
 ## Source Files
-- Test scope: `tests/test-scope.yaml`
-- C++ source: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Shared assets: `src/common/`
+- Shared runtime files: `src/common/`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -14,12 +14,9 @@
 
 ## Concept
 
-Benchmark a compiled model before integrating it into a full pipeline. The
-example runs `pyneat.Model.benchmark()` and writes latency, FPS, power, and
-energy measurements to JSON.
+Benchmark a compiled model before integrating it into a full pipeline. The example runs `pyneat.Model.benchmark()` and writes latency, FPS, power, and energy measurements to JSON.
 
-This synthetic model benchmark does not measure input decoding, Insight output,
-overlays, or application postprocessing.
+This synthetic model benchmark does not measure input decoding, Insight output, overlays, or application postprocessing.
 
 ## Preview
 
@@ -44,11 +41,9 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-This example accepts any compatible compiled MPK. Apps CI exercises the
-benchmark with `yolo26m-det-int8-b1.tar.gz`; it is not a required default.
+This example accepts any compatible compiled MPK. Apps CI exercises the benchmark with `yolo26m-det-int8-b1.tar.gz`; it is not a required default.
 
-The required platform version is recorded in `manifest.json`. Download a Model
-Zoo package:
+The required platform version is recorded in `manifest.json`. Download a Model Zoo package:
 
 ```bash
 mkdir -p models
@@ -68,8 +63,7 @@ cd ..
 
 ## Configure
 
-Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or provide
-the same values on the command line.
+Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or provide the same values on the command line.
 
 ```yaml
 model:
@@ -93,21 +87,17 @@ python3 examples/benchmarking/model-benchmark/src/python/main.py \
   --output-json sandbox/model-benchmark/report.json
 ```
 
-The command prints headline metrics and writes the complete report to the
-selected JSON path.
+The command prints headline metrics and writes the complete report to the selected JSON path.
 
 ## Benchmark Results
 
-See the maintained
-[benchmark results](https://github.com/sima-neat/apps/blob/main/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md)
-for measurements from Apps-supported packages.
+See the maintained [benchmark results](https://github.com/sima-neat/apps/blob/main/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md) for measurements from Apps-supported packages.
 
 ## Troubleshooting
 
 - Activate `~/pyneat` if the `pyneat` module is unavailable.
 - Confirm the model path points to a compiled `.tar.gz` package.
-- A zero power result means board power telemetry was unavailable; the model
-  benchmark still completed.
+- A zero power result means board power telemetry was unavailable; the model benchmark still completed.
 
 ## Source Files
 
@@ -116,5 +106,4 @@ for measurements from Apps-supported packages.
 
 ## Development From Source
 
-To modify or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -43,12 +43,13 @@ Run the remaining commands from `prebuilt-apps/`.
 
 This example accepts any compatible compiled MPK. Apps CI exercises the benchmark with `yolo26m-det-int8-b1.tar.gz`; it is not a required default.
 
-The required platform version is recorded in `manifest.json`. Download a Model Zoo package:
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Download a Model Zoo package:
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli modelzoo -v <platform-version> get <model-name>
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get <model-name>
 cd ..
 ```
 

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -30,7 +30,7 @@ This synthetic model benchmark does not measure input decoding, Insight output, 
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -43,9 +43,10 @@ Run the remaining commands from `prebuilt-apps/`.
 
 This example accepts any compatible compiled MPK. Apps CI exercises the benchmark with `yolo26m-det-int8-b1.tar.gz`; it is not a required default.
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Download a Model Zoo package:
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Download a Model Zoo package:
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -1,6 +1,7 @@
 # Model Benchmark
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | benchmarking |
@@ -12,86 +13,108 @@
 | Model | Any compiled model package |
 
 ## Concept
-Before building a full camera or Insight pipeline, benchmark the compiled model package by itself. This example loads one `.tar.gz` model package, runs `pyneat.Model.benchmark()`, and writes a JSON report with latency, FPS, power, and energy.
 
-This is a model-only synthetic benchmark. It does not measure RTSP input, camera decode, Insight video, metadata, overlays, or application postprocessing.
+Benchmark a compiled model before integrating it into a full pipeline. The
+example runs `pyneat.Model.benchmark()` and writes latency, FPS, power, and
+energy measurements to JSON.
+
+This synthetic model benchmark does not measure input decoding, Insight output,
+overlays, or application postprocessing.
 
 ## Preview
-The benchmark writes a report that can be compared across model packages:
 
 ![Model benchmark preview](../../../portal/assets/examples/benchmarking/model-benchmark/image.png)
 
-## Supported Models
-This example accepts any compiled model package supported by `pyneat.Model`.
-
-`tests/test-scope.yaml` lists the compiled model packages already used by Apps examples. `BENCHMARK_RESULTS.md` is the manually maintained table for reference benchmark results.
-
 ## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Activated `pyneat` environment.
-- Model artifacts are user-managed and should be downloaded into `models/`.
 
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
+- `sima-cli` on a supported Modalix or DevKit target.
+- A compiled model package supported by `pyneat.Model`.
 
-Clone and build the apps repo inside the Neat Development Environment:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
 
 ```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
 ```
 
-After building, run the example commands below on the Modalix/DevKit board.
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+This example accepts any compatible compiled MPK. Apps CI exercises the
+benchmark with `yolo26m-det-int8-b1.tar.gz`; it is not a required default.
+
+The required platform version is recorded in `manifest.json`. Download a Model
+Zoo package:
+
+```bash
+mkdir -p models
+cd models
+sima-cli modelzoo -v <platform-version> get <model-name>
+cd ..
+```
+
+For a model published as a direct artifact:
+
+```bash
+mkdir -p models
+cd models
+sima-cli download <model-url>
+cd ..
+```
 
 ## Configure
-Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or override these values from the command line.
+
+Edit `examples/benchmarking/model-benchmark/src/common/config.yaml`, or provide
+the same values on the command line.
 
 ```yaml
 model:
-  path: <model-path>                          # Path to the model package.
+  path: <model-path>
 
 benchmark:
-  frames: 1000                                # Number of synthetic frames.
+  frames: 1000
 
 output:
-  report_json: sandbox/model-benchmark/report.json # JSON report path.
+  report_json: sandbox/model-benchmark/report.json
 ```
 
 ## Run
-On the Modalix/DevKit board, from the Apps repo root:
 
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/benchmarking/model-benchmark/src/python/requirements.txt
-
 python3 examples/benchmarking/model-benchmark/src/python/main.py \
-  --model models/my_model.tar.gz \
+  --model models/<model-file>.tar.gz \
   --frames 1000 \
-  --output-json sandbox/model-benchmark/my_model.json
+  --output-json sandbox/model-benchmark/report.json
 ```
 
-The command prints the headline metrics and writes the JSON report:
-
-```text
-latency_ms=...
-fps=...
-avg_power_watts=...
-energy_joules=...
-report_json=sandbox/model-benchmark/my_model.json
-```
+The command prints headline metrics and writes the complete report to the
+selected JSON path.
 
 ## Benchmark Results
-See `BENCHMARK_RESULTS.md` for the manually maintained reference results for Apps-supported model packages.
 
-## Debugging Notes
-- If `pyneat` is missing, activate the Neat Python environment with `source ~/pyneat/bin/activate`.
-- If the model path fails, confirm the `.tar.gz` file exists on the target device.
-- If power is zero, the benchmark still completed; board power telemetry was unavailable for that run.
+See the maintained
+[benchmark results](https://github.com/sima-neat/apps/blob/main/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md)
+for measurements from Apps-supported packages.
+
+## Troubleshooting
+
+- Activate `~/pyneat` if the `pyneat` module is unavailable.
+- Confirm the model path points to a compiled `.tar.gz` package.
+- A zero power result means board power telemetry was unavailable; the model
+  benchmark still completed.
 
 ## Source Files
+
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
 - Shared config: `src/common/config.yaml`
-- Test scope: `tests/test-scope.yaml`
-- Reference results: `BENCHMARK_RESULTS.md`
+
+## Development From Source
+
+To modify or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -24,7 +24,7 @@ This synthetic model benchmark does not measure input decoding, Insight output, 
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - A compiled model package supported by `pyneat.Model`.
 
 ## Install Apps

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -44,12 +44,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `resnet_50_mpk.tar.gz` | Default | `resnet_50` |
 
-The required platform version is recorded in `manifest.json`.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli modelzoo -v <platform-version> get resnet_50
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get resnet_50
 cd ..
 ```
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -64,11 +64,14 @@ model:
   path: <model-path>
 
 io:
-  image: null                 # null uses the packaged sample image.
+  image: null
+  fallback_image_url: https://raw.githubusercontent.com/EliSchwartz/imagenet-sample-images/master/n01443537_goldfish.JPEG
 
 validation:
   min_probability: 0.50
 ```
+
+With `io.image: null`, the example downloads `fallback_image_url` and therefore requires network access. For offline use, set `io.image` to a readable local image path; the fallback URL is not used when a local path is configured.
 
 ## Run
 
@@ -91,7 +94,7 @@ python3 examples/classification/image-classifier/src/python/main.py \
 ## Troubleshooting
 
 - Verify `model.path` if model loading fails.
-- Set `io.image` if image decoding fails.
+- Set `io.image` to a readable local image if downloading or decoding the fallback image fails.
 - Lower `validation.min_probability` when investigating validation failures.
 
 ## Source Files

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -44,9 +44,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `resnet_50_mpk.tar.gz` | Default | `resnet_50` |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -29,7 +29,7 @@ The pipeline classifies this goldfish image:
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -1,6 +1,7 @@
 # Image Classifier
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | classification |
@@ -12,19 +13,39 @@
 | Model | resnet_50 |
 
 ## Concept
-Minimal Model API usage with a compiled ResNet50 model package. The example loads the package, runs single-image inference, and prints top-1/top-5 classification output.
+
+Minimal Model API usage with a compiled ResNet50 package. The example runs
+single-image inference and prints top-1 and top-5 classification results.
 
 ## Preview
-The pipeline is trying to classify this goldfish image.
+
+The pipeline classifies this goldfish image:
 
 ![Image classifier goldfish input](../../../portal/assets/examples/classification/image-classifier/image.jpeg)
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Primary model: `resnet_50`
+- `sima-cli` on a supported Modalix or DevKit target.
 
-Download the model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model package | Role | Model Zoo name |
+| --- | --- | --- |
+| `resnet_50_mpk.tar.gz` | Default | `resnet_50` |
+
+The required platform version is recorded in `manifest.json`.
 
 ```bash
 mkdir -p models
@@ -33,47 +54,35 @@ sima-cli modelzoo -v <platform-version> get resnet_50
 cd ..
 ```
 
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the config to the downloaded package.
 
 ## Configure
-Edit `examples/classification/image-classifier/src/common/config.yaml` if you want to use a different image or threshold.
+
+Edit `examples/classification/image-classifier/src/common/config.yaml` to use a
+different image or threshold.
 
 ```yaml
 model:
-  path: <model-path>                        # Path to the model package.
+  path: <model-path>
 
 io:
-  image: null                               # Input image. null uses the sample image.
+  image: null                 # null uses the packaged sample image.
 
 validation:
-  min_probability: 0.50                     # Minimum expected-class probability.
+  min_probability: 0.50
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/classification/image-classifier/image-classifier \
+./examples/classification/image-classifier/src/cpp/pre-built/image-classifier \
   --config examples/classification/image-classifier/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/classification/image-classifier/src/python/requirements.txt
@@ -81,12 +90,22 @@ python3 examples/classification/image-classifier/src/python/main.py \
   --config examples/classification/image-classifier/src/common/config.yaml
 ```
 
-## Debugging Notes
-- If you see a model load error, verify `model.path` points to a readable model package.
-- If image decode fails, set `io.image` in the config.
-- If top-1 validation fails, try lowering `validation.min_probability` for debug runs.
+## Troubleshooting
+
+- Verify `model.path` if model loading fails.
+- Set `io.image` if image decoding fails.
+- Lower `validation.min_probability` when investigating validation failures.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -24,7 +24,7 @@ The pipeline classifies this goldfish image:
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 
 ## Install Apps
 

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -14,8 +14,7 @@
 
 ## Concept
 
-Minimal Model API usage with a compiled ResNet50 package. The example runs
-single-image inference and prints top-1 and top-5 classification results.
+Minimal Model API usage with a compiled ResNet50 package. The example runs single-image inference and prints top-1 and top-5 classification results.
 
 ## Preview
 
@@ -58,8 +57,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Configure
 
-Edit `examples/classification/image-classifier/src/common/config.yaml` to use a
-different image or threshold.
+Edit `examples/classification/image-classifier/src/common/config.yaml` to use a different image or threshold.
 
 ```yaml
 model:
@@ -102,10 +100,8 @@ python3 examples/classification/image-classifier/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -22,7 +22,7 @@ Depth-map generation for image folders. The example runs inference for each imag
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 
 ## Install Apps
 

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -1,6 +1,7 @@
 # Depth Estimator
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | depth-estimation |
@@ -12,19 +13,37 @@
 | Model | depth_anything_v2_vits |
 
 ## Concept
-Depth-map generation for image folders. The example runs inference per image and writes visual depth outputs.
+
+Depth-map generation for image folders. The example runs inference for each
+image and writes a visual depth map.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![Depth estimator preview](../../../portal/assets/examples/depth-estimation/depth-estimator/image.png)
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Primary model: `depth_anything_v2_vits`
+- `sima-cli` on a supported Modalix or DevKit target.
 
-Download the model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model package | Role | Model Zoo name |
+| --- | --- | --- |
+| `depth_anything_v2_vits_mpk.tar.gz` | Default | `depth_anything_v2_vits` |
+
+The required platform version is recorded in `manifest.json`.
 
 ```bash
 mkdir -p models
@@ -33,45 +52,32 @@ sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
 cd ..
 ```
 
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the config to the downloaded package.
 
 ## Configure
+
 Edit `examples/depth-estimation/depth-estimator/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                         # Path to the model package.
+  path: <model-path>
 
 io:
-  input_dir: assets/datasets/coco                         # Folder containing input images.
-  output_dir: sandbox/depth-estimator                   # Folder for depth visualizations.
+  input_dir: assets/datasets/coco
+  output_dir: sandbox/depth-estimator
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/depth-estimation/depth-estimator/depth-estimator \
+./examples/depth-estimation/depth-estimator/src/cpp/pre-built/depth-estimator \
   --config examples/depth-estimation/depth-estimator/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/depth-estimation/depth-estimator/src/python/requirements.txt
@@ -79,12 +85,22 @@ python3 examples/depth-estimation/depth-estimator/src/python/main.py \
   --config examples/depth-estimation/depth-estimator/src/common/config.yaml
 ```
 
-## Debugging Notes
-- Check model path first if startup fails.
-- If no outputs are produced, verify `input_dir` has valid images.
-- Check write permissions on `output_dir`.
+## Troubleshooting
+
+- Verify `model.path` if startup fails.
+- Confirm `io.input_dir` contains supported images.
+- Confirm `io.output_dir` is writable.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -42,9 +42,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `depth_anything_v2_vits_mpk.tar.gz` | Default | `depth_anything_v2_vits` |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -14,8 +14,7 @@
 
 ## Concept
 
-Depth-map generation for image folders. The example runs inference for each
-image and writes a visual depth map.
+Depth-map generation for image folders. The example runs inference for each image and writes a visual depth map.
 
 ## Preview
 
@@ -97,10 +96,8 @@ python3 examples/depth-estimation/depth-estimator/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -27,7 +27,7 @@ Depth-map generation for image folders. The example runs inference for each imag
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -42,12 +42,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `depth_anything_v2_vits_mpk.tar.gz` | Default | `depth_anything_v2_vits` |
 
-The required platform version is recorded in `manifest.json`.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli modelzoo -v <platform-version> get depth_anything_v2_vits
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get depth_anything_v2_vits
 cd ..
 ```
 

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -44,12 +44,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `retinaface_mobilenet25_mod_0_mpk.tar.gz` | Default | Direct artifact |
 
-The required platform version is recorded in `manifest.json`.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz"
 cd ..
 ```
 

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -1,6 +1,7 @@
 # Face Detector
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | face-detection |
@@ -12,28 +13,40 @@
 | Model | retinaface_mobilenet25 |
 
 ## Concept
-This example demonstrates folder-based face detection with **RetinaFace**, a one-stage dense detector designed for robust face localization across pose, scale, and occlusion conditions.
 
-RetinaFace predicts:
-- Face bounding boxes
-- Face confidence scores
-- Five facial landmarks (left eye, right eye, nose tip, left mouth corner, right mouth corner)
+This example runs RetinaFace over an image folder. RetinaFace predicts face
+boxes, confidence scores, and five landmarks for eyes, nose, and mouth.
 
-Compared with generic object detectors, RetinaFace is specialized for facial geometry and alignment-sensitive tasks. Landmark outputs make it useful not only for drawing detection overlays, but also for downstream steps such as face alignment, tracking initialization, quality filtering, and recognition pre-processing.
-
-In this app, the compiled `retinaface_mobilenet25` package is run on images from an input folder, raw outputs are decoded into candidate detections, low-confidence candidates are filtered, overlapping boxes are merged with Non-Maximum Suppression (NMS), and the final boxes/landmarks are rendered to output images.
+The example decodes the compiled model outputs, filters low-confidence
+candidates, applies non-maximum suppression, and writes annotated images.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![Face detector preview](../../../portal/assets/examples/face-detection/face-detector/image.png)
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Validated with: `retinaface_mobilenet25`
+- `sima-cli` on a supported Modalix or DevKit target.
 
-Download the validated model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model | Role | Source |
+| --- | --- | --- |
+| `retinaface_mobilenet25_mod_0_mpk.tar.gz` | Default | Direct artifact |
+
+The required platform version is recorded in `manifest.json`.
 
 ```bash
 mkdir -p models
@@ -42,49 +55,36 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ..
 ```
 
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the config to the downloaded package.
 
 ## Configure
+
 Edit `examples/face-detection/face-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                                  # Path to the model package.
+  path: <model-path>
 
 io:
-  input_dir: assets/datasets/coco                               # Folder containing input images.
-  output_dir: sandbox/face-detector                           # Folder for annotated images.
+  input_dir: assets/datasets/coco
+  output_dir: sandbox/face-detector
 
 decode:
-  confidence_threshold: 0.40                                  # Minimum face confidence.
-  landmarks: true                                             # Draw five facial landmarks.
+  confidence_threshold: 0.40
+  landmarks: true
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/face-detection/face-detector_cpp/face-detector \
+./examples/face-detection/face-detector/src/cpp/pre-built/face-detector \
   --config examples/face-detection/face-detector/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/face-detection/face-detector/src/python/requirements.txt
@@ -92,69 +92,23 @@ python3 examples/face-detection/face-detector/src/python/main.py \
   --config examples/face-detection/face-detector/src/common/config.yaml
 ```
 
-## Testing
-On the Modalix/DevKit board, run from the apps repository root:
+## Troubleshooting
 
-```bash
-cd <apps-repo-root>
-```
-
-### C++
-Unit test:
-```bash
-ctest --test-dir build/examples/face-detection/face-detector_cpp \
-  -R 'face-detector.unit' --output-on-failure -V
-```
-
-E2E test:
-```bash
-SIMANEAT_APPS_TEST_MODELS_DIR="$PWD/models" \
-SIMANEAT_APPS_TEST_INPUT_DIR="$PWD/assets/datasets-test/coco" \
-SIMANEAT_APPS_TEST_OUTPUT_DIR=/tmp \
-SIMANEAT_APPS_TEST_TIMEOUT_MS=60000 \
-ctest --test-dir build/examples/face-detection/face-detector_cpp \
-  -R 'face-detector.e2e' --output-on-failure -V
-```
-
-### Python
-Unit test:
-```bash
-source ~/pyneat/bin/activate
-pip install -r examples/face-detection/face-detector/src/python/requirements.txt
-pip install pytest
-export PYTHONPATH="$PWD"
-pytest -c tests/pytest.ini --rootdir="$PWD" -m unit \
-  examples/face-detection/face-detector/tests/python/test_unit.py -v
-```
-
-E2E test:
-```bash
-source ~/pyneat/bin/activate
-pip install -r examples/face-detection/face-detector/src/python/requirements.txt
-pip install pytest
-export PYTHONPATH="$PWD"
-SIMANEAT_APPS_TEST_MODELS_DIR="$PWD/models" \
-SIMANEAT_APPS_TEST_INPUT_DIR="$PWD/assets/datasets-test/coco" \
-SIMANEAT_APPS_TEST_OUTPUT_DIR=/tmp/retinaface-python-e2e \
-SIMANEAT_APPS_TEST_TIMEOUT_MS=60000 \
-SIMANEAT_APPS_TEST_REQUIRE_E2E=1 \
-pytest -c tests/pytest.ini --rootdir="$PWD" -m e2e \
-  examples/face-detection/face-detector/tests/python/test_e2e.py -v
-```
-
-Notes:
-- Use an absolute path for `SIMANEAT_APPS_TEST_MODELS_DIR` in Python e2e. The test runs `main.py` with `cwd` set to the example directory.
-- `SIMANEAT_APPS_TEST_INPUT_DIR` is supported by both C++ and Python e2e tests.
-- If `SIMANEAT_APPS_TEST_INPUT_DIR` is not set, both e2e tests fall back to `assets/datasets-test/coco`.
-
-## Debugging Notes
-- If the model fails to load, verify `model.path` points to a readable model package.
-- If no detections appear, lower `decode.confidence_threshold` and confirm the input actually contains faces.
-- If too many duplicate boxes appear, reduce `decode.nms_iou` and/or lower `decode.top_k`.
-- If output writing fails, ensure `io.output_dir` exists or can be created.
+- Verify `model.path` if model loading fails.
+- Lower `decode.confidence_threshold` if expected faces are missing.
+- Adjust `decode.nms_iou` or `decode.top_k` if duplicate boxes remain.
+- Confirm `io.output_dir` can be created.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
+- Shared config: `src/common/config.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -24,7 +24,7 @@ The example decodes the compiled model outputs, filters low-confidence candidate
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 
 ## Install Apps
 

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -29,7 +29,7 @@ The example decodes the compiled model outputs, filters low-confidence candidate
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -44,9 +44,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `retinaface_mobilenet25_mod_0_mpk.tar.gz` | Default | Direct artifact |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -14,11 +14,9 @@
 
 ## Concept
 
-This example runs RetinaFace over an image folder. RetinaFace predicts face
-boxes, confidence scores, and five landmarks for eyes, nose, and mouth.
+This example runs RetinaFace over an image folder. RetinaFace predicts face boxes, confidence scores, and five landmarks for eyes, nose, and mouth.
 
-The example decodes the compiled model outputs, filters low-confidence
-candidates, applies non-maximum suppression, and writes annotated images.
+The example decodes the compiled model outputs, filters low-confidence candidates, applies non-maximum suppression, and writes annotated images.
 
 ## Preview
 
@@ -105,10 +103,8 @@ python3 examples/face-detection/face-detector/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -23,7 +23,7 @@ This example decodes an RTSP stream, runs YOLO26 detection, and sends video plus
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- An RTSP source and Insight receiver reachable from the target.
+- An RTSP source and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
 - The [LLiMa model manager](https://developer.sima.ai/software/genai-llima/runtime) available on the target when GenAI is enabled.
 
 ## Install Apps
@@ -52,9 +52,10 @@ Supported detector packages:
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -24,7 +24,7 @@ This example decodes an RTSP stream, runs YOLO26 detection, and sends video plus
 
 - `sima-cli` on a supported Modalix or DevKit target.
 - An RTSP source and Insight receiver reachable from the target.
-- A local model from the [SiMa.ai VLM collection](https://huggingface.co/collections/simaai/vision-language-models) when GenAI is enabled.
+- The [LLiMa model manager](https://developer.sima.ai/software/genai-llima/runtime) available on the target when GenAI is enabled.
 
 ## Install Apps
 
@@ -61,7 +61,17 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ..
 ```
 
-Set `model.path` to the downloaded detector package. VLM directories are not installed by this `sima-cli` command. Download the selected VLM from the linked collection and set `genai_server.model.path` to its local directory.
+Set `model.path` to the downloaded detector package.
+
+The default VLM is `Qwen3-VL-4B-Instruct-GPTQ-a16w4`. Browse the available precompiled models and install the default with LLiMa:
+
+```bash
+llima search
+llima search qwen
+llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
+```
+
+LLiMa stores models under `/media/nvme/llima/models/` by default. Set `LLIMA_MODELS_PATH` before `llima pull` to use another model directory, then update `genai_server.model.path` accordingly.
 
 ## Prepare Insight
 
@@ -93,8 +103,8 @@ genai_server:
   host: 0.0.0.0
   port: 9998
   model:
-    name: <served-vlm-model-name>
-    path: <path-to-vlm-model-dir>
+    name: Qwen3-VL-4B-Instruct-GPTQ-a16w4
+    path: /media/nvme/llima/models/Qwen3-VL-4B-Instruct-GPTQ-a16w4
 
 genai:
   enabled: false
@@ -118,6 +128,7 @@ pip install -r examples/genai/detection-to-vlm-assistant/src/python/requirements
 When GenAI is enabled, start the server in one terminal:
 
 ```bash
+source ~/pyneat/bin/activate
 python3 examples/genai/detection-to-vlm-assistant/src/python/genai_server.py \
   --config examples/genai/detection-to-vlm-assistant/src/common/config.yaml
 ```
@@ -125,6 +136,7 @@ python3 examples/genai/detection-to-vlm-assistant/src/python/genai_server.py \
 Start the detection pipeline in another terminal:
 
 ```bash
+source ~/pyneat/bin/activate
 python3 examples/genai/detection-to-vlm-assistant/src/python/detector_app.py \
   --config examples/genai/detection-to-vlm-assistant/src/common/config.yaml
 ```

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -52,12 +52,13 @@ Supported detector packages:
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -67,7 +67,6 @@ The default VLM is `Qwen3-VL-4B-Instruct-GPTQ-a16w4`. Browse the available preco
 
 ```bash
 llima search
-llima search qwen
 llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
 ```
 

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -14,10 +14,7 @@
 
 ## Concept
 
-This example decodes an RTSP stream, runs YOLO26 detection, and sends video
-plus detection metadata to Insight. When GenAI is enabled, a bounded background
-worker crops the highest-scoring person and sends it to a configured VLM server
-without blocking detection or Insight output.
+This example decodes an RTSP stream, runs YOLO26 detection, and sends video plus detection metadata to Insight. When GenAI is enabled, a bounded background worker crops the highest-scoring person and sends it to a configured VLM server without blocking detection or Insight output.
 
 ## Preview
 
@@ -27,8 +24,7 @@ without blocking detection or Insight output.
 
 - `sima-cli` on a supported Modalix or DevKit target.
 - An RTSP source and Insight receiver reachable from the target.
-- A local model from the [SiMa.ai VLM collection](https://huggingface.co/collections/simaai/vision-language-models)
-  when GenAI is enabled.
+- A local model from the [SiMa.ai VLM collection](https://huggingface.co/collections/simaai/vision-language-models) when GenAI is enabled.
 
 ## Install Apps
 
@@ -56,8 +52,7 @@ Supported detector packages:
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-file>` with a file from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
@@ -66,21 +61,17 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ..
 ```
 
-Set `model.path` to the downloaded detector package. VLM directories are not
-installed by this `sima-cli` command. Download the selected VLM from the linked
-collection and set `genai_server.model.path` to its local directory.
+Set `model.path` to the downloaded detector package. VLM directories are not installed by this `sima-cli` command. Download the selected VLM from the linked collection and set `genai_server.model.path` to its local directory.
 
 ## Prepare Insight
 
-Insight can host the input stream and render the video and detection metadata.
-Install its sample video assets when needed:
+Insight can host the input stream and render the video and detection metadata. Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-In the Insight Web UI, start a source and copy its RTSP URL. Use the host and
-UDP port ranges reported by `neat` for the output settings.
+In the Insight Web UI, start a source and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
 
@@ -138,9 +129,7 @@ python3 examples/genai/detection-to-vlm-assistant/src/python/detector_app.py \
   --config examples/genai/detection-to-vlm-assistant/src/common/config.yaml
 ```
 
-The GenAI path checks `/v1/models`, waits at least `genai.interval_seconds`
-between requests, and bounds queued and in-flight work with
-`genai.max_pending_requests`.
+The GenAI path checks `/v1/models`, waits at least `genai.interval_seconds` between requests, and bounds queued and in-flight work with `genai.max_pending_requests`.
 
 ## Troubleshooting
 
@@ -157,5 +146,4 @@ between requests, and bounds queued and in-flight work with
 
 ## Development From Source
 
-To modify or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -29,7 +29,7 @@ This example decodes an RTSP stream, runs YOLO26 detection, and sends video plus
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -81,7 +81,7 @@ LLiMa stores models under `/media/nvme/llima/models/` by default. Set `LLIMA_MOD
 
 ## Prepare Insight
 
-Insight can host the input stream and render the video and detection metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
+[Insight](https://developer.sima.ai/software/tools/insight/) can host the input stream and render the video and detection metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start a source and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -22,7 +22,7 @@ This example decodes an RTSP stream, runs YOLO26 detection, and sends video plus
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - An RTSP source and Insight receiver reachable from the target.
 - The [LLiMa model manager](https://developer.sima.ai/software/genai-llima/runtime) available on the target when GenAI is enabled.
 

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -81,11 +81,7 @@ LLiMa stores models under `/media/nvme/llima/models/` by default. Set `LLIMA_MOD
 
 ## Prepare Insight
 
-Insight can host the input stream and render the video and detection metadata. Install its sample video assets when needed:
-
-```bash
-sima-cli install assets/multi-video-sources
-```
+Insight can host the input stream and render the video and detection metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start a source and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -63,10 +63,17 @@ cd ..
 
 Set `model.path` to the downloaded detector package.
 
-The default VLM is `Qwen3-VL-4B-Instruct-GPTQ-a16w4`. Browse the available precompiled models and install the default with LLiMa:
+The default VLM is `Qwen3-VL-4B-Instruct-GPTQ-a16w4`.
+
+Search the supported models:
 
 ```bash
 llima search
+```
+
+Install the default model:
+
+```bash
 llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
 ```
 

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -1,6 +1,7 @@
 # Detection-to-VLM Assistant
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | genai |
@@ -12,137 +13,149 @@
 | Model | yolo26m-det-bf16-mla_tess-b1 |
 
 ## Concept
-This example decodes an RTSP stream, runs YOLO26 detection with internal box decode, and sends video plus object-detection metadata to Insight. Insight video uses `VideoSender`, which owns raw-frame caps, conversion, H.264 encoding, RTP packetization, and UDP output. When GenAI is enabled, the highest-score detected person is cropped and sent to the configured GenAI server from a bounded background worker, so the detection and Insight loop keeps running.
+
+This example decodes an RTSP stream, runs YOLO26 detection, and sends video
+plus detection metadata to Insight. When GenAI is enabled, a bounded background
+worker crops the highest-scoring person and sends it to a configured VLM server
+without blocking detection or Insight output.
 
 ## Preview
-Detection metadata visualized in Insight:
 
 ![Detection-to-VLM assistant preview](../../../portal/assets/examples/genai/detection-to-vlm-assistant/image.png)
 
-## Insight Setup
-[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+## Prerequisites
 
-In the Neat Development Environment, install the sample video assets:
+- `sima-cli` on a supported Modalix or DevKit target.
+- An RTSP source and Insight receiver reachable from the target.
+- A local model from the [SiMa.ai VLM collection](https://huggingface.co/collections/simaai/vision-language-models)
+  when GenAI is enabled.
+
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+Supported detector packages:
+
+| Model file | Role |
+| --- | --- |
+| `yolo26m-det-bf16-mla_tess-b1.tar.gz` | Default |
+| `yolo26n-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26s-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26l-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-b1.tar.gz` | Supported |
+| `yolo26m-det-int8-b1.tar.gz` | Supported |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-file>` with a file from the table.
+
+```bash
+mkdir -p models
+cd models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+cd ..
+```
+
+Set `model.path` to the downloaded detector package. VLM directories are not
+installed by this `sima-cli` command. Download the selected VLM from the linked
+collection and set `genai_server.model.path` to its local directory.
+
+## Prepare Insight
+
+Insight can host the input stream and render the video and detection metadata.
+Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-This provides 720p and 480p videos that Insight can stream as RTSP sources.
-
-To create a reproducible RTSP input:
-1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
-2. In Insight, open `RTSP Source`.
-3. Use a sample video or upload your own video.
-4. Start the stream and copy the RTSP URL.
-5. Put that RTSP URL into `source.rtsp_url`.
-
-Use the same `neat` output to set `insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default YOLO26 detector model, or set `model.path` to another readable model package.
-- Choose a vision-language model from the [SiMa.ai VLM collection](https://huggingface.co/collections/simaai/vision-language-models), download it locally, and set `genai_server.model.path` to that model directory.
-- Set `genai_server.model.name` to the served model name used by the detector app.
-- RTSP source created in Insight or provided by your camera.
-- Insight receiver running at the configured host and ports.
-- GenAI server running when `genai.enabled` is true.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
-
-## Download Models
-Use the SDK platform version wherever `<platform-version>` appears.
-
-Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
-
-Download the default detector model:
-
-```bash
-mkdir -p models
-cd models
-
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-
-cd ..
-```
-
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
+In the Insight Web UI, start a source and copy its RTSP URL. Use the host and
+UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
+
 Edit `examples/genai/detection-to-vlm-assistant/src/common/config.yaml`.
 
 ```yaml
 source:
-  rtsp_url: <rtsp-url-copied-from-insight>              # RTSP stream URL.
+  rtsp_url: <rtsp-url>
 
 model:
-  path: <model-path>                                    # Path to the model package.
+  path: <model-path>
 
 insight:
-  host: <insight-host-ip>                                  # Host running Insight.
-  video_port: <videoUDP start port from neat>              # UDP video port.
-  metadata_port: <metadataUDP start port from neat>        # UDP metadata port.
+  host: <insight-host-ip>
+  video_port: <videoUDP-start-port>
+  metadata_port: <metadataUDP-start-port>
 
 genai_server:
-  host: 0.0.0.0                                            # GenAI server bind host.
-  port: 9998                                               # GenAI server port.
+  host: 0.0.0.0
+  port: 9998
   model:
-    name: <served-vlm-model-name>                          # Model name used by requests.
-    path: <path-to-vlm-model-dir>                          # Local VLM model directory.
+    name: <served-vlm-model-name>
+    path: <path-to-vlm-model-dir>
 
 genai:
-  enabled: false                                           # Disable for detection plus Insight only.
-  host: 127.0.0.1                                          # GenAI server client host.
-  port: 9998                                               # GenAI server client port.
+  enabled: false
+  host: 127.0.0.1
+  port: 9998
   system_prompt: <system-prompt>
   user_prompt: <user-prompt>
 ```
 
-Change `genai.system_prompt` and `genai.user_prompt` to influence the GenAI output. The default asks what the detected person is doing in the crop.
+Set `genai.enabled: false` to run only detection and Insight output.
 
 ## Run
-From the `apps` repository root:
 
-In one terminal, start the local GenAI server:
+Install the Python dependencies:
+
+```bash
+source ~/pyneat/bin/activate
+pip install -r examples/genai/detection-to-vlm-assistant/src/python/requirements.txt
+```
+
+When GenAI is enabled, start the server in one terminal:
 
 ```bash
 python3 examples/genai/detection-to-vlm-assistant/src/python/genai_server.py \
   --config examples/genai/detection-to-vlm-assistant/src/common/config.yaml
 ```
 
-In a second terminal, start the detection-to-Insight pipeline:
+Start the detection pipeline in another terminal:
 
 ```bash
 python3 examples/genai/detection-to-vlm-assistant/src/python/detector_app.py \
   --config examples/genai/detection-to-vlm-assistant/src/common/config.yaml
 ```
 
-Set `genai.enabled: false` in the config to run only the detection and Insight path.
+The GenAI path checks `/v1/models`, waits at least `genai.interval_seconds`
+between requests, and bounds queued and in-flight work with
+`genai.max_pending_requests`.
 
-The GenAI path checks `/v1/models` before sending a crop, waits at least `genai.interval_seconds` between attempts, and keeps at most `genai.max_pending_requests` queued or in-flight requests.
+## Troubleshooting
 
-## Appendix: Additional Models
-Other supported batch-1 YOLO26 detector models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Replace the default filename in the download command and `model.path`.
+- Verify the RTSP URL and Insight ports before investigating inference.
+- Verify `model.path` points to the detector package.
+- Verify the VLM server lists `genai_server.model.name` under `/v1/models`.
+- Disable GenAI to isolate the detector and Insight path.
 
 ## Source Files
-- Python source: `src/python/detector_app.py`, `src/python/genai_server.py`
-- Shared assets: `src/common/`
+
+- Detector application: `src/python/detector_app.py`
+- GenAI server: `src/python/genai_server.py`
+- Shared runtime files: `src/common/`
+
+## Development From Source
+
+To modify or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/genai/detection-to-vlm-assistant/src/common/config.yaml
+++ b/examples/genai/detection-to-vlm-assistant/src/common/config.yaml
@@ -28,8 +28,8 @@ genai_server:                # Local GenAI server process.
   host: 0.0.0.0              # Host interface to bind.
   port: 9998                 # Server port.
   model:                     # Vision-language model served locally.
-    name: <served-vlm-model-name>
-    path: <path-to-vlm-model-dir>
+    name: Qwen3-VL-4B-Instruct-GPTQ-a16w4
+    path: /media/nvme/llima/models/Qwen3-VL-4B-Instruct-GPTQ-a16w4
 
 genai:                       # Optional crop-to-VLM requests.
   enabled: true              # Enable crop-to-VLM requests.

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -86,14 +86,15 @@ Search the supported models:
 llima search
 ```
 
-Install the default models independently:
+Install the VLMs you want to serve and the required ASR model:
 
 ```bash
 llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
+llima pull Qwen3-VL-2B-Instruct-GPTQ-a16w4
 llima pull whisper-small-a16w8
 ```
 
-Models installed with `llima pull` use `/media/nvme/llima/models/<model-name>` by default. Add an independently installed model's name and path to `config.local.yaml`; set `LLIMA_MODELS_PATH` before `llima pull` to use another model directory. The setup script remains the complete example installer because it also prepares the UI environment, RAG embedding model, TTS voices, local configuration, and RAG database.
+Models installed with `llima pull` use `/media/nvme/llima/models/<model-name>` by default. The setup script configures one default VLM; add every additional VLM's name and path under `server.models.chat` in `config.local.yaml` to serve multiple models at the same time. Set `LLIMA_MODELS_PATH` before `llima pull` to use another model directory. The setup script remains the complete example installer because it also prepares the UI environment, RAG embedding model, TTS voices, local configuration, and RAG database.
 
 `whisper-small-a16w8` is the supported ASR model and is always downloaded. To use another compatible SiMa.ai chat/VLM repository, override the default download:
 
@@ -137,10 +138,10 @@ After install, edit `config.local.yaml` to change or add hosted chat/VLM models:
 server:
   models:
     chat:
+      - name: Qwen3-VL-4B-Instruct-GPTQ-a16w4
+        path: /media/nvme/llima/models/Qwen3-VL-4B-Instruct-GPTQ-a16w4
       - name: Qwen3-VL-2B-Instruct-GPTQ-a16w4
-        path: /path/to/llima/models/Qwen3-VL-2B-Instruct-GPTQ-a16w4
-      - name: another-chat-or-vlm-model
-        path: /path/to/llima/models/another-chat-or-vlm-model
+        path: /media/nvme/llima/models/Qwen3-VL-2B-Instruct-GPTQ-a16w4
     asr:
       name: whisper-small-a16w8
       path: /path/to/llima/models/whisper-small-a16w8

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -78,10 +78,17 @@ By default, `setup.sh` downloads:
 - `simaai/whisper-small-a16w8`
 - `thenlper/gte-small`
 
-Use the [LLiMa CLI](https://developer.sima.ai/software/genai-llima/runtime) to browse or independently install the default precompiled server models:
+Use the [LLiMa CLI](https://developer.sima.ai/software/genai-llima/runtime) to manage precompiled server models.
+
+Search the supported models:
 
 ```bash
 llima search
+```
+
+Install the default models independently:
+
+```bash
 llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
 llima pull whisper-small-a16w8
 ```

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -16,23 +16,15 @@ This example hosts SiMa-supported GenAI models through Neat's OpenAI-compatible 
 
 The example supports one or more configured chat models, one configured ASR model, image/text chat, audio transcription, Piper TTS, system prompt control, chat history, voice selection, and abort.
 
-The demo runs as two processes. `src/python/server/main.py` reads the `server`
-section of the selected config and starts the Neat OpenAI-compatible server.
-`src/python/ui/main.py` reads the `app` section of the selected config and
-starts the existing Flask UI. `src/common/config.yaml` is the tracked template;
-`./setup.sh` writes the runnable local config to `config.local.yaml`.
+The demo runs as two processes. `src/python/server/main.py` reads the `server` section of the selected config and starts the Neat OpenAI-compatible server. `src/python/ui/main.py` reads the `app` section of the selected config and starts the existing Flask UI. `src/common/config.yaml` is the tracked template; `./setup.sh` writes the runnable local config to `config.local.yaml`.
 
 Runtime ownership is split deliberately:
 
-- Neat hosts the OpenAI-compatible `/v1/chat/completions` endpoint for text and
-  image chat.
+- Neat hosts the OpenAI-compatible `/v1/chat/completions` endpoint for text and image chat.
 - Neat hosts the OpenAI-compatible `/v1/audio/transcriptions` endpoint for ASR.
-- The Flask app owns UI state, system prompt handling, chat history, abort
-  requests, uploaded images, microphone recordings, and Piper TTS playback.
-- Piper TTS is app-side. The default requirements install Piper; TTS produces
-  audio when the configured voice assets are present under `src/python/ui/assets/`.
-- RAG is app-side and optional. It uses the Flask UI, local VectorDB service,
-  and the same chat model hosted by the Neat OpenAI-compatible server.
+- The Flask app owns UI state, system prompt handling, chat history, abort requests, uploaded images, microphone recordings, and Piper TTS playback.
+- Piper TTS is app-side. The default requirements install Piper; TTS produces audio when the configured voice assets are present under `src/python/ui/assets/`.
+- RAG is app-side and optional. It uses the Flask UI, local VectorDB service, and the same chat model hosted by the Neat OpenAI-compatible server.
 
 ## Preview
 Multimodal assistant UI:
@@ -48,8 +40,7 @@ Multimodal assistant UI:
 ~/pyneat/bin/python
 ```
 
-Set `PYNEAT_PYTHON=/path/to/python-with-pyneat` if your Neat Library environment is
-somewhere else.
+Set `PYNEAT_PYTHON=/path/to/python-with-pyneat` if your Neat Library environment is somewhere else.
 
 ## Install Apps
 
@@ -73,9 +64,7 @@ The setup script installs these model directories:
 | `whisper-small-a16w8` | Required ASR | Hugging Face |
 | `gte-small` | Default RAG embedding | Hugging Face |
 
-Install the UI virtual environment, default chat/VLM model, Whisper ASR model,
-GTE-small embedding model, Piper TTS voices, default RAG database, and generated
-local config:
+Install the UI virtual environment, default chat/VLM model, Whisper ASR model, GTE-small embedding model, Piper TTS voices, default RAG database, and generated local config:
 
 ```bash
 cd examples/genai/multimodal-assistant
@@ -89,9 +78,7 @@ By default, `setup.sh` downloads:
 - `simaai/whisper-small-a16w8`
 - `thenlper/gte-small`
 
-`whisper-small-a16w8` is the supported ASR model and is always downloaded.
-To use another compatible SiMa.ai chat/VLM repository, override the default
-download:
+`whisper-small-a16w8` is the supported ASR model and is always downloaded. To use another compatible SiMa.ai chat/VLM repository, override the default download:
 
 ```bash
 CHAT_MODEL_REPO=simaai/<chat-model-repo> ./setup.sh
@@ -106,9 +93,7 @@ Downloaded models use this layout by default:
 └── gte-small/
 ```
 
-On a SoM board, mount NVMe before running setup. If NVMe is mounted but the
-model directory is not writable, create it with ownership for the current
-user:
+On a SoM board, mount NVMe before running setup. If NVMe is mounted but the model directory is not writable, create it with ownership for the current user:
 
 ```bash
 sudo install -d \
@@ -117,22 +102,16 @@ sudo install -d \
   /media/nvme/llima/models
 ```
 
-On a system without NVMe, set `LLIMA_MODELS_PATH` to another writable
-location. To use the user-managed Apps model directory:
+On a system without NVMe, set `LLIMA_MODELS_PATH` to another writable location. To use the user-managed Apps model directory:
 
 ```bash
 APPS_ROOT="$(cd ../../.. && pwd)"
 LLIMA_MODELS_PATH="${APPS_ROOT}/models/genai" ./setup.sh
 ```
 
-The same three model directories are created under the selected path. For a
-standalone example, set `LLIMA_MODELS_PATH` to any writable absolute path.
+The same three model directories are created under the selected path. For a standalone example, set `LLIMA_MODELS_PATH` to any writable absolute path.
 
-The UI virtual environment is stored under `./.venv` unless `APP_VENV` is set.
-The generated config is stored at `./config.local.yaml` unless `CONFIG_PATH` is
-set.
-RAG is enabled by default and uses `src/python/ui/milvus.db`, created from
-`src/common/rag/neat.md`.
+The UI virtual environment is stored under `./.venv` unless `APP_VENV` is set. The generated config is stored at `./config.local.yaml` unless `CONFIG_PATH` is set. RAG is enabled by default and uses `src/python/ui/milvus.db`, created from `src/common/rag/neat.md`.
 
 ### Configure Chat/VLM Models
 After install, edit `config.local.yaml` to change or add hosted chat/VLM models:
@@ -150,9 +129,7 @@ server:
       path: /path/to/llima/models/whisper-small-a16w8
 ```
 
-The first chat/VLM entry is selected by default. Additional entries appear in
-the UI model selector. Model directories must contain `devkit/` and
-`elf_files/`.
+The first chat/VLM entry is selected by default. Additional entries appear in the UI model selector. Model directories must contain `devkit/` and `elf_files/`.
 
 ## Run
 Start both the Neat OpenAI-compatible server and the Flask UI:
@@ -179,8 +156,7 @@ Check that the configured models are hosted:
 curl -s http://127.0.0.1:9998/v1/models | python3 -m json.tool
 ```
 
-Wait until this command lists the configured chat and ASR models before testing
-the browser UI.
+Wait until this command lists the configured chat and ASR models before testing the browser UI.
 
 ### Manual Process Start
 Use this only when you want two explicit terminals.
@@ -207,22 +183,19 @@ python "${EXAMPLE_DIR}/src/python/ui/main.py" \
   --config "${EXAMPLE_DIR}/config.local.yaml"
 ```
 
-The supported entrypoints are `src/python/server/main.py` for model hosting and
-`src/python/ui/main.py` for the UI.
+The supported entrypoints are `src/python/server/main.py` for model hosting and `src/python/ui/main.py` for the UI.
 
 ## RAG
 RAG is enabled by default after `./setup.sh`.
 
-The installer downloads `thenlper/gte-small`, stores it under the configured
-models directory, and creates:
+The installer downloads `thenlper/gte-small`, stores it under the configured models directory, and creates:
 
 ```text
 src/python/ui/milvus.db
 src/python/ui/milvus.meta.json
 ```
 
-To point RAG at a different local embedding model or disable it, edit
-`config.local.yaml`:
+To point RAG at a different local embedding model or disable it, edit `config.local.yaml`:
 
 ```yaml
 app:
@@ -266,8 +239,7 @@ In the UI, enable `Search RAG Database` and ask:
 What is the canonical RAG validation phrase?
 ```
 
-The RAG status area should report whether RAG was used and how many hits were
-retrieved.
+The RAG status area should report whether RAG was used and how many hits were retrieved.
 
 ## Verify
 Use these checks after the model server and Flask UI are running.
@@ -340,5 +312,4 @@ Then test the browser UI:
 
 ## Development From Source
 
-To modify or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -90,7 +90,7 @@ Install the VLMs you want to serve and the required ASR model:
 
 ```bash
 llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
-llima pull Qwen3-VL-2B-Instruct-GPTQ-a16w4
+llima pull gemma-4-E2B-it-GPTQ-a16w4
 llima pull whisper-small-a16w8
 ```
 
@@ -140,8 +140,8 @@ server:
     chat:
       - name: Qwen3-VL-4B-Instruct-GPTQ-a16w4
         path: /media/nvme/llima/models/Qwen3-VL-4B-Instruct-GPTQ-a16w4
-      - name: Qwen3-VL-2B-Instruct-GPTQ-a16w4
-        path: /media/nvme/llima/models/Qwen3-VL-2B-Instruct-GPTQ-a16w4
+      - name: gemma-4-E2B-it-GPTQ-a16w4
+        path: /media/nvme/llima/models/gemma-4-E2B-it-GPTQ-a16w4
     asr:
       name: whisper-small-a16w8
       path: /path/to/llima/models/whisper-small-a16w8

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -82,7 +82,6 @@ Use the [LLiMa CLI](https://developer.sima.ai/software/genai-llima/runtime) to b
 
 ```bash
 llima search
-llima search qwen
 llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
 llima pull whisper-small-a16w8
 ```

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -40,7 +40,8 @@ Multimodal assistant UI:
 ![Multimodal Assistant preview](../../../portal/assets/examples/genai/multimodal-assistant/image.png)
 
 ## Prerequisites
-- Installed Neat Development Environment + Neat Library.
+
+- `sima-cli` on a supported Modalix or DevKit target.
 - The model server uses the Python environment where `pyneat` is available. The default scripts assume:
 
 ```text
@@ -50,32 +51,34 @@ Multimodal assistant UI:
 Set `PYNEAT_PYTHON=/path/to/python-with-pyneat` if your Neat Library environment is
 somewhere else.
 
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
+## Install Apps
 
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
-
-## Install
-Fetch only this example:
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-example.sh | bash -s -- multimodal-assistant
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
 ```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+The setup script installs these model directories:
+
+| Model | Role | Source |
+| --- | --- | --- |
+| `Qwen3-VL-4B-Instruct-GPTQ-a16w4` | Default chat/VLM | Hugging Face |
+| `whisper-small-a16w8` | Required ASR | Hugging Face |
+| `gte-small` | Default RAG embedding | Hugging Face |
 
 Install the UI virtual environment, default chat/VLM model, Whisper ASR model,
 GTE-small embedding model, Piper TTS voices, default RAG database, and generated
 local config:
 
 ```bash
-cd multimodal-assistant
+cd examples/genai/multimodal-assistant
 
 ./setup.sh
 ```
@@ -87,7 +90,8 @@ By default, `setup.sh` downloads:
 - `thenlper/gte-small`
 
 `whisper-small-a16w8` is the supported ASR model and is always downloaded.
-Override the default chat/VLM download with an environment variable when needed:
+To use another compatible SiMa.ai chat/VLM repository, override the default
+download:
 
 ```bash
 CHAT_MODEL_REPO=simaai/<chat-model-repo> ./setup.sh
@@ -114,11 +118,10 @@ sudo install -d \
 ```
 
 On a system without NVMe, set `LLIMA_MODELS_PATH` to another writable
-location. For a full Apps checkout, `models/` is the repo-local model
-convention:
+location. To use the user-managed Apps model directory:
 
 ```bash
-export APPS_ROOT=/path/to/apps
+APPS_ROOT="$(cd ../../.. && pwd)"
 LLIMA_MODELS_PATH="${APPS_ROOT}/models/genai" ./setup.sh
 ```
 
@@ -334,4 +337,8 @@ Then test the browser UI:
 - UI assets: `src/python/ui/templates/`, `src/python/ui/static/`, `src/python/ui/assets/`, `src/python/ui/certs/`
 - Manual API scripts: `src/python/ui/apitest/`
 - Shared config: `src/common/config.yaml`
-- Test scope: `tests/test-scope.yaml`
+
+## Development From Source
+
+To modify or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -78,6 +78,17 @@ By default, `setup.sh` downloads:
 - `simaai/whisper-small-a16w8`
 - `thenlper/gte-small`
 
+Use the [LLiMa CLI](https://developer.sima.ai/software/genai-llima/runtime) to browse or independently install the default precompiled server models:
+
+```bash
+llima search
+llima search qwen
+llima pull Qwen3-VL-4B-Instruct-GPTQ-a16w4
+llima pull whisper-small-a16w8
+```
+
+Models installed with `llima pull` use `/media/nvme/llima/models/<model-name>` by default. Add an independently installed model's name and path to `config.local.yaml`; set `LLIMA_MODELS_PATH` before `llima pull` to use another model directory. The setup script remains the complete example installer because it also prepares the UI environment, RAG embedding model, TTS voices, local configuration, and RAG database.
+
 `whisper-small-a16w8` is the supported ASR model and is always downloaded. To use another compatible SiMa.ai chat/VLM repository, override the default download:
 
 ```bash

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -33,7 +33,7 @@ Multimodal assistant UI:
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - The model server uses the Python environment where `pyneat` is available. The default scripts assume:
 
 ```text

--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -45,7 +45,7 @@ Set `PYNEAT_PYTHON=/path/to/python-with-pyneat` if your Neat Library environment
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -44,12 +44,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` | Default | Direct artifact |
 
-The required platform version is recorded in `manifest.json`.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz"
 cd ..
 ```
 

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -29,7 +29,7 @@ The model emits classification logits and normalized boxes for a fixed set of qu
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -24,7 +24,7 @@ The model emits classification logits and normalized boxes for a fixed set of qu
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 
 ## Install Apps
 

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -1,6 +1,7 @@
 # DETR Object Detector
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | object-detection |
@@ -12,21 +13,43 @@
 | Model | detr_resnet50_modified_class_embed_bbox_embed |
 
 ## Concept
-This example demonstrates folder-based object detection with a compiled **DETR** model. Each input image is resized with aspect-ratio preservation into the model frame, normalized with ImageNet mean and standard deviation, run through the Neat Library pipeline, and then decoded into object boxes and class scores.
 
-The model emits two raw tensors: classification logits and normalized bounding boxes for a fixed set of object queries. The example applies `softmax` over the class logits, `sigmoid` over the box outputs, filters by confidence, optionally keeps only the COCO `person` class, maps detections back onto the original image, and writes annotated output images.
+This example runs folder-based object detection with a compiled DETR model.
+Each image is resized with preserved aspect ratio, normalized, inferred, and
+decoded into object boxes and class scores.
+
+The model emits classification logits and normalized boxes for a fixed set of
+queries. The example applies softmax to the logits, sigmoid to the boxes,
+filters by confidence, optionally keeps only the COCO `person` class, maps
+detections to the original image, and writes annotated output.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![DETR object detector preview](../../../portal/assets/examples/object-detection/detr-object-detector/image.png)
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Validated with: `detr_resnet50_modified_class_embed_bbox_embed`
+- `sima-cli` on a supported Modalix or DevKit target.
 
-Download the validated model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model | Role | Source |
+| --- | --- | --- |
+| `detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` | Default | Direct artifact |
+
+The required platform version is recorded in `manifest.json`.
 
 ```bash
 mkdir -p models
@@ -35,49 +58,36 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ..
 ```
 
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the config to the downloaded package.
 
 ## Configure
+
 Edit `examples/object-detection/detr-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                                  # Path to the model package.
+  path: <model-path>
 
 io:
-  input_dir: assets/datasets/coco                                                # Folder containing input images.
-  output_dir: sandbox/detr-object-detector                                     # Folder for annotated images.
+  input_dir: assets/datasets/coco
+  output_dir: sandbox/detr-object-detector
 
 decode:
-  confidence_threshold: 0.70                                                   # Minimum object confidence.
-  person_only: false                                                           # Keep only COCO person detections when true.
+  confidence_threshold: 0.70
+  person_only: false
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/object-detection/detr-object-detector/detr-object-detector \
+./examples/object-detection/detr-object-detector/src/cpp/pre-built/detr-object-detector \
   --config examples/object-detection/detr-object-detector/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/detr-object-detector/src/python/requirements.txt
@@ -85,65 +95,23 @@ python3 examples/object-detection/detr-object-detector/src/python/main.py \
   --config examples/object-detection/detr-object-detector/src/common/config.yaml
 ```
 
-## Testing
-On the Modalix/DevKit board, run from the apps repository root:
+## Troubleshooting
 
-```bash
-cd <apps-repo-root>
-```
-
-### C++
-Unit test:
-```bash
-ctest --test-dir build/examples/object-detection/detr-object-detector \
-  -R 'detr-object-detector.unit' --output-on-failure -V
-```
-
-E2E test:
-```bash
-SIMANEAT_APPS_TEST_MODELS_DIR="$PWD/models" \
-SIMANEAT_APPS_TEST_INPUT_DIR="$PWD/assets/datasets-test/coco" \
-SIMANEAT_APPS_TEST_OUTPUT_DIR=/tmp \
-SIMANEAT_APPS_TEST_TIMEOUT_MS=180000 \
-ctest --test-dir build/examples/object-detection/detr-object-detector \
-  -R 'detr-object-detector.e2e' --output-on-failure -V
-```
-
-### Python
-Unit test:
-```bash
-source ~/pyneat/bin/activate
-pip install -r examples/object-detection/detr-object-detector/src/python/requirements.txt
-pip install pytest
-export PYTHONPATH="$PWD"
-pytest -c tests/pytest.ini --rootdir="$PWD" -m unit \
-  examples/object-detection/detr-object-detector/tests/python/test_unit.py -v
-```
-
-E2E test:
-```bash
-source ~/pyneat/bin/activate
-pip install -r examples/object-detection/detr-object-detector/src/python/requirements.txt
-pip install pytest
-export PYTHONPATH="$PWD"
-SIMANEAT_APPS_TEST_MODELS_DIR="$PWD/models" \
-SIMANEAT_APPS_TEST_INPUT_DIR="$PWD/assets/datasets-test/coco" \
-SIMANEAT_APPS_TEST_OUTPUT_DIR=/tmp/detr-python-e2e \
-SIMANEAT_APPS_TEST_TIMEOUT_MS=180000 \
-SIMANEAT_APPS_TEST_REQUIRE_E2E=1 \
-pytest -c tests/pytest.ini --rootdir="$PWD" -m e2e \
-  examples/object-detection/detr-object-detector/tests/python/test_e2e.py -v
-```
-
-## Debugging Notes
-- If the model fails to load, verify `model.path` points to a readable model package.
-- First-run model initialization can exceed 60 seconds on some setups. Increase `SIMANEAT_APPS_TEST_TIMEOUT_MS` (for example `180000`) for e2e runs.
-- If no detections appear, lower `decode.confidence_threshold` and confirm the input images contain supported COCO objects.
-- If detections are visibly offset, verify the model frame assumptions (`1333x800`) still match the compiled package.
-- If output writing fails, ensure `io.output_dir` exists or can be created.
+- Verify `model.path` if model loading fails.
+- Lower `decode.confidence_threshold` if expected objects are missing.
+- Confirm the compiled package still uses the documented `1333x800` frame.
+- Confirm `io.output_dir` can be created.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
+- Shared config: `src/common/config.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -44,9 +44,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` | Default | Direct artifact |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -14,14 +14,9 @@
 
 ## Concept
 
-This example runs folder-based object detection with a compiled DETR model.
-Each image is resized with preserved aspect ratio, normalized, inferred, and
-decoded into object boxes and class scores.
+This example runs folder-based object detection with a compiled DETR model. Each image is resized with preserved aspect ratio, normalized, inferred, and decoded into object boxes and class scores.
 
-The model emits classification logits and normalized boxes for a fixed set of
-queries. The example applies softmax to the logits, sigmoid to the boxes,
-filters by confidence, optionally keeps only the COCO `person` class, maps
-detections to the original image, and writes annotated output.
+The model emits classification logits and normalized boxes for a fixed set of queries. The example applies softmax to the logits, sigmoid to the boxes, filters by confidence, optionally keeps only the COCO `person` class, maps detections to the original image, and writes annotated output.
 
 ## Preview
 
@@ -108,10 +103,8 @@ python3 examples/object-detection/detr-object-detector/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -59,7 +59,7 @@ The application starts all source graphs together. Start every RTSP publisher be
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -14,16 +14,11 @@
 
 ## Concept
 
-This example runs one shared YOLO26 detector across fixed 16-, 24-, and
-48-stream RTSP profiles and publishes encoded video with synchronized detection
-metadata to Insight.
+This example runs one shared YOLO26 detector across fixed 16-, 24-, and 48-stream RTSP profiles and publishes encoded video with synchronized detection metadata to Insight.
 
-It complements `multi-stream-object-detector`. That example demonstrates the
-general multi-stream API; this example demonstrates the tuned high-density
-pipeline.
+It complements `multi-stream-object-detector`. That example demonstrates the general multi-stream API; this example demonstrates the tuned high-density pipeline.
 
-Each RTSP source is depacketized once, then Core fuses two branches into the
-same source pipeline:
+Each RTSP source is depacketized once, then Core fuses two branches into the same source pipeline:
 
 ```text
 RTSP H.264
@@ -31,21 +26,9 @@ RTSP H.264
   └─ decode ─> shared YOLO26 detector ─> timestamped metadata ─> channel N
 ```
 
-The application expresses this fan-out with ordinary `Graph::connect()` and
-starts it with ordinary `Graph::build()`. Core fuses the eligible topology
-internally. `VideoSender` consumes the read-only H.264 access unit before the
-decoder, so the application does not open a second RTSP session, copy a decoded
-EV buffer, run an encoder, or shuttle encoded frames through appsink/appsrc.
-The UDP sender uses `async=false` so its sink cannot hold the shared live
-pipeline in `PAUSED` while waiting for preroll from every stream.
-The encoded edge uses `RealtimeLatestByStream`; a congested Insight channel can
-drop stale encoded work without blocking that stream's decoder branch.
+The application expresses this fan-out with ordinary `Graph::connect()` and starts it with ordinary `Graph::build()`. Core fuses the eligible topology internally. `VideoSender` consumes the read-only H.264 access unit before the decoder, so the application does not open a second RTSP session, copy a decoded EV buffer, run an encoder, or shuttle encoded frames through appsink/appsrc. The UDP sender uses `async=false` so its sink cannot hold the shared live pipeline in `PAUSED` while waiting for preroll from every stream. The encoded edge uses `RealtimeLatestByStream`; a congested Insight channel can drop stale encoded work without blocking that stream's decoder branch.
 
-Detection metadata includes the source `rtp_timestamp` and is sent with
-nonblocking UDP. A compatible Insight receiver holds complete encoded RTP
-frames for 400 ms and matches metadata to that source timestamp before WebRTC
-forwarding. Keep one active viewer while validating metadata, as described
-below.
+Detection metadata includes the source `rtp_timestamp` and is sent with nonblocking UDP. A compatible Insight receiver holds complete encoded RTP frames for 400 ms and matches metadata to that source timestamp before WebRTC forwarding. Keep one active viewer while validating metadata, as described below.
 
 The three checked-in profiles use the same application and model:
 
@@ -55,8 +38,7 @@ The three checked-in profiles use the same application and model:
 | `config-24x720p20fps.yaml` | 24 | 1280×720 at 20 FPS | 20 FPS |
 | `config-48x720p10fps.yaml` | 48 | 1280×720 at 10 FPS | 10 FPS |
 
-The expected rate applies to both Insight video and detection metadata after
-startup and model warmup.
+The expected rate applies to both Insight video and detection metadata after startup and model warmup.
 
 ## Preview
 
@@ -66,16 +48,13 @@ The 48-stream profile running in Insight:
 
 ## Prerequisites
 
-- A Modalix DevKit compatible with the selected Apps release, with the decoder
-  service running.
+- A Modalix DevKit compatible with the selected Apps release, with the decoder service running.
 - Insight reachable from the DevKit.
 - 16, 24, or 48 H.264 RTSP sources matching the selected profile.
-- Constant source frame rate, 1280×720 resolution, no H.264 B-frames, and a
-  short, regular IDR interval. The validated sources use one IDR per second.
+- Constant source frame rate, 1280×720 resolution, no H.264 B-frames, and a short, regular IDR interval. The validated sources use one IDR per second.
 - The `yolo26n-det-int8-b1.tar.gz` model pack.
 
-The application starts all source graphs together. Start every RTSP publisher
-before starting the application.
+The application starts all source graphs together. Start every RTSP publisher before starting the application.
 
 ## Install Apps
 
@@ -104,8 +83,7 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ..
 ```
 
-Set `model.path` in the selected config to the downloaded package. Relative
-paths resolve from the config file; absolute paths are also supported.
+Set `model.path` in the selected config to the downloaded package. Relative paths resolve from the config file; absolute paths are also supported.
 
 ## Prepare The RTSP Sources
 
@@ -116,8 +94,7 @@ sima-cli install gh:sima-ai/tool-mediasources
 ./mediasrc.sh <video-dir>
 ```
 
-Prepare one reachable URL per configured stream. Verify the files or publishers
-before starting the application:
+Prepare one reachable URL per configured stream. Verify the files or publishers before starting the application:
 
 ```bash
 ffprobe -v error \
@@ -127,11 +104,7 @@ ffprobe -v error \
   <rtsp-url>
 ```
 
-The result must report H.264, `1280x720`, the selected profile FPS, and no
-B-frames. Using a different source FPS changes the output rate and is not the
-documented profile. The encoded Insight edge retains the latest complete access
-unit under congestion, so a one-second-or-shorter IDR interval bounds receiver
-recovery if an older access unit is replaced.
+The result must report H.264, `1280x720`, the selected profile FPS, and no B-frames. Using a different source FPS changes the output rate and is not the documented profile. The encoded Insight edge retains the latest complete access unit under congestion, so a one-second-or-shorter IDR interval bounds receiver recovery if an older access unit is replaced.
 
 ## Configure
 
@@ -141,20 +114,11 @@ Choose one config under `src/common/` and edit:
 - every entry under `streams`
 - `output.insight.host`
 
-`inference.max_inflight_per_stream` and `inference.max_inflight_total`
-bound raw decoder-backed frames admitted to the shared detector. The 16- and
-48-stream profiles use a total limit of eight; the 24-stream profile uses 24
-so one aggregate frame interval can be admitted without an unbounded queue.
-The realtime mux retains only the latest pending frame for each stream.
+`inference.max_inflight_per_stream` and `inference.max_inflight_total` bound raw decoder-backed frames admitted to the shared detector. The 16- and 48-stream profiles use a total limit of eight; the 24-stream profile uses 24 so one aggregate frame interval can be admitted without an unbounded queue. The realtime mux retains only the latest pending frame for each stream.
 
-Do not add the removed `inference.fan_in_policy` setting. Ordinary `connect()`
-and `build()` select the eligible realtime fan-in lowering automatically.
-Video/metadata synchronization is performed by Insight from each payload's
-source RTP timestamp; there is no application-side video-delay setting.
+Do not add the removed `inference.fan_in_policy` setting. Ordinary `connect()` and `build()` select the eligible realtime fan-in lowering automatically. Video/metadata synchronization is performed by Insight from each payload's source RTP timestamp; there is no application-side video-delay setting.
 
-Do not change `input.width`, `input.height`, or `input.fps` unless the RTSP
-sources also change. `input.skip_rtsp_probe` is enabled, so those values are the
-source contract.
+Do not change `input.width`, `input.height`, or `input.fps` unless the RTSP sources also change. `input.skip_rtsp_probe` is enabled, so those values are the source contract.
 
 Insight channel and port mapping is deterministic:
 
@@ -203,25 +167,17 @@ python3 "$APP_DIR/src/python/main.py" --config "$CONFIG"
 
 Stop the application with `Ctrl-C`.
 
-Use one active Insight viewer while validating metadata. Insight currently has
-a single-viewer metadata rendering limitation; multiple simultaneous viewers
-can make box delivery appear intermittent even when the application is
-advancing normally.
+Use one active Insight viewer while validating metadata. Insight currently has a single-viewer metadata rendering limitation; multiple simultaneous viewers can make box delivery appear intermittent even when the application is advancing normally.
 
 ## Expected Result
 
 - Every configured Insight channel receives live video.
 - Detection boxes appear on the matching channel.
-- Video and metadata advance at 25 FPS for 16 streams, 20 FPS for 24 streams,
-  or 10 FPS for 48 streams.
-- Final per-stream counters show every stream advancing; the application fails
-  with the missing channel IDs if a stream never starts or later stops.
-- No detection timeout or stalled channel is reported. Metadata sender counters
-  expose any nonblocking UDP drops without stalling inference.
+- Video and metadata advance at 25 FPS for 16 streams, 20 FPS for 24 streams, or 10 FPS for 48 streams.
+- Final per-stream counters show every stream advancing; the application fails with the missing channel IDs if a stream never starts or later stops.
+- No detection timeout or stalled channel is reported. Metadata sender counters expose any nonblocking UDP drops without stalling inference.
 
-If channels do not start, confirm that every publisher was already reachable
-and that the configured source caps match the selected profile. Restart the
-application after restarting the publishers.
+If channels do not start, confirm that every publisher was already reachable and that the configured source caps match the selected profile. Restart the application after restarting the publishers.
 
 ## Source Files
 
@@ -232,12 +188,8 @@ application after restarting the publishers.
 - 48-stream profile: `src/common/config-48x720p10fps.yaml`
 - COCO labels: `src/common/coco_label.txt`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
-The 16-, 24-, and 48-stream profiles still require Modalix, live RTSP
-publishers, and Insight for runtime validation.
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md). The 16-, 24-, and 48-stream profiles still require Modalix, live RTSP publishers, and Insight for runtime validation.

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -66,8 +66,8 @@ The 48-stream profile running in Insight:
 
 ## Prerequisites
 
-- Neat Apps, Core, and Internals from the same manifest.
-- A Modalix DevKit with the decoder service running.
+- A Modalix DevKit compatible with the selected Apps release, with the decoder
+  service running.
 - Insight reachable from the DevKit.
 - 16, 24, or 48 H.264 RTSP sources matching the selected profile.
 - Constant source frame rate, 1280×720 resolution, no H.264 B-frames, and a
@@ -77,24 +77,25 @@ The 48-stream profile running in Insight:
 The application starts all source graphs together. Start every RTSP publisher
 before starting the application.
 
-## Get The Apps Repo
+## Install Apps
 
-Install the Neat Library by following the official Neat installation guide.
-Then clone and build Apps:
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
 
 ```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
 ```
 
-Compile C++ examples in the Neat Development Environment. Run the application
-on Modalix.
+Run the remaining commands from `prebuilt-apps/`.
 
-## Download The Model
+## Prepare the Model
 
-From the Apps repository root, replace `<platform-version>` with the version in
-`deps/manifest.json`:
+| Model file | Role | Source |
+| --- | --- | --- |
+| `yolo26n-det-int8-b1.tar.gz` | Default | Direct artifact |
+
+The required platform version is recorded in `manifest.json`.
 
 ```bash
 mkdir -p models
@@ -103,9 +104,8 @@ sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/model
 cd ..
 ```
 
-The command stores the model under `models/`. Set `model.path` in the selected
-config to the downloaded package. Relative paths resolve from the config file;
-absolute paths are also supported.
+Set `model.path` in the selected config to the downloaded package. Relative
+paths resolve from the config file; absolute paths are also supported.
 
 ## Prepare The RTSP Sources
 
@@ -166,11 +166,11 @@ metadata port: 9100 + channel index
 
 ## Run
 
-Set the example and selected profile from the Apps repository root:
+Set the example and selected profile from the `prebuilt-apps/` root:
 
 ```bash
 APP_DIR=examples/object-detection/high-density-multi-stream-object-detector
-APP=./build/examples/object-detection/high-density-multi-stream-object-detector/high-density-multi-stream-object-detector
+APP=./examples/object-detection/high-density-multi-stream-object-detector/src/cpp/pre-built/high-density-multi-stream-object-detector
 CONFIG="$APP_DIR/src/common/config.yaml"
 ```
 
@@ -222,23 +222,21 @@ If channels do not start, confirm that every publisher was already reachable
 and that the configured source caps match the selected profile. Restart the
 application after restarting the publishers.
 
-## Tests
-
-Run the configured unit coverage through the Apps test entrypoint:
-
-```bash
-./tests/test.sh --unit
-```
-
-The 16-, 24-, and 48-stream runtime profiles require Modalix, live RTSP
-publishers, and Insight. Host unit tests do not prove their runtime FPS.
-
 ## Source Files
 
-- C++ implementation: `src/cpp/main.cpp`
+- C++ reference source: `src/cpp/main.cpp`
 - Python implementation: `src/python/main.py`
 - Default 16-stream profile: `src/common/config.yaml`
 - 24-stream profile: `src/common/config-24x720p20fps.yaml`
 - 48-stream profile: `src/common/config-48x720p10fps.yaml`
 - COCO labels: `src/common/coco_label.txt`
-- Test scope: `tests/test-scope.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+The 16-, 24-, and 48-stream profiles still require Modalix, live RTSP
+publishers, and Insight for runtime validation.

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -74,12 +74,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `yolo26n-det-int8-b1.tar.gz` | Default | Direct artifact |
 
-The required platform version is recorded in `manifest.json`.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz"
 cd ..
 ```
 

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -49,7 +49,7 @@ The 48-stream profile running in Insight:
 ## Prerequisites
 
 - A Modalix DevKit compatible with the selected Apps release, with the decoder service running.
-- Insight reachable from the DevKit.
+- An [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the DevKit.
 - 16, 24, or 48 H.264 RTSP sources matching the selected profile.
 - Constant source frame rate, 1280×720 resolution, no H.264 B-frames, and a short, regular IDR interval. The validated sources use one IDR per second.
 - The `yolo26n-det-int8-b1.tar.gz` model pack.
@@ -74,9 +74,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `yolo26n-det-int8-b1.tar.gz` | Default | Direct artifact |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -196,6 +196,7 @@ Run the C++ application:
 Run the Python implementation with the same config:
 
 ```bash
+source ~/pyneat/bin/activate
 python3 -m pip install -r "$APP_DIR/src/python/requirements.txt"
 python3 "$APP_DIR/src/python/main.py" --config "$CONFIG"
 ```

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -63,11 +63,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input streams and render each output channel. Install its sample video assets when needed:
-
-```bash
-sima-cli install assets/multi-video-sources
-```
+Insight can host the input streams and render each output channel. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start each source and copy its RTSP URL into `streams`. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -63,7 +63,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input streams and render each output channel. Install videos directly from the Insight catalog or through Insight's YouTube support.
+[Insight](https://developer.sima.ai/software/tools/insight/) can host the input streams and render each output channel. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start each source and copy its RTSP URL into `streams`. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -50,12 +50,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -22,7 +22,7 @@ This example runs a config-driven multi-stream RTSP detection pipeline and publi
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - RTSP sources reachable from the target.
 - On a reused Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the application if earlier video or ML workloads changed runtime state.
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -23,8 +23,7 @@ This example runs a config-driven multi-stream RTSP detection pipeline and publi
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- RTSP sources reachable from the target.
-- On a reused Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the application if earlier video or ML workloads changed runtime state.
+- RTSP sources and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
 
 ## Install Apps
 
@@ -50,9 +49,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -109,7 +109,6 @@ Validate the config without opening streams:
 ### C++
 
 ```bash
-SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 \
 ./examples/object-detection/multi-stream-object-detector/src/cpp/pre-built/multi-stream-object-detector \
   --config examples/object-detection/multi-stream-object-detector/src/common/config.yaml
 ```
@@ -119,7 +118,6 @@ SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 \
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/multi-stream-object-detector/src/python/requirements.txt
-SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 \
 python3 examples/object-detection/multi-stream-object-detector/src/python/main.py \
   --config examples/object-detection/multi-stream-object-detector/src/common/config.yaml
 ```

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -1,6 +1,7 @@
 # Multi-Stream Object Detector
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | object-detection |
@@ -12,141 +13,140 @@
 | Model | yolo26m-det-int8-b1 |
 
 ## Concept
-This example runs a config-driven multistream RTSP detection pipeline for YOLO26 model packs and publishes per-stream video plus detection metadata to Insight.
+
+This example runs a config-driven multi-stream RTSP detection pipeline and
+publishes video plus detection metadata for each stream to Insight.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![Multi-stream object detector preview](../../../portal/assets/examples/object-detection/multi-stream-object-detector/image.png)
 
-## Insight Setup
-[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+## Prerequisites
 
-In the Neat Development Environment, install the sample video assets:
+- `sima-cli` on a supported Modalix or DevKit target.
+- RTSP sources reachable from the target.
+- On a reused Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before
+  starting the application if earlier video or ML workloads changed runtime state.
+
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model file | Role |
+| --- | --- |
+| `yolo26m-det-int8-b1.tar.gz` | Default |
+| `yolo26n-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26s-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26l-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-b1.tar.gz` | Supported |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-file>` with a file from the table.
+
+```bash
+mkdir -p models
+cd models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+cd ..
+```
+
+Set `model.path` in the config to the downloaded package.
+
+## Prepare Insight
+
+Insight can host the input streams and render each output channel. Install its
+sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-This provides 720p and 480p videos that Insight can stream as RTSP sources.
-
-To create reproducible RTSP inputs:
-1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
-2. In Insight, open `RTSP Source`.
-3. Use sample videos or upload your own videos.
-4. Start each stream and copy the RTSP URLs.
-5. Put those RTSP URLs into `streams`.
-
-Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- RTSP sources created in Insight or provided by your cameras.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default YOLO26 model, or set `model.path` to another readable model package.
-- Edit `src/common/config.yaml` before running with real streams.
-- On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the example if the runtime has been used by earlier ML/video apps.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
-
-## Download Models
-Use the SDK platform version wherever `<platform-version>` appears.
-
-The default model is `yolo26m-det-int8-b1.tar.gz`.
-
-Download the default model:
-
-```bash
-mkdir -p models
-cd models
-
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
-
-cd ..
-```
-
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
+In the Insight Web UI, start each source and copy its RTSP URL into `streams`.
+Use the host and UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
+
 Edit `examples/object-detection/multi-stream-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                                   # Path to the model package.
+  path: <model-path>
 
 streams:
-  - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
-  - <second-rtsp-url-copied-from-insight>              # Second RTSP stream.
+  - <first-rtsp-url>
+  - <second-rtsp-url>
 
 inference:
-  frames: 0                                            # Frame limit per stream. 0 runs continuously.
-  max_inflight_per_stream: 4                           # Raw frames admitted per stream to the detector.
-  max_inflight_total: 16                               # Raw frames admitted across detector streams.
-  min_score: 0.30                                      # Minimum object confidence.
+  frames: 0
+  max_inflight_per_stream: 4
+  max_inflight_total: 16
+  min_score: 0.30
 
 output:
   insight:
-    host: <insight-host-ip>                            # Host running Insight.
-    video_port_base: <videoUDP start port from neat>   # First UDP video port.
-    metadata_port_base: <metadataUDP start port from neat> # First UDP metadata port.
+    host: <insight-host-ip>
+    video_port_base: <videoUDP-start-port>
+    metadata_port_base: <metadataUDP-start-port>
 ```
 
 ## Run
-### Validate Config Only
-This is useful for a quick smoke test without opening RTSP streams.
+
+Validate the config without opening streams:
 
 ```bash
-./build/examples/object-detection/multi-stream-object-detector/multi-stream-object-detector \
+./examples/object-detection/multi-stream-object-detector/src/cpp/pre-built/multi-stream-object-detector \
   --config examples/object-detection/multi-stream-object-detector/src/common/config.yaml \
   --validate-config-only
 ```
 
 ### C++
+
 ```bash
-SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 ./build/examples/object-detection/multi-stream-object-detector/multi-stream-object-detector \
+SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 \
+./examples/object-detection/multi-stream-object-detector/src/cpp/pre-built/multi-stream-object-detector \
   --config examples/object-detection/multi-stream-object-detector/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/multi-stream-object-detector/src/python/requirements.txt
-SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 examples/object-detection/multi-stream-object-detector/src/python/main.py \
+SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 \
+python3 examples/object-detection/multi-stream-object-detector/src/python/main.py \
   --config examples/object-detection/multi-stream-object-detector/src/common/config.yaml
 ```
 
-## Debugging Notes
-- The checked-in `src/common/config.yaml` includes four placeholder stream slots. Replace the RTSP URLs and Insight host before running.
-- This phase supports up to four active streams.
-- `max_inflight_per_stream` and `max_inflight_total` tune raw decoder-backed frame admission at the shared detector fan-in. Set either to `-1` to use Core defaults.
-- On Modalix DevKit, start with `bash /usr/bin/fix_devkit_runtime.sh`. If the runtime still behaves inconsistently, a full board reboot has been a more reliable reset than service restarts alone.
-- `output.debug_dir` and `output.save_every` let you save periodic aligned debug frames locally without changing the Insight output contract.
-- Profiling prints per-stream pull, metadata, output FPS, and detection-count summaries.
+## Troubleshooting
 
-## Appendix: Additional Models
-Other supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-
-Replace the default filename in the download command and `model.path`.
+- Replace all placeholder stream URLs and the Insight host before running.
+- This example supports up to four active streams.
+- Set either inflight limit to `-1` to use the Core default.
+- Verify host and UDP port ranges if Insight receives no output.
+- Use `output.debug_dir`, `output.save_every`, and profiling output for diagnosis.
 
 ## Source Files
-- C++: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
-- Python: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Shared assets: `src/common/`
+
+- C++ reference source: `src/cpp/main.cpp`
+- Python source: `src/python/main.py`
+- Shared runtime files: `src/common/`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -29,7 +29,7 @@ This example runs a config-driven multi-stream RTSP detection pipeline and publi
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -14,8 +14,7 @@
 
 ## Concept
 
-This example runs a config-driven multi-stream RTSP detection pipeline and
-publishes video plus detection metadata for each stream to Insight.
+This example runs a config-driven multi-stream RTSP detection pipeline and publishes video plus detection metadata for each stream to Insight.
 
 ## Preview
 
@@ -25,8 +24,7 @@ publishes video plus detection metadata for each stream to Insight.
 
 - `sima-cli` on a supported Modalix or DevKit target.
 - RTSP sources reachable from the target.
-- On a reused Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before
-  starting the application if earlier video or ML workloads changed runtime state.
+- On a reused Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting the application if earlier video or ML workloads changed runtime state.
 
 ## Install Apps
 
@@ -52,8 +50,7 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-file>` with a file from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
@@ -66,15 +63,13 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input streams and render each output channel. Install its
-sample video assets when needed:
+Insight can host the input streams and render each output channel. Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-In the Insight Web UI, start each source and copy its RTSP URL into `streams`.
-Use the host and UDP port ranges reported by `neat` for the output settings.
+In the Insight Web UI, start each source and copy its RTSP URL into `streams`. Use the host and UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
 
@@ -143,10 +138,8 @@ python3 examples/object-detection/multi-stream-object-detector/src/python/main.p
 - Python source: `src/python/main.py`
 - Shared runtime files: `src/common/`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -23,7 +23,7 @@ This focused example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, decodes 
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source.
+- An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
 
 ## Install Apps
 
@@ -49,9 +49,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -49,12 +49,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -28,7 +28,7 @@ This focused example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, decodes 
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -62,11 +62,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input stream and render the video and detection metadata. Install its sample video assets when needed:
-
-```bash
-sima-cli install assets/multi-video-sources
-```
+Insight can host the input stream and render the video and detection metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, open `RTSP Source`, start a sample or uploaded video, and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings below.
 

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -1,6 +1,7 @@
 # Single-Stream Object Detector
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | object-detection |
@@ -12,109 +13,106 @@
 | Model | yolo26m-det-bf16-mla_tess-b1 |
 
 ## Concept
-`single-stream-object-detector` is a focused reference example for a common deployment pattern:
 
-- ingest one RTSP H.264/MJPEG or HTTP MJPEG stream
-- decode the stream into NV12 frames
-- run YOLO26 object detection
-- send H.264 video plus detection metadata to Insight
-
-The example is intentionally narrow in scope. It is not a generic output-mode demo and it does not try to support multiple unrelated workflows in one binary. The code is structured to show the intended Insight path clearly.
+This focused example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream,
+decodes it, runs YOLO26 detection, and sends H.264 video plus detection metadata
+to Insight.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![Single-stream object detector preview](../../../portal/assets/examples/object-detection/single-stream-object-detector/image.png)
 
-## Insight Setup
-[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+## Prerequisites
 
-In the Neat Development Environment, install the sample video assets:
+- `sima-cli` on a supported Modalix or DevKit target.
+- An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source.
+
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model file | Role |
+| --- | --- |
+| `yolo26m-det-bf16-mla_tess-b1.tar.gz` | Default |
+| `yolo26n-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26s-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26l-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-b1.tar.gz` | Supported |
+| `yolo26m-det-int8-b1.tar.gz` | Supported |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-file>` with a file from the table.
+
+```bash
+mkdir -p models
+cd models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+cd ..
+```
+
+Set `model.path` in the config to the downloaded package.
+
+## Prepare Insight
+
+Insight can host the input stream and render the video and detection metadata.
+Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-This provides 720p and 480p videos that Insight can stream as RTSP sources.
-
-To create a reproducible RTSP input:
-1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
-2. In Insight, open `RTSP Source`.
-3. Use a sample video or upload your own video.
-4. Start the stream and copy the RTSP URL.
-5. Put that RTSP URL into `source.url`.
-
-Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- RTSP H.264, RTSP MJPEG, or HTTP MJPEG source created in Insight or provided by your camera.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
-
-## Download Models
-Use the SDK platform version wherever `<platform-version>` appears.
-
-Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
-
-Download the default model:
-
-```bash
-mkdir -p models
-cd models
-
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-
-cd ..
-```
-
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
+In the Insight Web UI, open `RTSP Source`, start a sample or uploaded video,
+and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for
+the output settings below.
 
 ## Configure
+
 Edit `examples/object-detection/single-stream-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                                      # Path to the model package.
+  path: <model-path>
 
 source:
-  type: rtsp                                             # rtsp or http.
-  codec: h264                                            # h264 or mjpeg.
-  url: <rtsp-url-copied-from-insight>                     # RTSP or HTTP MJPEG stream URL.
-  tcp: true                                               # Use TCP transport for RTSP.
-  fps: 0                                                  # 0 probes FPS. MJPEG requires config FPS or probeable FPS metadata.
+  type: rtsp
+  codec: h264
+  url: <rtsp-url>
+  tcp: true
+  fps: 0
 
 inference:
-  frames: 0                                               # Frame limit. 0 runs continuously.
-  min_score: 0.30                                         # Minimum object confidence.
+  frames: 0
+  min_score: 0.30
 
 output:
   insight:
-    host: <insight-host-ip>                               # Host running Insight.
-    video_port: <videoUDP start port from neat>           # UDP video port.
-    metadata_port: <metadataUDP start port from neat>     # UDP metadata port.
+    host: <insight-host-ip>
+    video_port: <videoUDP-start-port>
+    metadata_port: <metadataUDP-start-port>
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/object-detection/single-stream-object-detector/single-stream-object-detector \
+./examples/object-detection/single-stream-object-detector/src/cpp/pre-built/single-stream-object-detector \
   --config examples/object-detection/single-stream-object-detector/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/single-stream-object-detector/src/python/requirements.txt
@@ -122,26 +120,23 @@ python3 examples/object-detection/single-stream-object-detector/src/python/main.
   --config examples/object-detection/single-stream-object-detector/src/common/config.yaml
 ```
 
-## Debugging Notes
-- If the sample times out waiting for the first RTSP frame, the problem is usually upstream stream delivery or device connectivity, not YOLO itself.
-- If the RTSP source resolution changes, the startup probe is expected to adapt the decode path automatically.
-- If detections are missing but video is flowing, focus on the YOLO session and bbox extraction/parse path.
-- If video and detections are both missing in Insight, verify the host and UDP ports first.
+## Troubleshooting
 
-## Appendix: Additional Models
-Other supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Replace the default filename in the download command and `model.path`.
+- Verify stream reachability if the first frame times out.
+- Verify the Insight host and UDP ports if video and detections are absent.
+- Check model loading and score thresholds when video arrives without boxes.
+- The startup probe adapts the decode path when source resolution changes.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Insight documentation: <https://developer.sima.ai/software/tools/insight>
+- Shared config: `src/common/config.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -14,9 +14,7 @@
 
 ## Concept
 
-This focused example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream,
-decodes it, runs YOLO26 detection, and sends H.264 video plus detection metadata
-to Insight.
+This focused example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, decodes it, runs YOLO26 detection, and sends H.264 video plus detection metadata to Insight.
 
 ## Preview
 
@@ -51,8 +49,7 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-file>` with a file from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
@@ -65,16 +62,13 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input stream and render the video and detection metadata.
-Install its sample video assets when needed:
+Insight can host the input stream and render the video and detection metadata. Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-In the Insight Web UI, open `RTSP Source`, start a sample or uploaded video,
-and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for
-the output settings below.
+In the Insight Web UI, open `RTSP Source`, start a sample or uploaded video, and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings below.
 
 ## Configure
 
@@ -133,10 +127,8 @@ python3 examples/object-detection/single-stream-object-detector/src/python/main.
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -62,7 +62,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input stream and render the video and detection metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
+[Insight](https://developer.sima.ai/software/tools/insight/) can host the input stream and render the video and detection metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, open `RTSP Source`, start a sample or uploaded video, and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings below.
 

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -22,7 +22,7 @@ This focused example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, decodes 
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source.
 
 ## Install Apps

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -27,7 +27,7 @@ Minimal image-folder detection with a YOLO26 model. Each image is inferred, anno
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -48,12 +48,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -1,6 +1,7 @@
 # YOLO26 Object Detector
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | object-detection |
@@ -12,74 +13,83 @@
 | Model | yolo26m-det-bf16-mla_tess-b1 |
 
 ## Concept
-Minimal image-folder object detection pipeline using a YOLO26 detection model. Each image is inferred, annotated with bounding boxes and labels, and written to an output folder. The pipeline demonstrates the Neat Library API for model loading, inference, and result decoding.
+
+Minimal image-folder detection with a YOLO26 model. Each image is inferred,
+annotated with boxes and labels, and written to an output folder.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![YOLO26 object detector preview](../../../portal/assets/examples/object-detection/yolo26-object-detector/image.png)
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Default model: `yolo26m-det-bf16-mla_tess-b1.tar.gz`.
+- `sima-cli` on a supported Modalix or DevKit target.
 
-Download the default model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model file | Role |
+| --- | --- |
+| `yolo26m-det-bf16-mla_tess-b1.tar.gz` | Default |
+| `yolo26n-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26s-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26l-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-b1.tar.gz` | Supported |
+| `yolo26m-det-int8-b1.tar.gz` | Supported |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
 cd models
-
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
-
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
 cd ..
 ```
 
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-- Labels file: `examples/object-detection/yolo26-object-detector/src/common/coco_label.txt`
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the config to the downloaded package.
 
 ## Configure
+
 Edit `examples/object-detection/yolo26-object-detector/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                         # Path to the model package.
+  path: <model-path>
   labels: examples/object-detection/yolo26-object-detector/src/common/coco_label.txt
 
 io:
-  input_dir: assets/datasets/coco                           # Folder containing input images.
-  output_dir: sandbox/yolo26-object-detector              # Folder for annotated images.
+  input_dir: assets/datasets/coco
+  output_dir: sandbox/yolo26-object-detector
 
 decode:
-  score_threshold: 0.40                                   # Minimum object confidence.
-  nms_iou: 0.60                                           # Overlap threshold for NMS.
+  score_threshold: 0.40
+  nms_iou: 0.60
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector \
+./examples/object-detection/yolo26-object-detector/src/cpp/pre-built/yolo26-object-detector \
   --config examples/object-detection/yolo26-object-detector/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/object-detection/yolo26-object-detector/src/python/requirements.txt
@@ -87,69 +97,23 @@ python3 examples/object-detection/yolo26-object-detector/src/python/main.py \
   --config examples/object-detection/yolo26-object-detector/src/common/config.yaml
 ```
 
-## Testing
-On the Modalix/DevKit board, run from the apps repository root:
+## Troubleshooting
 
-```bash
-cd <apps-repo-root>
-```
-
-### C++
-Unit test:
-```bash
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector_unit_test \
-  ./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector
-```
-
-E2E test:
-```bash
-SIMANEAT_APPS_TEST_MODELS_DIR="$PWD/models" \
-SIMANEAT_APPS_TEST_INPUT_DIR="$PWD/assets/datasets-test/coco" \
-SIMANEAT_APPS_TEST_TIMEOUT_MS=60000 \
-./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector_e2e_test \
-  ./build/examples/object-detection/yolo26-object-detector/yolo26-object-detector
-```
-
-### Python
-Unit test:
-```bash
-source ~/pyneat/bin/activate
-pip install -r examples/object-detection/yolo26-object-detector/src/python/requirements.txt
-pytest examples/object-detection/yolo26-object-detector/tests/python/test_unit.py -v
-```
-
-E2E test:
-```bash
-source ~/pyneat/bin/activate
-pip install -r examples/object-detection/yolo26-object-detector/src/python/requirements.txt
-SIMANEAT_APPS_TEST_MODELS_DIR="$PWD/models" \
-SIMANEAT_APPS_TEST_INPUT_DIR="$PWD/assets/datasets-test/coco" \
-SIMANEAT_APPS_TEST_TIMEOUT_MS=60000 \
-SIMANEAT_APPS_TEST_REQUIRE_E2E=1 \
-pytest examples/object-detection/yolo26-object-detector/tests/python/test_e2e.py -v
-```
-
-## Debugging Notes
-- If detections are missing, validate label file ordering and score thresholds.
-- If model load fails, verify `model.path` points to a readable model package.
-- Ensure input folder contains supported image extensions (`.jpg`, `.jpeg`, `.png`, `.bmp`).
-- Use `--profile` to identify bottlenecks in the pipeline.
-- Use `decode.score_threshold` and `decode.nms_iou` to tune detection sensitivity.
-
-## Appendix: Additional Models
-Other supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-- `yolo26m-det-int8-b1.tar.gz`
-
-Replace the default filename in the download command and `model.path`.
+- Verify `model.path` and the labels file if detections are missing.
+- Confirm the input folder contains `.jpg`, `.jpeg`, `.png`, or `.bmp` files.
+- Adjust `decode.score_threshold` and `decode.nms_iou` when tuning detections.
+- Use `--profile` to inspect pipeline timing.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Shared assets: `src/common/coco_label.txt`
+- Shared config and labels: `src/common/`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -14,8 +14,7 @@
 
 ## Concept
 
-Minimal image-folder detection with a YOLO26 model. Each image is inferred,
-annotated with boxes and labels, and written to an output folder.
+Minimal image-folder detection with a YOLO26 model. Each image is inferred, annotated with boxes and labels, and written to an output folder.
 
 ## Preview
 
@@ -49,8 +48,7 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-file>` with a file from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
@@ -110,10 +108,8 @@ python3 examples/object-detection/yolo26-object-detector/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared config and labels: `src/common/`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -22,7 +22,7 @@ Minimal image-folder detection with a YOLO26 model. Each image is inferred, anno
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 
 ## Install Apps
 

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -48,9 +48,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -63,11 +63,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input stream and render segmentation metadata. Install its sample video assets when needed:
-
-```bash
-sima-cli install assets/multi-video-sources
-```
+Insight can host the input stream and render segmentation metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start a source and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -14,9 +14,7 @@
 
 ## Concept
 
-This example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, runs YOLO26
-instance segmentation, renders masks, and sends H.264 video plus segmentation
-metadata to Insight.
+This example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, runs YOLO26 instance segmentation, renders masks, and sends H.264 video plus segmentation metadata to Insight.
 
 ## Preview
 
@@ -52,8 +50,7 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-seg-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-file>` with a file from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
@@ -66,15 +63,13 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input stream and render segmentation metadata. Install its
-sample video assets when needed:
+Insight can host the input stream and render segmentation metadata. Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-In the Insight Web UI, start a source and copy its RTSP URL. Use the host and
-UDP port ranges reported by `neat` for the output settings.
+In the Insight Web UI, start a source and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
 
@@ -133,10 +128,8 @@ python3 examples/segmentation/single-stream-instance-segmenter/src/python/main.p
 - Python source: `src/python/main.py`
 - Shared config and labels: `src/common/`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -22,7 +22,7 @@ This example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, runs YOLO26 inst
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source.
 
 ## Install Apps

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -23,7 +23,7 @@ This example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, runs YOLO26 inst
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source.
+- An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
 
 ## Install Apps
 
@@ -50,9 +50,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-seg-int8-b1.tar.gz` | Supported |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -50,12 +50,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-seg-int8-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-segmentation/<model-file>
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/<model-file>"
 cd ..
 ```
 

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -1,6 +1,7 @@
 # Single Stream Instance Segmenter
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | segmentation |
@@ -12,112 +13,106 @@
 | Model | yolo26m-seg-bf16-b1 |
 
 ## Concept
-`single-stream-instance-segmenter` is a single-camera YOLO26 instance segmentation example:
 
-- ingest one RTSP H.264/MJPEG or HTTP MJPEG stream
-- decode the stream into frames
-- run YOLO26 instance segmentation
-- render mask overlays on the video
-- send H.264 video plus segmentation metadata to Insight
-
-The example keeps RTSP ingest, model inference, and Insight output separate so
-the segmentation behavior can be debugged independently from transport issues.
+This example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, runs YOLO26
+instance segmentation, renders masks, and sends H.264 video plus segmentation
+metadata to Insight.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![Single stream instance segmenter preview](../../../portal/assets/examples/segmentation/single-stream-instance-segmenter/image.png)
 
-## Insight Setup
-[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host an RTSP source, receive video from `VideoSender`, receive segmentation metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+## Prerequisites
 
-In the Neat Development Environment, install the sample video assets:
+- `sima-cli` on a supported Modalix or DevKit target.
+- An RTSP H.264, RTSP MJPEG, or HTTP MJPEG source.
+
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model file | Role |
+| --- | --- |
+| `yolo26m-seg-bf16-b1.tar.gz` | Default |
+| `yolo26n-seg-bf16-mla_tess.tar.gz` | Supported |
+| `yolo26s-seg-bf16-mla_tess.tar.gz` | Supported |
+| `yolo26m-seg-bf16-mla_tess.tar.gz` | Supported |
+| `yolo26l-seg-bf16-mla_tess.tar.gz` | Supported |
+| `yolo26x-seg-bf16-mla_tess.tar.gz` | Supported |
+| `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-seg-int8-b1.tar.gz` | Supported |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-file>` with a file from the table.
+
+```bash
+mkdir -p models
+cd models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-segmentation/<model-file>
+cd ..
+```
+
+Set `model.path` in the config to the downloaded package.
+
+## Prepare Insight
+
+Insight can host the input stream and render segmentation metadata. Install its
+sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-This provides 720p and 480p videos that Insight can stream as RTSP sources.
-
-To create a reproducible RTSP input:
-1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
-2. In Insight, open `RTSP Source`.
-3. Use a sample video or upload your own video.
-4. Start the stream and copy the RTSP URL.
-5. Put that RTSP URL into `source.url`.
-
-Use the same `neat` output to set `output.insight.host`, `video_port`, and `metadata_port` from the reported `videoUDP` and `metadataUDP` ranges.
-
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
-
-Default model: `yolo26m-seg-bf16-b1.tar.gz`.
-
-Download the default model:
-
-```bash
-mkdir -p models/YOLO26-SEGMENTATION
-cd models/YOLO26-SEGMENTATION
-
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
-
-cd ../..
-```
-
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- RTSP H.264, RTSP MJPEG, or HTTP MJPEG source created in Insight or provided by your camera.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default YOLO26 segmentation model, or set `model.path` to another readable model package.
-- `model.path`, `model.labels`, `source.url`, and `output.insight.host` set in `src/common/config.yaml`.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+In the Insight Web UI, start a source and copy its RTSP URL. Use the host and
+UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
+
 Edit `examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                                                # Path to the model package.
+  path: <model-path>
 
 source:
-  type: rtsp                                                         # rtsp or http.
-  codec: h264                                                        # h264 or mjpeg.
-  url: <rtsp-url-copied-from-insight>                                # RTSP or HTTP MJPEG stream URL.
-  tcp: true                                                          # Use TCP transport for RTSP.
-  fps: 0                                                             # 0 probes FPS. MJPEG requires config FPS or probeable FPS metadata.
+  type: rtsp
+  codec: h264
+  url: <rtsp-url>
+  tcp: true
+  fps: 0
 
 inference:
-  frames: 0                                                          # Frame limit. 0 runs continuously.
-  min_score: 0.55                                                    # Minimum instance confidence.
+  frames: 0
+  min_score: 0.55
 
 output:
   insight:
-    host: <insight-host-ip>                                          # Host running Insight.
-    video_port: <videoUDP start port from neat>                      # UDP video port.
-    metadata_port: <metadataUDP start port from neat>                # UDP metadata port.
+    host: <insight-host-ip>
+    video_port: <videoUDP-start-port>
+    metadata_port: <metadataUDP-start-port>
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/segmentation/single-stream-instance-segmenter/single-stream-instance-segmenter \
+./examples/segmentation/single-stream-instance-segmenter/src/cpp/pre-built/single-stream-instance-segmenter \
   --config examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/segmentation/single-stream-instance-segmenter/src/python/requirements.txt
@@ -125,28 +120,23 @@ python3 examples/segmentation/single-stream-instance-segmenter/src/python/main.p
   --config examples/segmentation/single-stream-instance-segmenter/src/common/config.yaml
 ```
 
-## Debugging Notes
-- If startup fails, verify `model.path` and `source.url`.
-- If the app times out waiting for RTSP, verify source reachability first.
-- If Insight receives no video, verify `output.insight.host` and UDP ports.
-- If saved frames are needed for inspection, set `output.save_dir` and `output.save_every`.
+## Troubleshooting
 
-## Appendix: Additional Models
-Other supported YOLO26 segmentation models:
-- `yolo26n-seg-bf16-mla_tess.tar.gz`
-- `yolo26s-seg-bf16-mla_tess.tar.gz`
-- `yolo26m-seg-bf16-mla_tess.tar.gz`
-- `yolo26l-seg-bf16-mla_tess.tar.gz`
-- `yolo26x-seg-bf16-mla_tess.tar.gz`
-- `yolo26m-seg-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-seg-int8-b1.tar.gz`
-
-Replace the default filename in the download command and `model.path`.
+- Verify `model.path` and the source URL if startup fails.
+- Verify stream reachability if the first frame times out.
+- Verify the Insight host and UDP ports if no output arrives.
+- Set `output.save_dir` and `output.save_every` to save sampled frames.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Shared config: `src/common/config.yaml`
-- Shared labels: `src/common/coco_label.txt`
+- Shared config and labels: `src/common/`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -28,7 +28,7 @@ This example ingests one RTSP H.264/MJPEG or HTTP MJPEG stream, runs YOLO26 inst
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -63,7 +63,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input stream and render segmentation metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
+[Insight](https://developer.sima.ai/software/tools/insight/) can host the input stream and render segmentation metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start a source and copy its RTSP URL. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -45,12 +45,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo_v8m_seg_mpk.tar.gz` | Supported | `yolo_v8m_seg` |
 | `yolo_v8l_seg_mpk.tar.gz` | Supported | `yolo_v8l_seg` |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-name>` with a model from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-name>` with a model from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli modelzoo -v <platform-version> get <model-name>
+sima-cli modelzoo -v "${PLATFORM_VERSION}" get <model-name>
 cd ..
 ```
 

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -14,8 +14,7 @@
 
 ## Concept
 
-Offline YOLOv8 instance segmentation over image folders using YOLOv8
-segmentation outputs and DetessDequant postprocessing.
+Offline YOLOv8 instance segmentation over image folders using YOLOv8 segmentation outputs and DetessDequant postprocessing.
 
 ## Preview
 
@@ -46,8 +45,7 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo_v8m_seg_mpk.tar.gz` | Supported | `yolo_v8m_seg` |
 | `yolo_v8l_seg_mpk.tar.gz` | Supported | `yolo_v8l_seg` |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-name>` with a model from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-name>` with a model from the table.
 
 ```bash
 mkdir -p models
@@ -104,10 +102,8 @@ python3 examples/segmentation/yolov8-instance-segmenter/src/python/main.py \
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -45,9 +45,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo_v8m_seg_mpk.tar.gz` | Supported | `yolo_v8m_seg` |
 | `yolo_v8l_seg_mpk.tar.gz` | Supported | `yolo_v8l_seg` |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-name>` with a model from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-name>` with a model from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -27,7 +27,7 @@ Offline YOLOv8 instance segmentation over image folders using YOLOv8 segmentatio
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -1,6 +1,7 @@
 # YOLOv8 Instance Segmenter
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | segmentation |
@@ -12,71 +13,78 @@
 | Model | yolo_v8n_seg |
 
 ## Concept
-Offline YOLOv8 instance segmentation over image folders using YOLOv8 segmentation outputs and DetessDequant post-processing.
+
+Offline YOLOv8 instance segmentation over image folders using YOLOv8
+segmentation outputs and DetessDequant postprocessing.
 
 ## Preview
-Snippet from a pipeline run:
 
 ![Instance segmenter preview](../../../portal/assets/examples/segmentation/yolov8-instance-segmenter/image.jpg)
 
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
+## Prerequisites
 
-Default model: `yolo_v8n_seg`.
+- `sima-cli` on a supported Modalix or DevKit target.
 
-Download the default model:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model package | Role | Model Zoo name |
+| --- | --- | --- |
+| `yolo_v8n_seg_mpk.tar.gz` | Default | `yolo_v8n_seg` |
+| `yolo_v8s_seg_mpk.tar.gz` | Supported | `yolo_v8s_seg` |
+| `yolo_v8m_seg_mpk.tar.gz` | Supported | `yolo_v8m_seg` |
+| `yolo_v8l_seg_mpk.tar.gz` | Supported | `yolo_v8l_seg` |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-name>` with a model from the table.
 
 ```bash
 mkdir -p models
 cd models
-
-sima-cli modelzoo -v <platform-version> get yolo_v8n_seg
-
+sima-cli modelzoo -v <platform-version> get <model-name>
 cd ..
 ```
 
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default model, or set `model.path` to another readable model package.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+Set `model.path` in the config to the downloaded package.
 
 ## Configure
+
 Edit `examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                   # Path to the model package.
+  path: <model-path>
 
 io:
-  input_dir: assets/datasets/coco                 # Folder containing input images.
-  output_dir: sandbox/yolov8-instance-segmenter # Folder for annotated images.
+  input_dir: assets/datasets/coco
+  output_dir: sandbox/yolov8-instance-segmenter
 
 decode:
-  score_threshold: 0.25                         # Minimum instance confidence.
+  score_threshold: 0.25
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/segmentation/yolov8-instance-segmenter/yolov8-instance-segmenter \
+./examples/segmentation/yolov8-instance-segmenter/src/cpp/pre-built/yolov8-instance-segmenter \
   --config examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/segmentation/yolov8-instance-segmenter/src/python/requirements.txt
@@ -84,16 +92,22 @@ python3 examples/segmentation/yolov8-instance-segmenter/src/python/main.py \
   --config examples/segmentation/yolov8-instance-segmenter/src/common/config.yaml
 ```
 
-## Debugging Notes
-- If startup fails, verify model file path and filename.
-- If output is empty, check `decode.score_threshold` and `runtime.infer_size`.
-- Ensure output directory is writable.
+## Troubleshooting
 
-## Appendix: Additional Models
-This example also works with `yolo_v8s_seg`, `yolo_v8m_seg`, and `yolo_v8l_seg`.
-Replace `yolo_v8n_seg` in the download command and update `model.path`.
+- Verify `model.path` if startup fails.
+- Adjust `decode.score_threshold` if output is empty.
+- Confirm `io.output_dir` is writable.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
 - Python source: `src/python/main.py`
 - Shared config: `src/common/config.yaml`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -22,7 +22,7 @@ Offline YOLOv8 instance segmentation over image folders using YOLOv8 segmentatio
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 
 ## Install Apps
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -14,9 +14,7 @@
 
 ## Concept
 
-Track people across multiple RTSP inputs with mixed-resolution support. The
-pipeline filters detections to the configured person class, assigns stable IDs
-per stream, and publishes live video and metadata to Insight.
+Track people across multiple RTSP inputs with mixed-resolution support. The pipeline filters detections to the configured person class, assigns stable IDs per stream, and publishes live video and metadata to Insight.
 
 ## Preview
 
@@ -51,8 +49,7 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace
-`<model-file>` with a file from the table.
+The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
 mkdir -p models
@@ -65,15 +62,13 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input streams and render tracking metadata. Install its
-sample video assets when needed:
+Insight can host the input streams and render tracking metadata. Install its sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-In the Insight Web UI, start each source and copy its RTSP URL into `streams`.
-Use the host and UDP port ranges reported by `neat` for the output settings.
+In the Insight Web UI, start each source and copy its RTSP URL into `streams`. Use the host and UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
 
@@ -136,10 +131,8 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
 - Python tracker helpers: `src/python/utils/`
 - Shared runtime files: `src/common/`
 
-The packaged C++ source is an implementation reference. Run the executable
-under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -62,7 +62,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input streams and render tracking metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
+[Insight](https://developer.sima.ai/software/tools/insight/) can host the input streams and render tracking metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start each source and copy its RTSP URL into `streams`. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -49,12 +49,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-The required platform version is recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
 
 ```bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -62,11 +62,7 @@ Set `model.path` in the config to the downloaded package.
 
 ## Prepare Insight
 
-Insight can host the input streams and render tracking metadata. Install its sample video assets when needed:
-
-```bash
-sima-cli install assets/multi-video-sources
-```
+Insight can host the input streams and render tracking metadata. Install videos directly from the Insight catalog or through Insight's YouTube support.
 
 In the Insight Web UI, start each source and copy its RTSP URL into `streams`. Use the host and UDP port ranges reported by `neat` for the output settings.
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -28,7 +28,7 @@ Track people across multiple RTSP inputs with mixed-resolution support. The pipe
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 ```bash
 sima-cli neat install apps@<release-version>

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -23,7 +23,7 @@ Track people across multiple RTSP inputs with mixed-resolution support. The pipe
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- RTSP sources and an Insight viewer reachable from the target.
+- RTSP sources and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
 
 ## Install Apps
 
@@ -49,9 +49,10 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-Set `PLATFORM_VERSION` to the `platform-version` value recorded in `manifest.json`. Replace `<model-file>` with a file from the table.
+Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
 ```bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -22,7 +22,7 @@ Track people across multiple RTSP inputs with mixed-resolution support. The pipe
 
 ## Prerequisites
 
-- `sima-cli` on a supported Modalix or DevKit target.
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - RTSP sources and an Insight viewer reachable from the target.
 
 ## Install Apps

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -1,6 +1,7 @@
 # Multi-Stream People Tracker
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | tracking |
@@ -12,106 +13,107 @@
 | Model | yolo26m-det-int8-b1 |
 
 ## Concept
-Multi-stream people tracking example with RTSP inputs, mixed-resolution support, Insight live video plus metadata output, and optional sampled overlay saves. The pipeline filters detector output to the configured person class and assigns stable track IDs per stream.
+
+Track people across multiple RTSP inputs with mixed-resolution support. The
+pipeline filters detections to the configured person class, assigns stable IDs
+per stream, and publishes live video and metadata to Insight.
 
 ## Preview
-Preview image from a live run:
 
 ![Multi-stream people tracker preview](../../../portal/assets/examples/tracking/multi-stream-people-tracker/image.png)
 
-## Insight Setup
-[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive tracking metadata from `MetadataSender`, and show rendered overlays plus runtime metrics in the browser.
+## Prerequisites
 
-In the Neat Development Environment, install the sample video assets:
+- `sima-cli` on a supported Modalix or DevKit target.
+- RTSP sources and an Insight viewer reachable from the target.
+
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+| Model file | Role |
+| --- | --- |
+| `yolo26m-det-int8-b1.tar.gz` | Default |
+| `yolo26n-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26s-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26l-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
+| `yolo26m-det-bf16-b1.tar.gz` | Supported |
+
+The required platform version is recorded in `manifest.json`. Replace
+`<model-file>` with a file from the table.
+
+```bash
+mkdir -p models
+cd models
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/<model-file>
+cd ..
+```
+
+Set `model.path` in the config to the downloaded package.
+
+## Prepare Insight
+
+Insight can host the input streams and render tracking metadata. Install its
+sample video assets when needed:
 
 ```bash
 sima-cli install assets/multi-video-sources
 ```
 
-This provides 720p and 480p videos that Insight can stream as RTSP sources.
-
-To create reproducible RTSP inputs:
-1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
-2. In Insight, open `RTSP Source`.
-3. Use sample videos or upload your own videos.
-4. Start each stream and copy the RTSP URLs.
-5. Put those RTSP URLs into `streams`.
-
-Use the same `neat` output to set `output.insight.host`, `video_port_base`, and `metadata_port_base` from the reported `videoUDP` and `metadataUDP` ranges.
-
-## Supported Models
-Use the SDK platform version wherever `<platform-version>` appears.
-
-Default model: `yolo26m-det-int8-b1.tar.gz`.
-
-Download the default model:
-
-```bash
-mkdir -p models
-cd models
-
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK<platform-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
-
-cd ..
-```
-
-The command stores the model under `models/` as a repo-local convention. `model.path` can point to any readable model package path.
-
-## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- A Neat Library Python environment with `pyneat`, `numpy`, and OpenCV available.
-- RTSP sources created in Insight or provided by your cameras.
-- Model artifacts are user-managed and should be downloaded into `models/`. Download the default YOLO26 detector model, or set `model.path` to another readable model package.
-- An Insight viewer instance reachable from the board/host running this example.
-
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
-
-Clone and build the apps repo inside the Neat Development Environment:
-
-```bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
-```
-
-After building, run the example commands below on the Modalix/DevKit board.
+In the Insight Web UI, start each source and copy its RTSP URL into `streams`.
+Use the host and UDP port ranges reported by `neat` for the output settings.
 
 ## Configure
+
 Edit `examples/tracking/multi-stream-people-tracker/src/common/config.yaml`.
 
 ```yaml
 model:
-  path: <model-path>                                   # Path to the model package.
+  path: <model-path>
 
 streams:
-  - <first-rtsp-url-copied-from-insight>               # First RTSP stream.
-  - <second-rtsp-url-copied-from-insight>              # Second RTSP stream.
+  - <first-rtsp-url>
+  - <second-rtsp-url>
 
 inference:
-  frames: 0                                            # Frame limit per stream. 0 runs continuously.
-  max_inflight_per_stream: 4                           # Raw frames admitted per stream to the detector.
-  max_inflight_total: 16                               # Raw frames admitted across detector streams.
-  min_score: 0.30                                      # Minimum person confidence.
+  frames: 0
+  max_inflight_per_stream: 4
+  max_inflight_total: 16
+  min_score: 0.30
 
 tracking:
-  max_missing_frames: 15                               # Frames to keep a missing track alive.
+  max_missing_frames: 15
 
 output:
   insight:
-    host: <insight-host-ip>                            # Host running Insight.
-    video_port_base: <videoUDP start port from neat>   # First UDP video port.
-    metadata_port_base: <metadataUDP start port from neat> # First UDP metadata port.
+    host: <insight-host-ip>
+    video_port_base: <videoUDP-start-port>
+    metadata_port_base: <metadataUDP-start-port>
 ```
 
 ## Run
+
 ### C++
+
 ```bash
-./build/examples/tracking/multi-stream-people-tracker/multi-stream-people-tracker \
+./examples/tracking/multi-stream-people-tracker/src/cpp/pre-built/multi-stream-people-tracker \
   --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
 ```
 
 ### Python
+
 ```bash
 source ~/pyneat/bin/activate
 pip install -r examples/tracking/multi-stream-people-tracker/src/python/requirements.txt
@@ -119,31 +121,25 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
   --config examples/tracking/multi-stream-people-tracker/src/common/config.yaml
 ```
 
-## Debugging Notes
-- Start with one RTSP stream and confirm the config before scaling to multiple cameras.
-- Confirm `model.path` points to a readable model package.
-- Confirm each RTSP URL is reachable from the board or host running the example.
-- `max_inflight_per_stream` and `max_inflight_total` tune raw decoder-backed frame admission at the shared detector fan-in. Set either to `-1` to use Core defaults.
-- If Insight appears idle, verify `output.insight.host`, `video_port_base`, and `metadata_port_base`.
-- If you want saved overlay frames, set both `output.debug_dir` and `output.save_every`.
+## Troubleshooting
 
-## Appendix: Additional Models
-Other supported batch-1 YOLO26 detection models:
-- `yolo26n-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26s-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26l-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26x-det-bf16-mla_tess-b1.tar.gz`
-- `yolo26m-det-bf16-b1.tar.gz`
-
-Replace the default filename in the download command and `model.path`.
+- Start with one stream before scaling to multiple inputs.
+- Verify `model.path`, every RTSP URL, and the Insight port ranges.
+- Set either inflight limit to `-1` to use the Core default.
+- Use `output.debug_dir` and `output.save_every` to save sampled overlays.
 
 ## Source Files
-- C++ source: `src/cpp/main.cpp`
-- C++ tracker helpers: `src/cpp/utils/tracker_api.cpp`, `src/cpp/utils/tracker.cpp`
-- C++ tests: `tests/cpp/test_unit.cpp`, `tests/cpp/test_e2e.cpp`
+
+- C++ reference source: `src/cpp/main.cpp`
+- C++ tracker helpers: `src/cpp/utils/`
 - Python source: `src/python/main.py`
-- Python tracker helpers: `src/python/utils/tracker.py`
-- Example config: `src/common/config.yaml`
-- Python tests: `tests/python/test_unit.py`, `tests/python/test_e2e.py`
-- Shared example data: `src/common/`
+- Python tracker helpers: `src/python/utils/`
+- Shared runtime files: `src/common/`
+
+The packaged C++ source is an implementation reference. Run the executable
+under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -211,7 +211,7 @@ render_readme() {
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | ${example_name} |
-| Model | TODO or TODO [https://host/path/model_mpk.tar.gz] |
+| Model | <default-model> |
 
 ## Concept
 
@@ -236,13 +236,34 @@ Run the remaining commands from \`prebuilt-apps/\`.
 
 ## Prepare the Model
 
-The default model is \`TODO\`.
+The default model is \`<default-model>\`.
 
 | Model | Role | Source |
 | --- | --- | --- |
-| \`TODO\` | Default | TODO: Model Zoo or direct artifact |
+| \`<default-model>\` | Default | <Model Zoo / direct artifact> |
+| \`<supported-model>\` | Supported | <Model Zoo / direct artifact> |
 
-The platform version required by model downloads is recorded in \`manifest.json\`. Download the model with \`sima-cli\`, store it under \`models/\`, and set \`model.path\` in the example config to the downloaded package.
+The platform version required by model downloads is recorded in \`manifest.json\`. Use the command that matches the model source and delete the other command.
+
+Model Zoo:
+
+\`\`\`bash
+mkdir -p models
+cd models
+sima-cli modelzoo -v <platform-version> get <model-name>
+cd ..
+\`\`\`
+
+Direct artifact:
+
+\`\`\`bash
+mkdir -p models
+cd models
+sima-cli download <model-url>
+cd ..
+\`\`\`
+
+Set \`model.path\` in the example config to the downloaded package.
 
 ## Run
 

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -202,6 +202,7 @@ render_readme() {
 # ${example_name}
 
 ## Metadata
+
 | Field | Value |
 | --- | --- |
 | Category | ${category} |
@@ -213,46 +214,48 @@ render_readme() {
 | Model | TODO or TODO [https://host/path/model_mpk.tar.gz] |
 
 ## Concept
+
 TODO: describe what this example demonstrates.
 
 ## Prerequisites
-- Installed Neat Development Environment + Neat Library.
-- Model artifacts are user-managed and should be downloaded into \`models/\`.
 
-## Get The Apps Repo
-Use the [Neat Development Environment](https://developer.sima.ai/software/getting-started/dev-environment/) with the [Neat Library](https://developer.sima.ai/software/getting-started/neat-library/) installed for setup and compilation.
+- \`sima-cli\` on a supported Modalix or DevKit target.
+- TODO: add example-specific input, service, or hardware requirements.
 
-Then clone and build the apps repo inside the Neat Development Environment:
+## Install Apps
+
+1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
+2. Install that version and enter the installed bundle:
 
 \`\`\`bash
-git clone https://github.com/sima-neat/apps.git
-cd apps
-./build.sh --clean
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
 \`\`\`
 
-After building, run the example commands below on the Modalix/DevKit board.
+Run the remaining commands from \`prebuilt-apps/\`.
 
-## Build
-### Build From The Apps Repo
-\`\`\`bash
-cd <apps-repo-root>
-./build.sh
-\`\`\`
+## Prepare the Model
 
-### Build This Example Directly With CMake
-\`\`\`bash
-cd <apps-repo-root>
-cmake -S examples/${category}/${example_name}/src/cpp -B build/${example_name}
-cmake --build build/${example_name} -j
-\`\`\`
+The default model is \`TODO\`.
+
+| Model | Role | Source |
+| --- | --- | --- |
+| \`TODO\` | Default | TODO: Model Zoo or direct artifact |
+
+The platform version required by model downloads is recorded in \`manifest.json\`.
+Download the model with \`sima-cli\`, store it under \`models/\`, and set
+\`model.path\` in the example config to the downloaded package.
 
 ## Run
+
 ### C++
+
 \`\`\`bash
-./build/examples/${category}/${example_name}/${example_name}
+./examples/${category}/${example_name}/src/cpp/pre-built/${example_name}
 \`\`\`
 
 ### Python
+
 \`\`\`bash
 source ~/pyneat/bin/activate
 pip install -r examples/${category}/${example_name}/src/python/requirements.txt
@@ -260,12 +263,18 @@ python3 examples/${category}/${example_name}/src/python/main.py
 \`\`\`
 
 ## Source Files
-- Test scope: \`tests/test-scope.yaml\`
-- C++: \`src/cpp/main.cpp\`
-- C++ tests: \`tests/cpp/test_unit.cpp\`, \`tests/cpp/test_e2e.cpp\`
-- Python: \`src/python/main.py\`
-- Python tests: \`tests/python/test_unit.py\`, \`tests/python/test_e2e.py\`
-- Shared assets: \`src/common/\`
+
+- C++ reference source: \`src/cpp/main.cpp\`
+- Python source: \`src/python/main.py\`
+- Shared runtime files: \`src/common/\`
+
+The packaged C++ source is an implementation reference. Run the executable
+under \`src/cpp/pre-built/\`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the
+[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
 EOF_MD
 }
 

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -219,7 +219,7 @@ TODO: describe what this example demonstrates.
 
 ## Prerequisites
 
-- \`sima-cli\` on a supported Modalix or DevKit target.
+- \`sima-cli\` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
 - TODO: add example-specific input, service, or hardware requirements.
 
 ## Install Apps

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -225,7 +225,7 @@ TODO: describe what this example demonstrates.
 ## Install Apps
 
 1. Choose a version from the [Neat Apps releases](https://github.com/sima-neat/apps/releases).
-2. Install that version and enter the installed bundle:
+2. Install the selected version and enter the installed bundle. We recommend using the latest release:
 
 \`\`\`bash
 sima-cli neat install apps@<release-version>

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -243,11 +243,12 @@ The default model is \`<default-model>\`.
 | \`<default-model>\` | Default | <Model Zoo / direct artifact> |
 | \`<supported-model>\` | Supported | <Model Zoo / direct artifact> |
 
-Set \`PLATFORM_VERSION\` to the \`platform-version\` value recorded in \`manifest.json\`. Use the command that matches the model source and delete the other command.
+Check the installed platform version, then set \`PLATFORM_VERSION\` to the displayed \`DISTRO_VERSION\` value. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
 \`\`\`bash
+cat /etc/buildinfo
 export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -242,9 +242,7 @@ The default model is \`TODO\`.
 | --- | --- | --- |
 | \`TODO\` | Default | TODO: Model Zoo or direct artifact |
 
-The platform version required by model downloads is recorded in \`manifest.json\`.
-Download the model with \`sima-cli\`, store it under \`models/\`, and set
-\`model.path\` in the example config to the downloaded package.
+The platform version required by model downloads is recorded in \`manifest.json\`. Download the model with \`sima-cli\`, store it under \`models/\`, and set \`model.path\` in the example config to the downloaded package.
 
 ## Run
 
@@ -268,13 +266,11 @@ python3 examples/${category}/${example_name}/src/python/main.py
 - Python source: \`src/python/main.py\`
 - Shared runtime files: \`src/common/\`
 
-The packaged C++ source is an implementation reference. Run the executable
-under \`src/cpp/pre-built/\`; the installed bundle does not include CMake files.
+The packaged C++ source is an implementation reference. Run the executable under \`src/cpp/pre-built/\`; the installed bundle does not include CMake files.
 
 ## Development From Source
 
-To modify, compile, or test this example, use the
-[Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
 EOF_MD
 }
 

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -243,14 +243,15 @@ The default model is \`<default-model>\`.
 | \`<default-model>\` | Default | <Model Zoo / direct artifact> |
 | \`<supported-model>\` | Supported | <Model Zoo / direct artifact> |
 
-The platform version required by model downloads is recorded in \`manifest.json\`. Use the command that matches the model source and delete the other command.
+Set \`PLATFORM_VERSION\` to the \`platform-version\` value recorded in \`manifest.json\`. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
 \`\`\`bash
+export PLATFORM_VERSION="<platform-version>"
 mkdir -p models
 cd models
-sima-cli modelzoo -v <platform-version> get <model-name>
+sima-cli modelzoo -v "\${PLATFORM_VERSION}" get <model-name>
 cd ..
 \`\`\`
 

--- a/scripts/validate_readmes.py
+++ b/scripts/validate_readmes.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Validate that every example README.md conforms to the required template.
+"""Validate that every example README.md conforms to the required contract.
 
 Scans examples/*/*/README.md files and verifies:
 - Metadata table exists with all required fields
 - Field values match allowed enums (categories, difficulties, languages, statuses)
-- Required sections are present
+- Installed Apps commands and required sections are present
 
 Exit code 0 on success, 1 if any README is missing or malformed.
 """
@@ -40,16 +40,43 @@ REQUIRED_METADATA_FIELDS = {
     "Binary Name",
     "Model",
 }
-MODEL_REFERENCE_RE = re.compile(r"^(?P<label>[^\[]+?)(?:\s*\[(?P<url>https?://[^\]]+)\])?$")
+MODEL_REFERENCE_RE = re.compile(
+    r"^(?P<label>[^\[]+?)(?:\s*\[(?P<url>https?://[^\]]+)\])?$"
+)
 
 REQUIRED_SECTIONS = {
     "Metadata",
     "Concept",
     "Prerequisites",
-    "Get The Apps Repo",
+    "Install Apps",
+    "Prepare the Model",
     "Run",
     "Source Files",
+    "Development From Source",
 }
+
+REQUIRED_SECTION_ORDER = (
+    "Metadata",
+    "Concept",
+    "Prerequisites",
+    "Install Apps",
+    "Prepare the Model",
+    "Run",
+    "Source Files",
+    "Development From Source",
+)
+
+RELEASES_URL = "https://github.com/sima-neat/apps/releases"
+INSTALL_COMMAND = "sima-cli neat install apps@<release-version>"
+CONTRIBUTING_URL = "https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md"
+SOURCE_ONLY_COMMANDS = (
+    "git clone ",
+    "build.sh",
+    "cmake ",
+    "ctest ",
+    "./build/",
+    "tests/test.sh",
+)
 
 
 def parse_metadata_table(content: str) -> dict[str, str] | None:
@@ -73,14 +100,75 @@ def parse_metadata_table(content: str) -> dict[str, str] | None:
     return metadata if metadata else None
 
 
-def get_sections(content: str) -> set[str]:
-    """Return set of H2 section names found in the content."""
-    sections = set()
+def parse_sections(content: str) -> tuple[dict[str, str], list[str]]:
+    """Return H2 section bodies and their document order."""
+    sections: dict[str, list[str]] = {}
+    order: list[str] = []
+    current: str | None = None
     for line in content.splitlines():
         match = re.match(r"^##\s+(.+)$", line)
         if match:
-            sections.add(match.group(1).strip())
-    return sections
+            current = match.group(1).strip()
+            if current not in sections:
+                sections[current] = []
+                order.append(current)
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return {name: "\n".join(lines).strip() for name, lines in sections.items()}, order
+
+
+def validate_installed_workflow(
+    *,
+    sections: dict[str, str],
+    metadata: dict[str, str],
+    readme_path: Path,
+) -> list[str]:
+    """Validate commands that must work from the installed bundle root."""
+    errors: list[str] = []
+    install = sections.get("Install Apps", "")
+    run = sections.get("Run", "")
+    development = sections.get("Development From Source", "")
+
+    if RELEASES_URL not in install:
+        errors.append("Install Apps must link to the Neat Apps releases page")
+    if INSTALL_COMMAND not in install:
+        errors.append(f"Install Apps must use '{INSTALL_COMMAND}'")
+    if "cd prebuilt-apps" not in install:
+        errors.append("Install Apps must enter the prebuilt-apps directory")
+
+    for command in SOURCE_ONLY_COMMANDS:
+        if command in install or command in run:
+            errors.append(
+                f"Source-only command '{command.strip()}' must not appear in "
+                "Install Apps or Run"
+            )
+
+    parts = readme_path.parts
+    try:
+        examples_idx = list(parts).index("examples")
+        category = parts[examples_idx + 1]
+        example = parts[examples_idx + 2]
+    except (ValueError, IndexError):
+        return errors
+
+    languages = {
+        item.strip()
+        for item in metadata.get("Languages", "").split(",")
+        if item.strip()
+    }
+    if "C++" in languages:
+        binary = metadata.get("Binary Name", "").strip()
+        expected = f"examples/{category}/{example}/src/cpp/pre-built/{binary}"
+        if binary and expected not in run:
+            errors.append(f"Run must reference packaged C++ binary '{expected}'")
+    if "Python" in languages and "src/python/" not in run:
+        errors.append("Run must reference a packaged src/python/ entrypoint")
+
+    if CONTRIBUTING_URL not in development:
+        errors.append("Development From Source must link to CONTRIBUTING.md")
+
+    return errors
 
 
 def validate_readme(readme_path: Path) -> list[str]:
@@ -89,10 +177,25 @@ def validate_readme(readme_path: Path) -> list[str]:
     content = readme_path.read_text()
 
     # Check required sections
-    sections = get_sections(content)
+    sections, section_order = parse_sections(content)
     for section in REQUIRED_SECTIONS:
         if section not in sections:
             errors.append(f"Missing required section: ## {section}")
+
+    present_required_sections = [
+        section for section in section_order if section in REQUIRED_SECTIONS
+    ]
+    expected_order = [
+        section for section in REQUIRED_SECTION_ORDER if section in sections
+    ]
+    if present_required_sections != expected_order:
+        errors.append(
+            "Required sections are out of order. Expected: "
+            + ", ".join(REQUIRED_SECTION_ORDER)
+        )
+
+    if "Get The Apps Repo" in sections:
+        errors.append("Obsolete section: ## Get The Apps Repo")
 
     # Parse and validate metadata
     metadata = parse_metadata_table(content)
@@ -123,7 +226,9 @@ def validate_readme(readme_path: Path) -> list[str]:
         for item in metadata.get("Languages", "").split(",")
         if item.strip()
     ]
-    invalid_languages = [language for language in languages if language not in VALID_LANGUAGES]
+    invalid_languages = [
+        language for language in languages if language not in VALID_LANGUAGES
+    ]
     if invalid_languages:
         errors.append(
             f"Invalid Languages '{metadata.get('Languages', '')}'. "
@@ -143,6 +248,14 @@ def validate_readme(readme_path: Path) -> list[str]:
             "Invalid Model metadata. Use either '<model_label>' or "
             "'<model_label> [https://host/path/model_mpk.tar.gz]'"
         )
+
+    errors.extend(
+        validate_installed_workflow(
+            sections=sections,
+            metadata=metadata,
+            readme_path=readme_path,
+        )
+    )
 
     # Verify the example directory matches its category
     parts = readme_path.parts
@@ -180,9 +293,7 @@ def main() -> int:
 
     # Find all example directories (examples/<category>/<name>/)
     example_dirs = sorted(
-        d
-        for d in examples_dir.glob("*/*")
-        if d.is_dir() and not d.name.startswith(".")
+        d for d in examples_dir.glob("*/*") if d.is_dir() and not d.name.startswith(".")
     )
 
     if not example_dirs:

--- a/tests/scripts/test_readme_contract.py
+++ b/tests/scripts/test_readme_contract.py
@@ -1,0 +1,114 @@
+import importlib.util
+from pathlib import Path
+
+
+APPS_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "validate_readmes_for_test",
+    APPS_ROOT / "scripts" / "validate_readmes.py",
+)
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(VALIDATOR)
+validate_readme = VALIDATOR.validate_readme
+
+
+def write_readme(tmp_path: Path, *, install: str, run: str) -> Path:
+    readme = tmp_path / "examples" / "classification" / "sample" / "README.md"
+    readme.parent.mkdir(parents=True)
+    readme.write_text(
+        f"""# Sample
+
+## Metadata
+| Field | Value |
+| --- | --- |
+| Category | classification |
+| Difficulty | Beginner |
+| Tags | sample |
+| Languages | C++, Python |
+| Status | experimental |
+| Binary Name | sample |
+| Model | sample-model |
+
+## Concept
+Sample concept.
+
+## Prerequisites
+- A supported target.
+
+## Install Apps
+{install}
+
+## Prepare the Model
+Download the sample model.
+
+## Run
+{run}
+
+## Source Files
+- C++ source: `src/cpp/main.cpp`
+
+## Development From Source
+See [CONTRIBUTING.md](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+""",
+        encoding="utf-8",
+    )
+    return readme
+
+
+VALID_INSTALL = """Choose a version from https://github.com/sima-neat/apps/releases.
+
+```bash
+sima-cli neat install apps@<release-version>
+cd prebuilt-apps
+```"""
+
+VALID_RUN = """```bash
+./examples/classification/sample/src/cpp/pre-built/sample
+python3 examples/classification/sample/src/python/main.py
+```"""
+
+
+def test_installed_readme_contract_accepts_packaged_commands(tmp_path: Path) -> None:
+    readme = write_readme(tmp_path, install=VALID_INSTALL, run=VALID_RUN)
+
+    assert validate_readme(readme) == []
+
+
+def test_installed_readme_contract_requires_versioned_install(tmp_path: Path) -> None:
+    readme = write_readme(
+        tmp_path,
+        install=VALID_INSTALL.replace("apps@<release-version>", "apps"),
+        run=VALID_RUN,
+    )
+
+    assert any("apps@<release-version>" in error for error in validate_readme(readme))
+
+
+def test_installed_readme_contract_rejects_build_tree_binary(tmp_path: Path) -> None:
+    readme = write_readme(
+        tmp_path,
+        install=VALID_INSTALL,
+        run=VALID_RUN.replace(
+            "./examples/classification/sample/src/cpp/pre-built/sample",
+            "./build/examples/classification/sample/sample",
+        ),
+    )
+
+    errors = validate_readme(readme)
+    assert any("Source-only command './build/'" in error for error in errors)
+    assert any("packaged C++ binary" in error for error in errors)
+
+
+def test_installed_readme_contract_rejects_source_builds_in_install(
+    tmp_path: Path,
+) -> None:
+    readme = write_readme(
+        tmp_path,
+        install=VALID_INSTALL + "\n\n./build.sh --clean",
+        run=VALID_RUN,
+    )
+
+    assert any(
+        "Source-only command 'build.sh'" in error for error in validate_readme(readme)
+    )


### PR DESCRIPTION
## Why

Users installing an Apps release should be able to run examples directly from the packaged `prebuilt-apps/` bundle. The existing documentation still centered on cloning and building the repository, referenced build-tree paths, and scattered model preparation across different sections.

## What Changed

- Standardized installation through `sima-cli neat install apps@<release-version>` and linked the available Apps releases.
- Updated all 14 example READMEs to run from `prebuilt-apps/`, using packaged C++ executables and Python entrypoints.
- Documented each default model, additional supported models, and the corresponding Model Zoo, direct artifact, or example-specific installation method.
- Kept source compilation and testing as a secondary contributor workflow.
- Updated the README template, scaffold generator, contributor guidance, and validation rules so new examples follow the same structure.

## Validation

- `python3 -m pytest -q tests/scripts` — 73 passed
- `python3 scripts/validate_readmes.py` — all 14 READMEs passed
- Catalog generation — all 14 examples contain the required installed-workflow sections
- `bash -n scripts/create_example_scaffold.sh`
- Ruff formatting and lint checks
- `git diff --check`

## Notes

This PR changes documentation and README validation only. It does not change runtime or packaging behavior. Runtime and hardware execution were not repeated.

The repository-wide formatting check could not run because `clang-format` is unavailable on the host. No C or C++ files changed.

Closes #351
Closes #342
Part of #341
