### PR TITLE
ci(vulcan): align stable Core context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ on:
         default: false
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -86,3 +87,16 @@ jobs:
     secrets:
       NEAT_RELEASES_APP_ID: ${{ secrets.NEAT_RELEASES_APP_ID }}
       NEAT_RELEASES_APP_PRIVATE_KEY: ${{ secrets.NEAT_RELEASES_APP_PRIVATE_KEY }}
+
+  trigger-vulcan:
+    name: Trigger tagged Vulcan build
+    needs: release
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Vulcan for release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag_name }}
+        run: gh workflow run vulcan-ci.yml --ref "${RELEASE_TAG}"

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -52,6 +52,7 @@ jobs:
 
   build:
     name: Build Apps on Vulcan
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs:
       - resolve-core-context
       - resolve-vulcan-config

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -8,6 +8,9 @@ on:
       - "**"
     tags:
       - "*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch: {}
 
 permissions:
@@ -31,9 +34,27 @@ jobs:
     with:
       vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
 
+  resolve-core-context:
+    name: Resolve Core Context
+    runs-on: ubuntu-latest
+    outputs:
+      dependency_branch: ${{ steps.resolve.outputs.dependency_branch }}
+    steps:
+      - name: Select Core dependency branch
+        id: resolve
+        env:
+          DEPENDENCY_BRANCH: >-
+            ${{ (github.ref_type == 'tag' ||
+              github.ref_name == 'main' ||
+              startsWith(github.ref_name, 'release-') ||
+              github.base_ref == 'main') && 'main' || github.ref_name }}
+        run: echo "dependency_branch=${DEPENDENCY_BRANCH}" >> "${GITHUB_OUTPUT}"
+
   build:
     name: Build Apps on Vulcan
-    needs: resolve-vulcan-config
+    needs:
+      - resolve-core-context
+      - resolve-vulcan-config
     uses: sima-neat/.github/.github/workflows/vulcan-build.yml@main
     with:
       vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
@@ -71,6 +92,7 @@ jobs:
           -e GITHUB_REF_NAME="${{ github.ref_name }}" \
           -e GITHUB_REF_TYPE="${{ github.ref_type }}" \
           -e GITHUB_SHA="${{ github.sha }}" \
+          -e NEAT_APPS_DEPENDENCY_BRANCH="${{ needs.resolve-core-context.outputs.dependency_branch }}" \
           -e NEAT_APPS_ARTIFACT_BRANCH_KEY="${{ github.head_ref || github.ref_name }}" \
           -e NEAT_APPS_ARTIFACT_SHORT_SHA="${{ github.sha }}" \
           -e NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
@@ -180,6 +202,7 @@ jobs:
     name: Test Apps Runtime
     needs:
       - build
+      - resolve-core-context
       - resolve-vulcan-config
       - resolve-test-runner
     runs-on:
@@ -215,7 +238,8 @@ jobs:
       - name: Install snap Core for Apps tests
         run: |
           artifact_base_url="${{ needs.resolve-vulcan-config.outputs.artifact_base_url }}"
-          NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
+          NEAT_APPS_DEPENDENCY_BRANCH="${{ needs.resolve-core-context.outputs.dependency_branch }}" \
+            NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
             NEAT_CORE_INSTALL_MODE=vulcan \
             NEAT_VULCAN_ENV="${{ needs.resolve-vulcan-config.outputs.vulcan_env }}" \
             ./build.sh --only-install-neat-core

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -901,6 +901,11 @@ def test_vulcan_uses_one_core_context_for_build_and_runtime_tests():
     dependency_output = "needs.resolve-core-context.outputs.dependency_branch"
 
     assert "pull_request:\n    branches:\n      - main" in workflow
+    assert (
+        "if: ${{ github.event_name != 'pull_request' || "
+        "github.event.pull_request.head.repo.full_name == github.repository }}"
+        in workflow
+    )
     assert "github.ref_type == 'tag'" in workflow
     assert "github.ref_name == 'main'" in workflow
     assert "startsWith(github.ref_name, 'release-')" in workflow

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -20,6 +20,7 @@ BUILD_SH = APPS_ROOT / "build.sh"
 ARCHIVE_INSTALLER = APPS_ROOT / "scripts/install-neat-apps.sh"
 VULCAN_INSTALLER = APPS_ROOT / "scripts/install-vulcan-apps-package.sh"
 VULCAN_WORKFLOW = APPS_ROOT / ".github/workflows/vulcan-ci.yml"
+RELEASE_WORKFLOW = APPS_ROOT / ".github/workflows/release.yml"
 RUNTIME_ARCHIVE_VALIDATOR = APPS_ROOT / "scripts/ci/validate_apps_runtime_archive.sh"
 
 
@@ -893,6 +894,33 @@ def test_vulcan_runtime_gate_uses_snap_core_without_customer_dependencies():
     assert "./build.sh --only-install-neat-core" in workflow
     assert "NEAT_CORE_INSTALL_MODE=vulcan" in workflow
     assert "NEAT_APPS_SKIP_DEPENDENCIES=1" in workflow
+
+
+def test_vulcan_uses_one_core_context_for_build_and_runtime_tests():
+    workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
+    dependency_output = "needs.resolve-core-context.outputs.dependency_branch"
+
+    assert "pull_request:\n    branches:\n      - main" in workflow
+    assert "github.ref_type == 'tag'" in workflow
+    assert "github.ref_name == 'main'" in workflow
+    assert "startsWith(github.ref_name, 'release-')" in workflow
+    assert "github.base_ref == 'main'" in workflow
+    assert "&& 'main' || github.ref_name" in workflow
+    assert workflow.count(dependency_output) == 2
+    assert (
+        'NEAT_APPS_ARTIFACT_BRANCH_KEY="${{ github.head_ref || github.ref_name }}"'
+        in workflow
+    )
+
+
+def test_release_dispatches_vulcan_for_the_created_tag():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actions: write" in workflow
+    assert "trigger-vulcan:" in workflow
+    assert "if: ${{ !inputs.dry_run }}" in workflow
+    assert "RELEASE_TAG: ${{ needs.release.outputs.tag_name }}" in workflow
+    assert 'gh workflow run vulcan-ci.yml --ref "${RELEASE_TAG}"' in workflow
 
 
 def test_vulcan_installer_keeps_existing_runtime_when_core_install_fails(tmp_path):


### PR DESCRIPTION
## Summary

- resolve the Core dependency context once for each Vulcan run
- use Core main for main, release branches, version tags, and PRs targeting main
- pass the same Core context to the SDK build and Modalix runtime test
- dispatch tagged Vulcan validation from the existing Apps release workflow
- preserve PR artifact publication under the source branch

## Validation

- `python3 -m pytest tests/scripts/test_manifest_contract.py -q` (57 passed)
- `python3 -m pytest tests/scripts -q` (87 passed)
- test-scope validation and generated-scope validation
- shell syntax checks for the local test entrypoints
- Python compile checks for test utilities
- workflow YAML parsing
- `actionlint` with existing repository-specific runner/source warnings ignored
- `ruff format --check` and `ruff check` for the changed Python test
- pre-commit and scoped pre-push checks

The host `tests/test.sh --unit --python` run reaches all local suites but cannot complete the two existing segmentation suites because host Python has no `pyneat`; full SDK/Modalix runtime validation remains assigned to Vulcan.

Closes #368