### PR TITLE
fix(release): install manifest-selected Core

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -48,9 +48,7 @@ jobs:
       ensure_sdk_container: true
       sdk_setup_args: "-y -n --minimal --workspace /mnt/vulcan/workspace --no-model-sdk --no-insight"
       artifact_name: neat-apps-build
-      artifact_path: |
-        neat-apps-*.tar.gz
-        deps/neat-core.json
+      artifact_path: neat-apps-*.tar.gz
       artifact_retention_days: 3
       build_command: |
         set -euo pipefail
@@ -148,11 +146,9 @@ jobs:
           exit 1
         fi
         test -f neat-apps-tests.tar.gz
-        test -f deps/neat-core.json
         scripts/ci/validate_apps_runtime_archive.sh "${runtime_archives[0]}"
-        python3 -m json.tool deps/neat-core.json >/dev/null
         tar -tzf neat-apps-tests.tar.gz neat-apps-tests/tests/test.sh >/dev/null
-        ls -lh "${runtime_archives[0]}" neat-apps-tests.tar.gz deps/neat-core.json
+        ls -lh "${runtime_archives[0]}" neat-apps-tests.tar.gz
 
   publish-vulcan-artifacts:
     name: Publish to Vulcan
@@ -170,7 +166,7 @@ jobs:
       artifact_folder: "."
       artifact_pattern: neat-apps-dist
       artifact_glob: "*"
-      min_artifact_count: 4
+      min_artifact_count: 3
 
   resolve-portal-publish-config:
     name: Resolve Portal Publish Config
@@ -222,16 +218,19 @@ jobs:
 
       - name: Install Apps Core for runtime tests
         run: |
+          set -euo pipefail
           artifact_base_url="${{ needs.resolve-vulcan-config.outputs.artifact_base_url }}"
+          mapfile -t runtime_archives < <(
+            find _vulcan-test/artifacts -maxdepth 1 -type f -name 'neat-apps-*.tar.gz' \
+              ! -name 'neat-apps-tests.tar.gz' | sort
+          )
+          if [[ "${#runtime_archives[@]}" -ne 1 ]]; then
+            echo "Expected exactly one runtime candidate, found ${#runtime_archives[@]}" >&2
+            exit 1
+          fi
           core_target="$(
-            python3 - _vulcan-test/artifacts/deps/neat-core.json <<'PY'
-          import json
-          import sys
-
-          with open(sys.argv[1], encoding="utf-8") as handle:
-              core = json.load(handle)["neat-core"]
-          print(f'{core["ref"]}-{core["spec"]}')
-          PY
+            tar -xOzf "${runtime_archives[0]}" prebuilt-apps/deps/neat-core.json \
+              | python3 -c 'import json, sys; core = json.load(sys.stdin)["neat-core"]; print("{}-{}".format(core["ref"], core["spec"]))'
           )"
           NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
             NEAT_CORE_INSTALL_MODE=vulcan \
@@ -253,8 +252,6 @@ jobs:
 
           mkdir -p _vulcan-test/package
           tar -xzf "${runtime_archives[0]}" -C _vulcan-test/package
-          mkdir -p _vulcan-test/package/deps
-          cp _vulcan-test/artifacts/deps/neat-core.json _vulcan-test/package/deps/
           (
             cd _vulcan-test/package
             NEAT_APPS_SKIP_DEPENDENCIES=1 \
@@ -318,8 +315,6 @@ jobs:
 
           cp "${runtime_archive}" dist/
           install -m 0755 scripts/install-vulcan-apps-package.sh dist/install_vulcan_apps_package.sh
-          mkdir -p dist/deps
-          cp _vulcan-test/artifacts/deps/neat-core.json dist/deps/
 
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             version="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -34,28 +34,10 @@ jobs:
     with:
       vulcan_env: ${{ vars.VULCAN_ENV || 'production' }}
 
-  resolve-core-context:
-    name: Resolve Core Context
-    runs-on: ubuntu-latest
-    outputs:
-      dependency_branch: ${{ steps.resolve.outputs.dependency_branch }}
-    steps:
-      - name: Select Core dependency branch
-        id: resolve
-        env:
-          DEPENDENCY_BRANCH: >-
-            ${{ (github.ref_type == 'tag' ||
-              github.ref_name == 'main' ||
-              startsWith(github.ref_name, 'release-') ||
-              github.base_ref == 'main') && 'main' || github.ref_name }}
-        run: echo "dependency_branch=${DEPENDENCY_BRANCH}" >> "${GITHUB_OUTPUT}"
-
   build:
     name: Build Apps on Vulcan
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    needs:
-      - resolve-core-context
-      - resolve-vulcan-config
+    needs: resolve-vulcan-config
     uses: sima-neat/.github/.github/workflows/vulcan-build.yml@main
     with:
       vulcan_env: ${{ needs.resolve-vulcan-config.outputs.vulcan_env }}
@@ -66,7 +48,9 @@ jobs:
       ensure_sdk_container: true
       sdk_setup_args: "-y -n --minimal --workspace /mnt/vulcan/workspace --no-model-sdk --no-insight"
       artifact_name: neat-apps-build
-      artifact_path: neat-apps-*.tar.gz
+      artifact_path: |
+        neat-apps-*.tar.gz
+        deps/neat-core.json
       artifact_retention_days: 3
       build_command: |
         set -euo pipefail
@@ -93,7 +77,6 @@ jobs:
           -e GITHUB_REF_NAME="${{ github.ref_name }}" \
           -e GITHUB_REF_TYPE="${{ github.ref_type }}" \
           -e GITHUB_SHA="${{ github.sha }}" \
-          -e NEAT_APPS_DEPENDENCY_BRANCH="${{ needs.resolve-core-context.outputs.dependency_branch }}" \
           -e NEAT_APPS_ARTIFACT_BRANCH_KEY="${{ github.head_ref || github.ref_name }}" \
           -e NEAT_APPS_ARTIFACT_SHORT_SHA="${{ github.sha }}" \
           -e NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
@@ -165,9 +148,11 @@ jobs:
           exit 1
         fi
         test -f neat-apps-tests.tar.gz
+        test -f deps/neat-core.json
         scripts/ci/validate_apps_runtime_archive.sh "${runtime_archives[0]}"
+        python3 -m json.tool deps/neat-core.json >/dev/null
         tar -tzf neat-apps-tests.tar.gz neat-apps-tests/tests/test.sh >/dev/null
-        ls -lh "${runtime_archives[0]}" neat-apps-tests.tar.gz
+        ls -lh "${runtime_archives[0]}" neat-apps-tests.tar.gz deps/neat-core.json
 
   publish-vulcan-artifacts:
     name: Publish to Vulcan
@@ -185,7 +170,7 @@ jobs:
       artifact_folder: "."
       artifact_pattern: neat-apps-dist
       artifact_glob: "*"
-      min_artifact_count: 3
+      min_artifact_count: 4
 
   resolve-portal-publish-config:
     name: Resolve Portal Publish Config
@@ -203,7 +188,6 @@ jobs:
     name: Test Apps Runtime
     needs:
       - build
-      - resolve-core-context
       - resolve-vulcan-config
       - resolve-test-runner
     runs-on:
@@ -236,14 +220,23 @@ jobs:
             echo "/usr/bin/fix_devkit_runtime.sh not found; continuing with existing devkit runtime state."
           fi
 
-      - name: Install snap Core for Apps tests
+      - name: Install Apps Core for runtime tests
         run: |
           artifact_base_url="${{ needs.resolve-vulcan-config.outputs.artifact_base_url }}"
-          NEAT_APPS_DEPENDENCY_BRANCH="${{ needs.resolve-core-context.outputs.dependency_branch }}" \
-            NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
+          core_target="$(
+            python3 - _vulcan-test/artifacts/deps/neat-core.json <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              core = json.load(handle)["neat-core"]
+          print(f'{core["ref"]}-{core["spec"]}')
+          PY
+          )"
+          NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
             NEAT_CORE_INSTALL_MODE=vulcan \
             NEAT_VULCAN_ENV="${{ needs.resolve-vulcan-config.outputs.vulcan_env }}" \
-            ./build.sh --only-install-neat-core
+            ./build.sh --only-install-neat-core --neat-core-version "${core_target}"
 
       - name: Install runtime candidate and overlay tests
         run: |
@@ -260,6 +253,8 @@ jobs:
 
           mkdir -p _vulcan-test/package
           tar -xzf "${runtime_archives[0]}" -C _vulcan-test/package
+          mkdir -p _vulcan-test/package/deps
+          cp _vulcan-test/artifacts/deps/neat-core.json _vulcan-test/package/deps/
           (
             cd _vulcan-test/package
             NEAT_APPS_SKIP_DEPENDENCIES=1 \
@@ -323,6 +318,8 @@ jobs:
 
           cp "${runtime_archive}" dist/
           install -m 0755 scripts/install-vulcan-apps-package.sh dist/install_vulcan_apps_package.sh
+          mkdir -p dist/deps
+          cp _vulcan-test/artifacts/deps/neat-core.json dist/deps/
 
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             version="${GITHUB_REF_NAME#v}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tests/.env.local
 tests/configs/.env.local
 .neat-core-installed
 deps/debs/
+deps/neat-core.json
 portal/node_modules/
 portal/.vite/
 portal/dist/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sima-cli neat install apps
 cd prebuilt-apps
 ```
 
-The Apps installer installs the latest Core and Insight versions from main. The installed bundle is placed under `prebuilt-apps/`. Run the remaining commands from that directory.
+The Apps installer installs the Core selected for the Apps package and installs Insight through `sima-cli`. The installed bundle is placed under `prebuilt-apps/`. Run the remaining commands from that directory.
 
 ## Run an Example
 
@@ -124,7 +124,7 @@ curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-exa
 
 ## Dependency Selection
 
-`deps/manifest.json` keeps Core on the `snap` policy for source builds and records the SDK channel and platform version. It does not pin Insight. The Apps installer uses bare `core` and `insight` targets, which `sima-cli` resolves to the latest versions from main.
+`deps/manifest.json` selects Core and records the SDK channel and platform version. Development uses the `snap` policy, while a release-preparation branch can select an exact Core artifact. Vulcan records the resolved Core target under package metadata and the Apps installer uses that same target. Insight is not pinned in the Apps manifest.
 
 ## Support
 

--- a/build.sh
+++ b/build.sh
@@ -151,7 +151,15 @@ package_distribution() {
   mkdir -p \
     "${stage_dir}/examples" \
     "${stage_dir}/assets" \
+    "${stage_dir}/deps" \
     "${test_stage_dir}/examples"
+
+  if [[ ! -f "${NEAT_CORE_METADATA}" ]]; then
+    echo "ERROR: missing resolved Core metadata: ${NEAT_CORE_METADATA}" >&2
+    rm -rf "${stage_root}"
+    return 1
+  fi
+  cp "${NEAT_CORE_METADATA}" "${stage_dir}/deps/neat-core.json"
 
   while IFS= read -r cpp_dir; do
     local rel target_dir

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPS_DIR="${NEAT_APPS_TEST_DEPS_DIR:-${ROOT_DIR}/deps}"
 APPS_MANIFEST="${DEPS_DIR}/manifest.json"
+NEAT_CORE_METADATA="${DEPS_DIR}/neat-core.json"
 NEAT_DEBS_DIR="${DEPS_DIR}/debs"
 NEAT_INSTALLER_URL="${NEAT_INSTALLER_URL:-https://tools.sima-neat.com/install-neat.sh}"
 NEAT_ARTIFACTS_BASE_URL="${NEAT_ARTIFACTS_BASE_URL:-https://artifacts.neat.sima.ai/core}"
@@ -395,11 +396,11 @@ current_dependency_branch() {
     printf '%s\n' "${NEAT_APPS_DEPENDENCY_BRANCH}"
     return 0
   fi
-  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-    printf '%s\n' "${GITHUB_BASE_REF}"
+  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    printf '%s\n' "${GITHUB_HEAD_REF}"
     return 0
   fi
-  if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+  if [[ "${GITHUB_REF_TYPE:-}" != "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
     printf '%s\n' "${GITHUB_REF_NAME}"
     return 0
   fi
@@ -420,28 +421,6 @@ current_dependency_tag() {
     return 0
   fi
   printf '\n'
-}
-
-protected_manifest_branch_context() {
-  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-    printf '%s\n' "${GITHUB_BASE_REF}"
-    return 0
-  fi
-  if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
-    printf '%s\n' "${GITHUB_REF_NAME}"
-    return 0
-  fi
-  if command -v git >/dev/null 2>&1 && git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null
-    return 0
-  fi
-  echo ""
-}
-
-is_protected_manifest_context() {
-  local branch
-  branch="$(protected_manifest_branch_context)"
-  [[ "${branch}" == "main" || "${branch}" == "develop" ]]
 }
 
 core_branch_exists() {
@@ -704,15 +683,7 @@ validate_explicit_core_ref() {
 }
 
 resolve_empty_neat_core_branch() {
-  local branch tag
-  if [[ -z "${NEAT_APPS_DEPENDENCY_BRANCH:-}" ]]; then
-    tag="$(current_dependency_tag)"
-    if [[ -n "${tag}" ]]; then
-      printf '%s\n' "${tag}"
-      return 0
-    fi
-  fi
-
+  local branch
   branch="$(current_dependency_branch)"
 
   if [[ "${branch}" == "main" || "${branch}" == "develop" ]]; then
@@ -755,11 +726,6 @@ resolve_neat_core_target() {
   fi
 
   if [[ -n "${manifest_core}" ]]; then
-    if is_protected_manifest_context; then
-      echo "ERROR: ${APPS_MANIFEST} must keep neat-core as policy=snap on main/develop." >&2
-      return 1
-    fi
-
     if [[ "${manifest_core}" == *":"* ]]; then
       branch="${manifest_core%%:*}"
       version="${manifest_core#*:}"
@@ -775,6 +741,21 @@ resolve_neat_core_target() {
     printf '%s\n%s\n' "${branch}" "${version}"
     return 0
   fi
+}
+
+write_neat_core_metadata() {
+  local ref="$1"
+  local spec="$2"
+  mkdir -p "$(dirname "${NEAT_CORE_METADATA}")"
+  python3 - "${NEAT_CORE_METADATA}" "${ref}" "${spec}" <<'PY'
+import json
+import sys
+
+path, ref, spec = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump({"neat-core": {"ref": ref, "spec": spec}}, handle, indent=2)
+    handle.write("\n")
+PY
 }
 
 load_neat_core_target() {
@@ -832,7 +813,7 @@ run_sima_cli_core_install() {
 }
 
 ensure_neat_core() {
-  local branch exact_tag install_mode sima_cli_bin version vulcan_env
+  local branch install_mode sima_cli_bin version vulcan_env
   mkdir -p "${DEPS_DIR}" "${NEAT_DEBS_DIR}"
   load_neat_core_target
   branch="${NEAT_CORE_TARGET_BRANCH}"
@@ -851,14 +832,10 @@ ensure_neat_core() {
 
   # Resolve "latest" to an exact tag before checking installed state.
   if [[ "${version}" == "latest" ]]; then
-    if ! version="$(resolve_latest_version "${branch}")"; then
-      exact_tag="$(current_dependency_tag)"
-      if [[ -n "${exact_tag}" && "${branch}" == "${exact_tag}" ]]; then
-        echo "ERROR: Failed to resolve exact tag-snap NEAT core artifact for tag '${branch}'." >&2
-      fi
-      exit 1
-    fi
+    version="$(resolve_latest_version "${branch}")" || exit 1
   fi
+  NEAT_CORE_TARGET_VERSION="${version}"
+  write_neat_core_metadata "${branch}" "${version}"
 
   local expected_tag="${branch}/${version}"
   if neat_core_installed_matches "${branch}" "${version}" "${vulcan_env:-}"; then
@@ -954,13 +931,7 @@ if [[ "${INSTALL_CORE}" -eq 1 ]]; then
   NEAT_CORE_DISPLAY_BRANCH="${NEAT_CORE_TARGET_BRANCH}"
   NEAT_CORE_DISPLAY_VERSION="${NEAT_CORE_TARGET_VERSION}"
   if [[ "${NEAT_CORE_DISPLAY_VERSION}" == "latest" ]]; then
-    if ! NEAT_CORE_DISPLAY_VERSION="$(resolve_latest_version "${NEAT_CORE_DISPLAY_BRANCH}")"; then
-      exact_tag="$(current_dependency_tag)"
-      if [[ -n "${exact_tag}" && "${NEAT_CORE_DISPLAY_BRANCH}" == "${exact_tag}" ]]; then
-        echo "ERROR: Failed to resolve exact tag-snap NEAT core artifact for tag '${NEAT_CORE_DISPLAY_BRANCH}'." >&2
-      fi
-      exit 1
-    fi
+    NEAT_CORE_DISPLAY_VERSION="$(resolve_latest_version "${NEAT_CORE_DISPLAY_BRANCH}")" || exit 1
   fi
 fi
 

--- a/scripts/ci/validate_apps_runtime_archive.sh
+++ b/scripts/ci/validate_apps_runtime_archive.sh
@@ -10,6 +10,7 @@ fi
 runtime_root="prebuilt-apps"
 
 python3 - "${archive}" "${runtime_root}" <<'PY'
+import json
 import sys
 import tarfile
 from pathlib import PurePosixPath
@@ -25,6 +26,7 @@ def fail(message: str) -> None:
 
 with tarfile.open(archive, "r:gz") as bundle:
     members = bundle.getmembers()
+    core_metadata_name = f"{root}/deps/neat-core.json"
     text_suffixes = {
         ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp",
         ".json", ".md", ".py", ".sh", ".yaml", ".yml",
@@ -45,6 +47,8 @@ with tarfile.open(archive, "r:gz") as bundle:
             fail(f"runtime archive contains an unsafe path: {member.name}")
         if member.name != root and not member.name.startswith(prefix):
             fail(f"runtime archive member is outside {root}/: {member.name}")
+        if path.name == "neat-core.json" and member.name != core_metadata_name:
+            fail(f"Core metadata is outside {core_metadata_name}: {member.name}")
         if member.isfile() and member.name.endswith(model_suffixes):
             fail(f"runtime archive contains a packaged model: {member.name}")
         if (
@@ -67,11 +71,29 @@ with tarfile.open(archive, "r:gz") as bundle:
             content = source.read() if source is not None else b""
             if any(reference in content for reference in obsolete_references):
                 fail(f"runtime archive contains an obsolete path reference: {member.name}")
+
+    try:
+        core_metadata = bundle.getmember(core_metadata_name)
+    except KeyError:
+        fail(f"runtime archive is missing {core_metadata_name}")
+    if not core_metadata.isfile():
+        fail(f"runtime archive is missing {core_metadata_name}")
+    source = bundle.extractfile(core_metadata)
+    data = json.load(source)
+    core = data.get("neat-core")
+    if not isinstance(core, dict):
+        fail(f"invalid Core metadata in {core_metadata_name}")
+    ref = core.get("ref")
+    spec = core.get("spec")
+    if not isinstance(ref, str) or not ref.strip():
+        fail(f"invalid Core ref in {core_metadata_name}")
+    if not isinstance(spec, str) or not spec.strip() or spec == "latest":
+        fail(f"invalid Core spec in {core_metadata_name}")
 PY
 
 members="$(tar -tzf "${archive}")"
 
-forbidden='(^|/)(manifest\.json|neat-core\.json|models|portal|tests|test-scope\.yaml|CMakeLists\.txt|CTestTestfile\.cmake|cmake_install\.cmake|Makefile|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(a|pyc|pyo|log|db|lock)$'
+forbidden='(^|/)(manifest\.json|models|portal|tests|test-scope\.yaml|CMakeLists\.txt|CTestTestfile\.cmake|cmake_install\.cmake|Makefile|[^/]+_(unit|e2e)_test|sandbox[^/]*|__pycache__)(/|$)|\.(a|pyc|pyo|log|db|lock)$'
 if grep -E "${forbidden}" <<<"${members}"; then
   echo "Runtime archive contains non-runtime or generated files." >&2
   exit 1

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -11,11 +11,8 @@ DEPS_MARKER_VALUE="sima-neat/apps"
 CORE_INSTALL_DIR="${DEPS_DIR}/core"
 INSIGHT_INSTALL_DIR="${DEPS_DIR}/insight"
 DEPS_WORKSPACE_ACTIVE=0
-PACKAGE_DEPS_OWNED=0
 PACKAGE_DIR="$(pwd -P)"
-PACKAGE_DEPS_DIR="${PACKAGE_DIR}/deps"
-CORE_METADATA_PATH="${PACKAGE_DEPS_DIR}/neat-core.json"
-FLAT_CORE_METADATA_PATH="${PACKAGE_DIR}/neat-core.json"
+CORE_METADATA_PATH=""
 PACKAGE_EXTRACT_DIR=""
 PACKAGE_ARCHIVE=""
 
@@ -83,25 +80,12 @@ cleanup_dependency_workspace() {
     echo "ERROR: refusing to remove dependency workspace without its ownership marker: ${DEPS_DIR}" >&2
     return 1
   fi
-  if [[ "${PACKAGE_DEPS_OWNED}" == "1" \
-    && "$(cd "${DEPS_DIR}" && pwd -P)" == "${PACKAGE_DEPS_DIR}" ]]; then
-    rm -rf "${CORE_INSTALL_DIR}" "${INSIGHT_INSTALL_DIR}"
-    rm -f "${DEPS_MARKER}"
-    DEPS_WORKSPACE_ACTIVE=0
-    return 0
-  fi
   rm -rf "${DEPS_DIR}"
   DEPS_WORKSPACE_ACTIVE=0
 }
 
 prepare_dependency_workspace() {
   if [[ -e "${DEPS_DIR}" || -L "${DEPS_DIR}" ]]; then
-    if [[ "${PACKAGE_DEPS_OWNED}" == "1" && -d "${DEPS_DIR}" && ! -L "${DEPS_DIR}" \
-      && "$(cd "${DEPS_DIR}" && pwd -P)" == "${PACKAGE_DEPS_DIR}" ]]; then
-      printf '%s\n' "${DEPS_MARKER_VALUE}" >"${DEPS_MARKER}"
-      DEPS_WORKSPACE_ACTIVE=1
-      return 0
-    fi
     if ! dependency_workspace_is_owned; then
       echo "ERROR: refusing to replace unowned dependency workspace: ${DEPS_DIR}" >&2
       return 1
@@ -166,10 +150,6 @@ cleanup_package_staging() {
   fi
   if [[ -n "${PACKAGE_ARCHIVE}" ]]; then
     rm -f "${PACKAGE_ARCHIVE}"
-  fi
-  if [[ "${PACKAGE_DEPS_OWNED}" == "1" ]]; then
-    rm -f "${CORE_METADATA_PATH}"
-    rmdir "${PACKAGE_DEPS_DIR}" 2>/dev/null || true
   fi
   rm -f "${PACKAGE_DIR}/install_vulcan_apps_package.sh"
 }
@@ -276,12 +256,7 @@ fi
 
 locate_package_staging
 
-if [[ ! -e "${CORE_METADATA_PATH}" && ! -L "${CORE_METADATA_PATH}" \
-  && -f "${FLAT_CORE_METADATA_PATH}" && ! -L "${FLAT_CORE_METADATA_PATH}" ]]; then
-  mkdir -p "${PACKAGE_DEPS_DIR}"
-  mv "${FLAT_CORE_METADATA_PATH}" "${CORE_METADATA_PATH}"
-fi
-
+CORE_METADATA_PATH="${RUNTIME_SRC}/deps/neat-core.json"
 if [[ ! -f "${CORE_METADATA_PATH}" || -L "${CORE_METADATA_PATH}" ]]; then
   echo "ERROR: Apps package is missing ${CORE_METADATA_PATH}." >&2
   exit 1
@@ -292,12 +267,6 @@ if ! CORE_TARGET="$(extract_neat_core_target)"; then
 fi
 CORE_REF="$(printf '%s\n' "${CORE_TARGET}" | sed -n '1p')"
 CORE_SPEC="$(printf '%s\n' "${CORE_TARGET}" | sed -n '2p')"
-if [[ -n "$(find "${PACKAGE_DEPS_DIR}" -mindepth 1 -maxdepth 1 \
-  ! -name neat-core.json -print -quit)" ]]; then
-  echo "ERROR: refusing unexpected entries in package dependency metadata: ${PACKAGE_DEPS_DIR}." >&2
-  exit 1
-fi
-PACKAGE_DEPS_OWNED=1
 
 if [[ "${NEAT_APPS_SKIP_DEPENDENCIES:-0}" == "1" ]]; then
   echo

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -11,7 +11,11 @@ DEPS_MARKER_VALUE="sima-neat/apps"
 CORE_INSTALL_DIR="${DEPS_DIR}/core"
 INSIGHT_INSTALL_DIR="${DEPS_DIR}/insight"
 DEPS_WORKSPACE_ACTIVE=0
+PACKAGE_DEPS_OWNED=0
 PACKAGE_DIR="$(pwd -P)"
+PACKAGE_DEPS_DIR="${PACKAGE_DIR}/deps"
+CORE_METADATA_PATH="${PACKAGE_DEPS_DIR}/neat-core.json"
+FLAT_CORE_METADATA_PATH="${PACKAGE_DIR}/neat-core.json"
 PACKAGE_EXTRACT_DIR=""
 PACKAGE_ARCHIVE=""
 
@@ -39,6 +43,32 @@ resolve_sima_cli_bin() {
   return 1
 }
 
+extract_neat_core_target() {
+  python3 - "${CORE_METADATA_PATH}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    core = json.load(handle).get("neat-core")
+
+if not isinstance(core, dict):
+    raise SystemExit(1)
+
+ref = core.get("ref")
+spec = core.get("spec")
+if not isinstance(ref, str) or not isinstance(spec, str):
+    raise SystemExit(1)
+
+ref = ref.strip()
+spec = spec.strip()
+if not ref or not spec or spec == "latest":
+    raise SystemExit(1)
+
+print(ref)
+print(spec)
+PY
+}
+
 dependency_workspace_is_owned() {
   [[ -d "${DEPS_DIR}" && ! -L "${DEPS_DIR}" \
     && -f "${DEPS_MARKER}" && ! -L "${DEPS_MARKER}" ]] \
@@ -53,12 +83,25 @@ cleanup_dependency_workspace() {
     echo "ERROR: refusing to remove dependency workspace without its ownership marker: ${DEPS_DIR}" >&2
     return 1
   fi
+  if [[ "${PACKAGE_DEPS_OWNED}" == "1" \
+    && "$(cd "${DEPS_DIR}" && pwd -P)" == "${PACKAGE_DEPS_DIR}" ]]; then
+    rm -rf "${CORE_INSTALL_DIR}" "${INSIGHT_INSTALL_DIR}"
+    rm -f "${DEPS_MARKER}"
+    DEPS_WORKSPACE_ACTIVE=0
+    return 0
+  fi
   rm -rf "${DEPS_DIR}"
   DEPS_WORKSPACE_ACTIVE=0
 }
 
 prepare_dependency_workspace() {
   if [[ -e "${DEPS_DIR}" || -L "${DEPS_DIR}" ]]; then
+    if [[ "${PACKAGE_DEPS_OWNED}" == "1" && -d "${DEPS_DIR}" && ! -L "${DEPS_DIR}" \
+      && "$(cd "${DEPS_DIR}" && pwd -P)" == "${PACKAGE_DEPS_DIR}" ]]; then
+      printf '%s\n' "${DEPS_MARKER_VALUE}" >"${DEPS_MARKER}"
+      DEPS_WORKSPACE_ACTIVE=1
+      return 0
+    fi
     if ! dependency_workspace_is_owned; then
       echo "ERROR: refusing to replace unowned dependency workspace: ${DEPS_DIR}" >&2
       return 1
@@ -124,9 +167,11 @@ cleanup_package_staging() {
   if [[ -n "${PACKAGE_ARCHIVE}" ]]; then
     rm -f "${PACKAGE_ARCHIVE}"
   fi
-  rm -f \
-    "${PACKAGE_DIR}/install_vulcan_apps_package.sh" \
-    "${PACKAGE_DIR}/neat-core.json"
+  if [[ "${PACKAGE_DEPS_OWNED}" == "1" ]]; then
+    rm -f "${CORE_METADATA_PATH}"
+    rmdir "${PACKAGE_DEPS_DIR}" 2>/dev/null || true
+  fi
+  rm -f "${PACKAGE_DIR}/install_vulcan_apps_package.sh"
 }
 
 promote_apps_runtime() {
@@ -231,6 +276,29 @@ fi
 
 locate_package_staging
 
+if [[ ! -e "${CORE_METADATA_PATH}" && ! -L "${CORE_METADATA_PATH}" \
+  && -f "${FLAT_CORE_METADATA_PATH}" && ! -L "${FLAT_CORE_METADATA_PATH}" ]]; then
+  mkdir -p "${PACKAGE_DEPS_DIR}"
+  mv "${FLAT_CORE_METADATA_PATH}" "${CORE_METADATA_PATH}"
+fi
+
+if [[ ! -f "${CORE_METADATA_PATH}" || -L "${CORE_METADATA_PATH}" ]]; then
+  echo "ERROR: Apps package is missing ${CORE_METADATA_PATH}." >&2
+  exit 1
+fi
+if ! CORE_TARGET="$(extract_neat_core_target)"; then
+  echo "ERROR: invalid Core dependency metadata: ${CORE_METADATA_PATH}." >&2
+  exit 1
+fi
+CORE_REF="$(printf '%s\n' "${CORE_TARGET}" | sed -n '1p')"
+CORE_SPEC="$(printf '%s\n' "${CORE_TARGET}" | sed -n '2p')"
+if [[ -n "$(find "${PACKAGE_DEPS_DIR}" -mindepth 1 -maxdepth 1 \
+  ! -name neat-core.json -print -quit)" ]]; then
+  echo "ERROR: refusing unexpected entries in package dependency metadata: ${PACKAGE_DEPS_DIR}." >&2
+  exit 1
+fi
+PACKAGE_DEPS_OWNED=1
+
 if [[ "${NEAT_APPS_SKIP_DEPENDENCIES:-0}" == "1" ]]; then
   echo
   echo "WARNING: Skipping Core and Insight dependency installation."
@@ -241,17 +309,19 @@ else
   }
 
   echo
-  echo "Installing the latest Core version from main:"
+  echo "Installing the Core selected by Apps:"
+  echo "  Ref        : ${CORE_REF}"
+  echo "  Spec       : ${CORE_SPEC}"
   trap cleanup_dependency_workspace EXIT
   prepare_dependency_workspace
   echo "  Scratch dir: ${CORE_INSTALL_DIR}"
   run_sima_cli_install "${CORE_INSTALL_DIR}" "${SIMA_CLI_RESOLVED}" \
     -d . \
     -t minimal \
-    core
+    "core@${CORE_REF}:${CORE_SPEC}"
 
   echo
-  echo "Installing the latest Insight version from main:"
+  echo "Installing Insight through sima-cli:"
   echo "  Scratch dir: ${INSIGHT_INSTALL_DIR}"
   run_sima_cli_install "${INSIGHT_INSTALL_DIR}" "${SIMA_CLI_RESOLVED}" \
     -d . \

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -358,9 +358,21 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
     return bin_dir
 
 
-def _write_vulcan_runtime(package_dir: Path) -> Path:
+def _write_vulcan_runtime(
+    package_dir: Path,
+    core: object | None = None,
+    metadata_dir: Path | None = None,
+) -> Path:
     runtime_dir = package_dir / "prebuilt-apps"
     runtime_dir.mkdir(parents=True)
+    if core is None:
+        core = {"ref": "develop", "spec": "core-sha"}
+    deps_dir = (metadata_dir or package_dir) / "deps"
+    deps_dir.mkdir(parents=True)
+    (deps_dir / "neat-core.json").write_text(
+        json.dumps({"neat-core": core}),
+        encoding="utf-8",
+    )
     return runtime_dir
 
 
@@ -537,6 +549,9 @@ def test_snap_manifest_resolves_from_dependency_branch(tmp_path):
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert _installer_args(tmp_path) == "--minimum develop devsha1"
     assert _curl_log(tmp_path).count("https://core.test/develop/latest.tag") == 1
+    assert json.loads(
+        (tmp_path / "deps" / "neat-core.json").read_text(encoding="utf-8")
+    ) == {"neat-core": {"ref": "develop", "spec": "devsha1"}}
 
 
 def test_empty_manifest_custom_branch_uses_matching_core_artifact_once(tmp_path):
@@ -665,28 +680,35 @@ def test_explicit_manifest_fails_when_artifact_is_invalid(tmp_path):
     assert "unavailable NEAT core artifact" in proc.stderr
 
 
-def test_protected_branch_rejects_explicit_manifest_value(tmp_path):
+def test_explicit_manifest_is_used_for_pr_into_main(tmp_path):
     proc = _run_build(
         tmp_path,
-        neat_core="main-mainsha1",
+        neat_core={"ref": "main", "spec": "mainsha1"},
         args=["--only-install-neat-core"],
-        env={"GITHUB_REF_NAME": "main"},
+        env={**_installer_env(tmp_path), "GITHUB_BASE_REF": "main"},
     )
 
-    assert proc.returncode != 0
-    assert "must keep neat-core as policy=snap on main/develop" in proc.stderr
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == "--minimum main mainsha1"
+    assert json.loads(
+        (tmp_path / "deps" / "neat-core.json").read_text(encoding="utf-8")
+    ) == {"neat-core": {"ref": "main", "spec": "mainsha1"}}
 
 
-def test_protected_branch_rejects_explicit_dependency_object_manifest(tmp_path):
+def test_snap_manifest_uses_pr_source_branch(tmp_path):
     proc = _run_build(
         tmp_path,
-        neat_core={"branch": "main", "spec": "mainsha1"},
+        neat_core={"policy": "snap"},
         args=["--only-install-neat-core"],
-        env={"GITHUB_REF_NAME": "main"},
+        env={
+            **_installer_env(tmp_path),
+            "GITHUB_BASE_REF": "main",
+            "GITHUB_HEAD_REF": "zz-core-artifact-for-test",
+        },
     )
 
-    assert proc.returncode != 0
-    assert "must keep neat-core as policy=snap on main/develop" in proc.stderr
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _installer_args(tmp_path) == ("--minimum zz-core-artifact-for-test featsha1")
 
 
 def test_unsupported_manifest_object_fails(tmp_path):
@@ -698,43 +720,6 @@ def test_unsupported_manifest_object_fails(tmp_path):
 
     assert proc.returncode != 0
     assert "unsupported neat-core.policy" in proc.stderr
-
-
-def test_snap_manifest_tag_build_uses_matching_core_tag(tmp_path):
-    proc = _run_build(
-        tmp_path,
-        args=["--only-install-neat-core"],
-        env={
-            **_installer_env(tmp_path),
-            "GITHUB_REF_TYPE": "tag",
-            "GITHUB_REF_NAME": "v2.1.0",
-            "NEAT_APPS_TEST_LATEST_TAGS": "\n".join(
-                [
-                    "develop=devsha1",
-                    "v2.1.0=tagsha1",
-                ]
-            ),
-        },
-    )
-
-    assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert _installer_args(tmp_path) == "--minimum v2.1.0 tagsha1"
-    assert "https://core.test/v2.1.0/latest.tag" in _curl_log(tmp_path)
-
-
-def test_snap_manifest_tag_build_fails_without_matching_core_tag(tmp_path):
-    proc = _run_build(
-        tmp_path,
-        args=["--only-install-neat-core"],
-        env={
-            "GITHUB_REF_TYPE": "tag",
-            "GITHUB_REF_NAME": "v9.9.9",
-        },
-    )
-
-    assert proc.returncode != 0
-    assert "exact tag-snap NEAT core artifact" in proc.stderr
-    assert "using develop-latest" not in proc.stderr
 
 
 def test_core_installer_runs_from_deps_debs_scratch_dir(tmp_path):
@@ -833,25 +818,78 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
     assert (tmp_path / "sima-cli-args.txt").read_text(
         encoding="utf-8"
     ).splitlines() == [
-        "neat install -d . -t minimal core",
+        "neat install -d . -t minimal core@develop:core-sha",
         "neat install -d . insight",
     ]
     assert not (package_dir / "deps").exists()
     assert f"  {install_dir}" in proc.stdout
 
 
+def test_vulcan_installer_rejects_missing_core_metadata_before_promotion(tmp_path):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir)
+    (package_dir / "deps" / "neat-core.json").unlink()
+    install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
+
+    assert proc.returncode != 0
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+
+
+def test_vulcan_installer_rejects_mutable_core_metadata(tmp_path):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir, {"ref": "main", "spec": "latest"})
+
+    proc = _run_vulcan_installer(tmp_path, package_dir)
+
+    assert proc.returncode != 0
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+
+
+def test_vulcan_installer_refuses_unowned_package_deps(tmp_path):
+    package_dir = tmp_path / "package"
+    _write_vulcan_runtime(package_dir)
+    user_file = package_dir / "deps" / "user-file"
+    user_file.write_text("keep\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir)
+
+    assert proc.returncode != 0
+    assert user_file.read_text(encoding="utf-8") == "keep\n"
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+
+
+def test_vulcan_installer_normalizes_flattened_core_metadata(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
+    (package_dir / "deps" / "neat-core.json").rename(package_dir / "neat-core.json")
+    (package_dir / "deps").rmdir()
+
+    proc = _run_vulcan_installer(tmp_path, package_dir)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (package_dir / "prebuilt-apps" / "runtime-marker").read_text(
+        encoding="utf-8"
+    ) == "new\n"
+    assert not (package_dir / "neat-core.json").exists()
+    assert not (package_dir / "deps").exists()
+
+
 def test_vulcan_installer_removes_downloaded_package_staging(tmp_path):
     package_dir = tmp_path / "package"
     package_name = "neat-apps-integration-apps-runtime-bundle-deadbeef"
     extracted_dir = package_dir / package_name
-    runtime_dir = _write_vulcan_runtime(extracted_dir)
+    runtime_dir = _write_vulcan_runtime(extracted_dir, metadata_dir=package_dir)
     (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
     archive = package_dir / f"{package_name}.tar.gz"
     archive.write_text("archive\n", encoding="utf-8")
     install_script = package_dir / "install_vulcan_apps_package.sh"
     install_script.write_text("installer\n", encoding="utf-8")
-    legacy_metadata = package_dir / "neat-core.json"
-    legacy_metadata.write_text("{}\n", encoding="utf-8")
     unrelated = package_dir / "keep.txt"
     unrelated.write_text("keep\n", encoding="utf-8")
 
@@ -864,7 +902,7 @@ def test_vulcan_installer_removes_downloaded_package_staging(tmp_path):
     assert not extracted_dir.exists()
     assert not archive.exists()
     assert not install_script.exists()
-    assert not legacy_metadata.exists()
+    assert not (package_dir / "deps").exists()
     assert unrelated.read_text(encoding="utf-8") == "keep\n"
 
 
@@ -888,17 +926,17 @@ def test_vulcan_installer_can_skip_dependency_installation(tmp_path):
     assert "Skipping Core and Insight dependency installation" in proc.stdout
 
 
-def test_vulcan_runtime_gate_uses_snap_core_without_customer_dependencies():
+def test_vulcan_runtime_gate_uses_packaged_core_without_customer_dependencies():
     workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "./build.sh --only-install-neat-core" in workflow
+    assert "deps/neat-core.json" in workflow
+    assert "--neat-core-version" in workflow
     assert "NEAT_CORE_INSTALL_MODE=vulcan" in workflow
     assert "NEAT_APPS_SKIP_DEPENDENCIES=1" in workflow
 
 
-def test_vulcan_uses_one_core_context_for_build_and_runtime_tests():
+def test_vulcan_does_not_override_manifest_core_context():
     workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
-    dependency_output = "needs.resolve-core-context.outputs.dependency_branch"
 
     assert "pull_request:\n    branches:\n      - main" in workflow
     assert (
@@ -906,12 +944,8 @@ def test_vulcan_uses_one_core_context_for_build_and_runtime_tests():
         "github.event.pull_request.head.repo.full_name == github.repository }}"
         in workflow
     )
-    assert "github.ref_type == 'tag'" in workflow
-    assert "github.ref_name == 'main'" in workflow
-    assert "startsWith(github.ref_name, 'release-')" in workflow
-    assert "github.base_ref == 'main'" in workflow
-    assert "&& 'main' || github.ref_name" in workflow
-    assert workflow.count(dependency_output) == 2
+    assert "resolve-core-context" not in workflow
+    assert "NEAT_APPS_DEPENDENCY_BRANCH" not in workflow
     assert (
         'NEAT_APPS_ARTIFACT_BRANCH_KEY="${{ github.head_ref || github.ref_name }}"'
         in workflow
@@ -967,7 +1001,7 @@ def test_vulcan_installer_keeps_existing_runtime_when_insight_install_fails(tmp_
     assert (tmp_path / "sima-cli-args.txt").read_text(
         encoding="utf-8"
     ).splitlines() == [
-        "neat install -d . -t minimal core",
+        "neat install -d . -t minimal core@develop:core-sha",
         "neat install -d . insight",
     ]
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -31,9 +31,17 @@ def _write_runtime_archive(
     executable_members: tuple[str, ...] = (),
     extra_archive_members: tuple[str, ...] = (),
     member_contents: dict[str, str] | None = None,
+    include_core_metadata: bool = True,
 ) -> Path:
     archive_root = tmp_path / "archive-root" / root_name
     archive_root.mkdir(parents=True)
+    if include_core_metadata:
+        core_metadata = archive_root / "deps/neat-core.json"
+        core_metadata.parent.mkdir(parents=True)
+        core_metadata.write_text(
+            json.dumps({"neat-core": {"ref": "develop", "spec": "core-sha"}}),
+            encoding="utf-8",
+        )
     for member in members:
         path = archive_root / member
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -67,6 +75,13 @@ def test_runtime_archive_validator_accepts_shipped_datasets(tmp_path):
     proc = _validate_runtime_archive(archive)
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
+
+
+def test_runtime_archive_validator_rejects_missing_core_metadata(tmp_path):
+    archive = _write_runtime_archive(tmp_path, include_core_metadata=False)
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
 
 
 def test_runtime_archive_validator_rejects_legacy_root(tmp_path):
@@ -361,13 +376,12 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
 def _write_vulcan_runtime(
     package_dir: Path,
     core: object | None = None,
-    metadata_dir: Path | None = None,
 ) -> Path:
     runtime_dir = package_dir / "prebuilt-apps"
     runtime_dir.mkdir(parents=True)
     if core is None:
         core = {"ref": "develop", "spec": "core-sha"}
-    deps_dir = (metadata_dir or package_dir) / "deps"
+    deps_dir = runtime_dir / "deps"
     deps_dir.mkdir(parents=True)
     (deps_dir / "neat-core.json").write_text(
         json.dumps({"neat-core": core}),
@@ -811,6 +825,9 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
     assert not (install_dir / "neat-apps-runtime").exists()
+    assert json.loads(
+        (install_dir / "deps/neat-core.json").read_text(encoding="utf-8")
+    ) == {"neat-core": {"ref": "develop", "spec": "core-sha"}}
     assert (tmp_path / "sima-cli-cwd.txt").read_text(encoding="utf-8").splitlines() == [
         str(package_dir / "deps" / "core"),
         str(package_dir / "deps" / "insight"),
@@ -827,8 +844,8 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
 
 def test_vulcan_installer_rejects_missing_core_metadata_before_promotion(tmp_path):
     package_dir = tmp_path / "package"
-    _write_vulcan_runtime(package_dir)
-    (package_dir / "deps" / "neat-core.json").unlink()
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "deps" / "neat-core.json").unlink()
     install_dir = tmp_path / "installed" / "prebuilt-apps"
     install_dir.mkdir(parents=True)
     (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
@@ -850,41 +867,11 @@ def test_vulcan_installer_rejects_mutable_core_metadata(tmp_path):
     assert not (tmp_path / "sima-cli-args.txt").exists()
 
 
-def test_vulcan_installer_refuses_unowned_package_deps(tmp_path):
-    package_dir = tmp_path / "package"
-    _write_vulcan_runtime(package_dir)
-    user_file = package_dir / "deps" / "user-file"
-    user_file.write_text("keep\n", encoding="utf-8")
-
-    proc = _run_vulcan_installer(tmp_path, package_dir)
-
-    assert proc.returncode != 0
-    assert user_file.read_text(encoding="utf-8") == "keep\n"
-    assert not (tmp_path / "sima-cli-args.txt").exists()
-
-
-def test_vulcan_installer_normalizes_flattened_core_metadata(tmp_path):
-    package_dir = tmp_path / "package"
-    runtime_dir = _write_vulcan_runtime(package_dir)
-    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
-    (package_dir / "deps" / "neat-core.json").rename(package_dir / "neat-core.json")
-    (package_dir / "deps").rmdir()
-
-    proc = _run_vulcan_installer(tmp_path, package_dir)
-
-    assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert (package_dir / "prebuilt-apps" / "runtime-marker").read_text(
-        encoding="utf-8"
-    ) == "new\n"
-    assert not (package_dir / "neat-core.json").exists()
-    assert not (package_dir / "deps").exists()
-
-
 def test_vulcan_installer_removes_downloaded_package_staging(tmp_path):
     package_dir = tmp_path / "package"
     package_name = "neat-apps-integration-apps-runtime-bundle-deadbeef"
     extracted_dir = package_dir / package_name
-    runtime_dir = _write_vulcan_runtime(extracted_dir, metadata_dir=package_dir)
+    runtime_dir = _write_vulcan_runtime(extracted_dir)
     (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
     archive = package_dir / f"{package_name}.tar.gz"
     archive.write_text("archive\n", encoding="utf-8")
@@ -903,6 +890,7 @@ def test_vulcan_installer_removes_downloaded_package_staging(tmp_path):
     assert not archive.exists()
     assert not install_script.exists()
     assert not (package_dir / "deps").exists()
+    assert (package_dir / "prebuilt-apps/deps/neat-core.json").is_file()
     assert unrelated.read_text(encoding="utf-8") == "keep\n"
 
 
@@ -921,6 +909,7 @@ def test_vulcan_installer_can_skip_dependency_installation(tmp_path):
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
+    assert (install_dir / "deps/neat-core.json").is_file()
     assert not (tmp_path / "sima-cli-args.txt").exists()
     assert not (package_dir / "deps").exists()
     assert "Skipping Core and Insight dependency installation" in proc.stdout
@@ -929,7 +918,9 @@ def test_vulcan_installer_can_skip_dependency_installation(tmp_path):
 def test_vulcan_runtime_gate_uses_packaged_core_without_customer_dependencies():
     workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "deps/neat-core.json" in workflow
+    assert "artifact_path: neat-apps-*.tar.gz" in workflow
+    assert "tar -xOzf" in workflow
+    assert "prebuilt-apps/deps/neat-core.json" in workflow
     assert "--neat-core-version" in workflow
     assert "NEAT_CORE_INSTALL_MODE=vulcan" in workflow
     assert "NEAT_APPS_SKIP_DEPENDENCIES=1" in workflow


### PR DESCRIPTION
## Summary

Make the Apps manifest the single source for the Core used by the SDK build, Modalix validation, and customer installation.

- Keep `policy: snap` for development builds and resolve it to one exact Core ref and spec.
- Allow release-preparation branches to select an official Core artifact explicitly.
- Remove Vulcan's destination-branch, release-branch, and tag-based Core override.
- Package the resolved target at `prebuilt-apps/deps/neat-core.json`.
- Make Vulcan and the customer installer use that same target.
- Preserve the Core metadata in the installed runtime.
- Continue installing Insight through its bare `sima-cli` target.

The runtime archive is the only transport for the Core metadata. Vulcan no longer uploads or publishes `neat-core.json` as a separate artifact.

## Validation

- `python3 -m pytest tests/scripts -q` — 88 passed.
- `python3 tests/utils/test_scope.py --scope-file examples validate --quiet`
- `bash -n build.sh scripts/install-vulcan-apps-package.sh scripts/ci/validate_apps_runtime_archive.sh`
- `shellcheck scripts/install-vulcan-apps-package.sh scripts/ci/validate_apps_runtime_archive.sh`
- Parsed `.github/workflows/vulcan-ci.yml` with PyYAML.
- Pre-commit and pre-push checks passed.
- [Vulcan CI](https://github.com/sima-neat/apps/actions/runs/29918456322) — all 12 checks passed, including SDK build, exact-Core installation from the runtime archive, full Modalix tests, package publication, latest-tag promotion, and portal/SysDoc publication.

Refs #372
Refs #341
