### PR TITLE
fix(release): enforce prebuilt Apps layout

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -143,7 +143,7 @@ jobs:
         fi
         test -f neat-apps-tests.tar.gz
         scripts/ci/validate_apps_runtime_archive.sh "${runtime_archives[0]}"
-        tar -tzf "${runtime_archives[0]}" neat-apps-runtime/neat-core.json >/dev/null
+        tar -tzf "${runtime_archives[0]}" prebuilt-apps/neat-core.json >/dev/null
         tar -tzf neat-apps-tests.tar.gz neat-apps-tests/tests/test.sh >/dev/null
         ls -lh "${runtime_archives[0]}" neat-apps-tests.tar.gz
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ portal/public/catalog.json
 portal/public/example-assets/
 install_neat_framework.sh
 neat-apps-runtime/
+prebuilt-apps/
 docs/*
 .vscode/*

--- a/build.sh
+++ b/build.sh
@@ -145,7 +145,7 @@ package_distribution() {
   archive_name="neat-apps-${branch_key}-${version}.tar.gz"
   archive_path="${ROOT_DIR}/${archive_name}"
   stage_root="$(mktemp -d /tmp/neat-apps-package.XXXXXX)"
-  stage_dir="${stage_root}/neat-apps-runtime"
+  stage_dir="${stage_root}/prebuilt-apps"
   test_stage_dir="${stage_root}/neat-apps-tests"
 
   mkdir -p \

--- a/scripts/ci/validate_apps_runtime_archive.sh
+++ b/scripts/ci/validate_apps_runtime_archive.sh
@@ -7,14 +7,101 @@ if [[ -z "${archive}" || ! -f "${archive}" ]]; then
   exit 1
 fi
 
-members="$(tar -tzf "${archive}")"
+runtime_root="prebuilt-apps"
 
-for required_file in neat-core.json manifest.json; do
-  if ! grep -qx "neat-apps-runtime/${required_file}" <<<"${members}"; then
-    echo "Runtime archive is missing neat-apps-runtime/${required_file}." >&2
-    exit 1
-  fi
-done
+python3 - "${archive}" "${runtime_root}" <<'PY'
+import json
+import sys
+import tarfile
+from pathlib import PurePosixPath
+
+archive, root = sys.argv[1:]
+prefix = f"{root}/"
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+with tarfile.open(archive, "r:gz") as bundle:
+    members = bundle.getmembers()
+    by_name = {member.name: member for member in members}
+    text_suffixes = {
+        ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp",
+        ".json", ".md", ".py", ".sh", ".yaml", ".yml",
+    }
+    obsolete_references = (
+        b"assets/models/",
+        b"assets/test_images/",
+        b"assets/test_images_classification/",
+        b"neat-apps-runtime/",
+        b"/usr/bin/fix_devkit_runtime.sh",
+    )
+
+    for member in members:
+        path = PurePosixPath(member.name)
+        if path.is_absolute() or ".." in path.parts:
+            fail(f"runtime archive contains an unsafe path: {member.name}")
+        if member.name != root and not member.name.startswith(prefix):
+            fail(f"runtime archive member is outside {root}/: {member.name}")
+        if (
+            member.isfile()
+            and member.mode & 0o111
+            and "/src/cpp/" in member.name
+            and "/src/cpp/pre-built/" not in member.name
+        ):
+            fail(f"C++ executable is outside src/cpp/pre-built/: {member.name}")
+        if member.isfile() and PurePosixPath(member.name).suffix in text_suffixes:
+            source = bundle.extractfile(member)
+            content = source.read() if source is not None else b""
+            if any(reference in content for reference in obsolete_references):
+                fail(f"runtime archive contains an obsolete path reference: {member.name}")
+
+    def read_json(name: str) -> dict:
+        member = by_name.get(name)
+        if member is None or not member.isfile():
+            fail(f"runtime archive is missing {name}")
+        source = bundle.extractfile(member)
+        if source is None:
+            fail(f"unable to read {name}")
+        try:
+            payload = json.load(source)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            fail(f"{name} is not valid JSON")
+        if not isinstance(payload, dict):
+            fail(f"{name} must contain a JSON object")
+        return payload
+
+    core = read_json(f"{root}/neat-core.json").get("neat-core")
+    if not isinstance(core, dict):
+        fail("neat-core.json must define neat-core")
+    branch = core.get("branch")
+    version = core.get("version")
+    if (
+        not isinstance(branch, str)
+        or not branch.strip()
+        or not isinstance(version, str)
+        or not version.strip()
+        or version.strip().lower() == "latest"
+    ):
+        fail("neat-core.json must contain an exact branch and version")
+
+    insight = read_json(f"{root}/manifest.json").get("insight")
+    if not isinstance(insight, dict):
+        fail("manifest.json must define insight")
+    ref = insight.get("branch", insight.get("ref"))
+    version = insight.get("version")
+    if (
+        not isinstance(ref, str)
+        or not ref.strip()
+        or not isinstance(version, str)
+        or not version.strip()
+    ):
+        fail("manifest.json must contain an Insight branch or ref and version")
+PY
+
+members="$(tar -tzf "${archive}")"
 
 forbidden='(^|/)(models|portal|tests|test-scope\.yaml|CMakeLists\.txt|CTestTestfile\.cmake|cmake_install\.cmake|Makefile|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(a|pyc|pyo|log|db|lock)$'
 if grep -E "${forbidden}" <<<"${members}"; then
@@ -32,8 +119,8 @@ if [[ -n "${root_example_binaries}" ]]; then
 fi
 
 invalid_assets="$(
-  grep '^neat-apps-runtime/assets/' <<<"${members}" \
-    | grep -Ev '^neat-apps-runtime/assets/$|^neat-apps-runtime/assets/datasets(/|$)' \
+  grep "^${runtime_root}/assets/" <<<"${members}" \
+    | grep -Ev "^${runtime_root}/assets/$|^${runtime_root}/assets/datasets(/|$)" \
     || true
 )"
 if [[ -n "${invalid_assets}" ]]; then

--- a/scripts/ci/validate_apps_runtime_archive.sh
+++ b/scripts/ci/validate_apps_runtime_archive.sh
@@ -31,6 +31,8 @@ with tarfile.open(archive, "r:gz") as bundle:
         ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp",
         ".json", ".md", ".py", ".sh", ".yaml", ".yml",
     }
+    model_suffixes = (".tar.gz", ".mpk", ".onnx")
+    allowed_example_root_executables = {"run.sh", "setup.sh"}
     obsolete_references = (
         b"assets/models/",
         b"assets/test_images/",
@@ -45,6 +47,16 @@ with tarfile.open(archive, "r:gz") as bundle:
             fail(f"runtime archive contains an unsafe path: {member.name}")
         if member.name != root and not member.name.startswith(prefix):
             fail(f"runtime archive member is outside {root}/: {member.name}")
+        if member.isfile() and member.name.endswith(model_suffixes):
+            fail(f"runtime archive contains a packaged model: {member.name}")
+        if (
+            member.isfile()
+            and member.mode & 0o111
+            and len(path.parts) == 5
+            and path.parts[:2] == (root, "examples")
+            and path.name not in allowed_example_root_executables
+        ):
+            fail(f"executable is at an example root: {member.name}")
         if (
             member.isfile()
             and member.mode & 0o111
@@ -106,15 +118,6 @@ members="$(tar -tzf "${archive}")"
 forbidden='(^|/)(models|portal|tests|test-scope\.yaml|CMakeLists\.txt|CTestTestfile\.cmake|cmake_install\.cmake|Makefile|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(a|pyc|pyo|log|db|lock)$'
 if grep -E "${forbidden}" <<<"${members}"; then
   echo "Runtime archive contains non-runtime or generated files." >&2
-  exit 1
-fi
-
-root_example_binaries="$(
-  awk -F/ 'NF == 5 && $2 == "examples" && ($4 == $5 || $4 == $5 "_cpp")' <<<"${members}"
-)"
-if [[ -n "${root_example_binaries}" ]]; then
-  printf '%s\n' "${root_example_binaries}" >&2
-  echo "Runtime archive contains a root-level example binary." >&2
   exit 1
 fi
 

--- a/scripts/install-neat-apps.sh
+++ b/scripts/install-neat-apps.sh
@@ -202,7 +202,7 @@ mkdir -p "${DEST_DIR}"
 echo "Extracting into ${DEST_DIR}/ ..."
 tar -xzf "${LOCAL_ARCHIVE}" -C "${DEST_DIR}"
 
-RUNTIME_DIR="${DEST_DIR}/neat-apps-runtime"
+RUNTIME_DIR="${DEST_DIR}/prebuilt-apps"
 NEAT_CORE_JSON_PATH="${RUNTIME_DIR}/neat-core.json"
 
 if [[ ! -f "${NEAT_CORE_JSON_PATH}" ]]; then

--- a/scripts/install-neat-apps.sh
+++ b/scripts/install-neat-apps.sh
@@ -14,13 +14,13 @@ set -euo pipefail
 # - If no tag is provided, or the tag is "latest", fetch branch/latest.tag.
 # - Download neat-apps-<branch-key>-<tag>.tar.gz from the apps download root.
 # - If arg 1 points to an existing .tar.gz file, use that local archive directly.
-# - Extract the archive into ./neat-apps.
+# - Extract the archive into the current directory as ./prebuilt-apps.
 
 BASE_URL="${NEAT_APPS_BASE_URL:-https://apps.sima-neat.com/download}"
 NEAT_INSTALLER_URL="${NEAT_INSTALLER_URL:-https://tools.sima-neat.com/install-neat.sh}"
 BRANCH="${1:-}"
 TAG_INPUT="${2:-latest}"
-DEST_DIR="${NEAT_APPS_INSTALL_DIR:-neat-apps}"
+DEST_DIR="${NEAT_APPS_INSTALL_DIR:-.}"
 LOCAL_ARCHIVE="${NEAT_APPS_ARCHIVE:-}"
 
 usage() {
@@ -34,8 +34,8 @@ Environment:
                           default: https://apps.sima-neat.com/download
   NEAT_INSTALLER_URL      Hosted NEAT core installer URL
                           default: https://tools.sima-neat.com/install-neat.sh
-  NEAT_APPS_INSTALL_DIR   Destination directory for extracted files
-                          default: ./neat-apps
+  NEAT_APPS_INSTALL_DIR   Parent directory for the extracted prebuilt-apps
+                          default: current directory
   NEAT_APPS_ARCHIVE       Use an already downloaded local apps archive
 USAGE
 }
@@ -239,4 +239,4 @@ fi
 
 echo
 echo "Installed apps runtime under:"
-echo "  ${DEST_DIR}"
+echo "  ${RUNTIME_DIR}"

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DEST_DIR="${NEAT_APPS_INSTALL_DIR:-prebuilt-apps}"
-RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-neat-apps-runtime}"
+RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-prebuilt-apps}"
 INSTALL_ROOT="$(dirname "${DEST_DIR}")"
 LEGACY_RUNTIME_DIR="${INSTALL_ROOT}/neat-apps/neat-apps-runtime"
 VULCAN_ENV="${NEAT_VULCAN_ENV:-${VULCAN_ENV:-production}}"

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
@@ -20,33 +21,109 @@ VULCAN_INSTALLER = APPS_ROOT / "scripts/install-vulcan-apps-package.sh"
 RUNTIME_ARCHIVE_VALIDATOR = APPS_ROOT / "scripts/ci/validate_apps_runtime_archive.sh"
 
 
-def _write_runtime_archive(tmp_path: Path, *members: str) -> Path:
-    archive_root = tmp_path / "archive-root" / "neat-apps-runtime"
+def _write_runtime_archive(
+    tmp_path: Path,
+    *members: str,
+    root_name: str = "prebuilt-apps",
+    neat_core: object | None = None,
+    insight: object | None = None,
+    executable_members: tuple[str, ...] = (),
+    extra_archive_members: tuple[str, ...] = (),
+    member_contents: dict[str, str] | None = None,
+) -> Path:
+    archive_root = tmp_path / "archive-root" / root_name
     archive_root.mkdir(parents=True)
-    (archive_root / "neat-core.json").write_text("{}\n", encoding="utf-8")
-    (archive_root / "manifest.json").write_text("{}\n", encoding="utf-8")
+    if neat_core is None:
+        neat_core = {"branch": "develop", "version": "core-sha"}
+    if insight is None:
+        insight = {"ref": "main", "version": "latest"}
+    (archive_root / "neat-core.json").write_text(
+        json.dumps({"neat-core": neat_core}), encoding="utf-8"
+    )
+    (archive_root / "manifest.json").write_text(
+        json.dumps({"insight": insight}), encoding="utf-8"
+    )
     for member in members:
         path = archive_root / member
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("fixture\n", encoding="utf-8")
+        content = (member_contents or {}).get(member, "fixture\n")
+        path.write_text(content, encoding="utf-8")
+        if member in executable_members:
+            path.chmod(0o755)
 
     archive = tmp_path / "runtime.tar.gz"
     with tarfile.open(archive, "w:gz") as output:
-        output.add(archive_root, arcname="neat-apps-runtime")
+        output.add(archive_root, arcname=root_name)
+        for member in extra_archive_members:
+            payload = b"fixture\n"
+            info = tarfile.TarInfo(member)
+            info.size = len(payload)
+            output.addfile(info, io.BytesIO(payload))
     return archive
 
 
-def test_runtime_archive_validator_accepts_shipped_datasets(tmp_path):
-    archive = _write_runtime_archive(tmp_path, "assets/datasets/coco/example.jpg")
-
-    proc = subprocess.run(
+def _validate_runtime_archive(archive: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         ["bash", str(RUNTIME_ARCHIVE_VALIDATOR), str(archive)],
         check=False,
         capture_output=True,
         text=True,
     )
 
+
+def test_runtime_archive_validator_accepts_shipped_datasets(tmp_path):
+    archive = _write_runtime_archive(tmp_path, "assets/datasets/coco/example.jpg")
+    proc = _validate_runtime_archive(archive)
+
     assert proc.returncode == 0, proc.stderr + proc.stdout
+
+
+def test_runtime_archive_validator_rejects_legacy_root(tmp_path):
+    archive = _write_runtime_archive(tmp_path, root_name="neat-apps-runtime")
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize("member", ["unexpected.txt", "../escape.txt"])
+def test_runtime_archive_validator_rejects_members_outside_root(tmp_path, member):
+    archive = _write_runtime_archive(
+        tmp_path,
+        extra_archive_members=(member,),
+    )
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "neat_core",
+    [
+        {},
+        {"branch": "", "version": "core-sha"},
+        {"branch": "develop", "version": "latest"},
+    ],
+)
+def test_runtime_archive_validator_rejects_invalid_core_target(tmp_path, neat_core):
+    archive = _write_runtime_archive(tmp_path, neat_core=neat_core)
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "insight",
+    [
+        {},
+        {"ref": "", "version": "latest"},
+        {"ref": "main", "version": ""},
+    ],
+)
+def test_runtime_archive_validator_rejects_invalid_insight_target(tmp_path, insight):
+    archive = _write_runtime_archive(tmp_path, insight=insight)
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
 
 
 @pytest.mark.parametrize(
@@ -63,32 +140,56 @@ def test_runtime_archive_validator_accepts_shipped_datasets(tmp_path):
 )
 def test_runtime_archive_validator_rejects_forbidden_content(tmp_path, member):
     archive = _write_runtime_archive(tmp_path, member)
+    proc = _validate_runtime_archive(archive)
 
-    proc = subprocess.run(
-        ["bash", str(RUNTIME_ARCHIVE_VALIDATOR), str(archive)],
-        check=False,
-        capture_output=True,
-        text=True,
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "assets/models/",
+        "assets/test_images/",
+        "assets/test_images_classification/",
+        "neat-apps-runtime/",
+        "/usr/bin/fix_devkit_runtime.sh",
+    ],
+)
+def test_runtime_archive_validator_rejects_obsolete_references(tmp_path, reference):
+    readme = "examples/classification/demo/README.md"
+    archive = _write_runtime_archive(
+        tmp_path,
+        readme,
+        member_contents={readme: reference},
     )
+    proc = _validate_runtime_archive(archive)
 
     assert proc.returncode != 0
 
 
 def test_runtime_archive_validator_accepts_cpp_reference_and_prebuilt_binary(tmp_path):
+    prebuilt_binary = "examples/classification/demo/src/cpp/pre-built/demo"
     archive = _write_runtime_archive(
         tmp_path,
         "examples/classification/demo/src/cpp/main.cpp",
-        "examples/classification/demo/src/cpp/pre-built/demo",
+        prebuilt_binary,
+        executable_members=(prebuilt_binary,),
     )
-
-    proc = subprocess.run(
-        ["bash", str(RUNTIME_ARCHIVE_VALIDATOR), str(archive)],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    proc = _validate_runtime_archive(archive)
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
+
+
+def test_runtime_archive_validator_rejects_misplaced_cpp_executable(tmp_path):
+    misplaced_binary = "examples/classification/demo/src/cpp/demo"
+    archive = _write_runtime_archive(
+        tmp_path,
+        misplaced_binary,
+        executable_members=(misplaced_binary,),
+    )
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
 
 
 def _write_manifest(
@@ -243,7 +344,7 @@ def _write_vulcan_runtime(
     neat_core: object | None = None,
     insight: object | None = None,
 ) -> Path:
-    runtime_dir = package_dir / "neat-apps-runtime"
+    runtime_dir = package_dir / "prebuilt-apps"
     runtime_dir.mkdir(parents=True)
     if neat_core is None:
         neat_core = {"branch": "develop", "version": "core-sha"}
@@ -709,7 +810,7 @@ def test_vulcan_core_install_skips_when_neat_json_matches(tmp_path):
 
 def test_vulcan_installer_rejects_latest_core_before_replacing_runtime(tmp_path):
     package_dir = tmp_path / "package"
-    runtime_dir = package_dir / "neat-apps-runtime"
+    runtime_dir = package_dir / "prebuilt-apps"
     runtime_dir.mkdir(parents=True)
     (runtime_dir / "neat-core.json").write_text(
         json.dumps({"neat-core": {"branch": "develop", "version": "latest"}}),

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -17,6 +17,7 @@ import pytest
 
 APPS_ROOT = Path(__file__).resolve().parents[2]
 BUILD_SH = APPS_ROOT / "build.sh"
+ARCHIVE_INSTALLER = APPS_ROOT / "scripts/install-neat-apps.sh"
 VULCAN_INSTALLER = APPS_ROOT / "scripts/install-vulcan-apps-package.sh"
 RUNTIME_ARCHIVE_VALIDATOR = APPS_ROOT / "scripts/ci/validate_apps_runtime_archive.sh"
 
@@ -131,11 +132,10 @@ def test_runtime_archive_validator_rejects_invalid_insight_target(tmp_path, insi
     [
         "assets/datasets-test/coco/example.jpg",
         "models/example.tar.gz",
+        "examples/classification/demo/src/common/model.tar.gz",
         "portal/assets/examples/example.png",
         "examples/classification/demo/src/cpp/CMakeLists.txt",
         "examples/classification/demo/src/cpp/pre-built/CTestTestfile.cmake",
-        "examples/classification/demo/demo",
-        "examples/face-detection/face-detector_cpp/face-detector",
     ],
 )
 def test_runtime_archive_validator_rejects_forbidden_content(tmp_path, member):
@@ -180,8 +180,18 @@ def test_runtime_archive_validator_accepts_cpp_reference_and_prebuilt_binary(tmp
     assert proc.returncode == 0, proc.stderr + proc.stdout
 
 
-def test_runtime_archive_validator_rejects_misplaced_cpp_executable(tmp_path):
-    misplaced_binary = "examples/classification/demo/src/cpp/demo"
+@pytest.mark.parametrize(
+    "misplaced_binary",
+    [
+        "examples/classification/demo/src/cpp/demo",
+        "examples/classification/demo/demo",
+        "examples/classification/demo/helper",
+        "examples/face-detection/face-detector_cpp/face-detector",
+    ],
+)
+def test_runtime_archive_validator_rejects_misplaced_cpp_executable(
+    tmp_path, misplaced_binary
+):
     archive = _write_runtime_archive(
         tmp_path,
         misplaced_binary,
@@ -190,6 +200,21 @@ def test_runtime_archive_validator_rejects_misplaced_cpp_executable(tmp_path):
     proc = _validate_runtime_archive(archive)
 
     assert proc.returncode != 0
+
+
+def test_runtime_archive_validator_accepts_example_root_scripts(tmp_path):
+    scripts = (
+        "examples/genai/multimodal-assistant/run.sh",
+        "examples/genai/multimodal-assistant/setup.sh",
+    )
+    archive = _write_runtime_archive(
+        tmp_path,
+        *scripts,
+        executable_members=scripts,
+    )
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
 
 
 def _write_manifest(
@@ -305,6 +330,41 @@ def _write_fake_curl(tmp_path: Path) -> tuple[Path, Path]:
     )
     curl_path.chmod(0o755)
     return bin_dir, log_path
+
+
+def test_archive_installer_extracts_flat_prebuilt_apps_by_default(tmp_path):
+    archive = _write_runtime_archive(tmp_path, "runtime-marker")
+    bin_dir, curl_log = _write_fake_curl(tmp_path)
+    installer_url = "https://installer.test/install-neat.sh"
+    installer_pwd = tmp_path / "installer-pwd.txt"
+    installer_args = tmp_path / "installer-args.txt"
+    env = os.environ.copy()
+    env.pop("NEAT_APPS_INSTALL_DIR", None)
+    env.update(
+        {
+            "NEAT_APPS_ARCHIVE": str(archive),
+            "NEAT_INSTALLER_URL": installer_url,
+            "NEAT_APPS_TEST_CURL_LOG": str(curl_log),
+            "NEAT_APPS_TEST_INSTALLER_URL": installer_url,
+            "NEAT_APPS_TEST_INSTALLER_PWD": str(installer_pwd),
+            "NEAT_APPS_TEST_INSTALLER_ARGS": str(installer_args),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+        }
+    )
+
+    proc = subprocess.run(
+        ["bash", str(ARCHIVE_INSTALLER), "develop"],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (tmp_path / "prebuilt-apps" / "runtime-marker").is_file()
+    assert not (tmp_path / "neat-apps").exists()
+    assert "  ./prebuilt-apps" in proc.stdout
 
 
 def _write_fake_sima_cli(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Why

The Apps archive used `neat-apps-runtime/` while the installed bundle used `prebuilt-apps/`. This created two names for the same runtime and left important release-package requirements unenforced before publication.

## What Changed

- Use `prebuilt-apps/` as the archive root and installed directory.
- Reject archives with invalid Core or Insight metadata, misplaced C++ executables, tests, models, portal content, generated files, unsupported assets, or obsolete path references.
- Preserve migration from the legacy nested installation and retain user-installed models during upgrades.
- Keep the separate internal test archive unchanged.

## Validation

- `python3 -m pytest -q tests/scripts` — 88 passed
- Shell syntax validation for the build, archive validation, and installation scripts
- `git diff --check`

## Risk

The top-level directory inside the runtime archive changes from `neat-apps-runtime/` to `prebuilt-apps/`. Supported installation paths are updated together and continue installing into `prebuilt-apps/`.

Closes #346
