### PR TITLE
Cherry-pick deterministic Apps upgrades into 0.4.0

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -256,7 +256,7 @@ jobs:
             cd _vulcan-test/package
             NEAT_APPS_SKIP_DEPENDENCIES=1 \
               NEAT_APPS_INSTALL_DIR="${GITHUB_WORKSPACE}/_vulcan-test/install/prebuilt-apps" \
-              bash "${GITHUB_WORKSPACE}/scripts/install-vulcan-apps-package.sh"
+              bash "${GITHUB_WORKSPACE}/scripts/install-vulcan-apps-package.sh" "./prebuilt-apps"
           )
           if [[ -e "${GITHUB_WORKSPACE}/_vulcan-test/install/deps" ]]; then
             echo "Apps dependency workspace was not cleaned." >&2
@@ -312,6 +312,10 @@ jobs:
               ! -name 'neat-apps-tests.tar.gz' | sort
           )
           runtime_archive="${runtime_archives[0]}"
+          runtime_archive_name="$(basename "${runtime_archive}")"
+          runtime_extract_dir="${runtime_archive_name%.tar.gz}"
+          runtime_install_path="./${runtime_extract_dir}/prebuilt-apps"
+          printf -v quoted_runtime_install_path '%q' "${runtime_install_path}"
 
           cp "${runtime_archive}" dist/
           install -m 0755 scripts/install-vulcan-apps-package.sh dist/install_vulcan_apps_package.sh
@@ -325,7 +329,7 @@ jobs:
             --name gh:sima-neat/apps \
             --version "${version}" \
             --description "SiMa.ai Neat example applications runtime" \
-            --install-script install_vulcan_apps_package.sh
+            --install-script "bash ./install_vulcan_apps_package.sh ${quoted_runtime_install_path}"
 
           python3 -m json.tool dist/metadata.json >/dev/null
           scripts/ci/validate_apps_runtime_archive.sh "dist/$(basename "${runtime_archive}")"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ sima-cli neat install apps
 cd prebuilt-apps
 ```
 
-The Apps installer installs the Core selected for the Apps package and installs Insight through `sima-cli`. The installed bundle is placed under `prebuilt-apps/`. Run the remaining commands from that directory.
+Use `-d <install-root>` to install `prebuilt-apps/` under another directory. The Apps installer installs the Core selected for the Apps package and installs Insight through `sima-cli`. Run the remaining commands from the installed `prebuilt-apps/` directory.
+
+Run the same command with the same installation root to upgrade Apps. Before replacing an existing installation, the installer asks for confirmation, carries `models/` into the new bundle, and retains the remaining previous files under `.prebuilt-apps-backup/`. If that backup already exists, the installer warns before replacing it.
 
 ## Run an Example
 
@@ -73,6 +75,8 @@ Before downloading a model, set `PLATFORM_VERSION` to the displayed `DISTRO_VERS
 | `examples/<category>/<example>/src/common/` | Shared runtime configuration and data |
 | `assets/datasets/` | Shipped runtime sample data |
 | `models/` | User-managed model packages |
+| `deps/neat-apps.json` | Installed Apps ref and exact commit |
+| `deps/neat-core.json` | Core artifact selected for this Apps build |
 
 The installed bundle does not contain CMake files or tests. Clone the repository
 to compile source or run the Apps test suite.

--- a/build.sh
+++ b/build.sh
@@ -132,7 +132,7 @@ artifact_version() {
 package_distribution() {
   local build_path="${ROOT_DIR}/${BUILD_DIR}"
   local stage_root stage_dir test_stage_dir
-  local branch_key version archive_name archive_path
+  local branch_key version archive_name archive_path apps_ref apps_spec
   local test_archive_path="${ROOT_DIR}/neat-apps-tests.tar.gz"
 
   if [[ ! -d "${build_path}" ]]; then
@@ -160,6 +160,33 @@ package_distribution() {
     return 1
   fi
   cp "${NEAT_CORE_METADATA}" "${stage_dir}/deps/neat-core.json"
+  apps_ref="${NEAT_APPS_ARTIFACT_BRANCH_KEY:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}}"
+  if [[ -z "${apps_ref}" ]] && command -v git >/dev/null 2>&1; then
+    apps_ref="$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  fi
+  if [[ -z "${apps_ref}" ]]; then
+    echo "ERROR: unable to determine the Apps source ref." >&2
+    rm -rf "${stage_root}"
+    return 1
+  fi
+  apps_spec="${GITHUB_SHA:-}"
+  if [[ -z "${apps_spec}" ]] && command -v git >/dev/null 2>&1; then
+    apps_spec="$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || true)"
+  fi
+  if [[ -z "${apps_spec}" ]]; then
+    echo "ERROR: unable to determine the Apps source commit." >&2
+    rm -rf "${stage_root}"
+    return 1
+  fi
+  python3 - "${stage_dir}/deps/neat-apps.json" "${apps_ref}" "${apps_spec}" <<'PY'
+import json
+import sys
+
+path, ref, spec = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump({"neat-apps": {"ref": ref, "spec": spec}}, handle, indent=2)
+    handle.write("\n")
+PY
 
   while IFS= read -r cpp_dir; do
     local rel target_dir

--- a/scripts/ci/validate_apps_runtime_archive.sh
+++ b/scripts/ci/validate_apps_runtime_archive.sh
@@ -11,6 +11,7 @@ runtime_root="prebuilt-apps"
 
 python3 - "${archive}" "${runtime_root}" <<'PY'
 import json
+import re
 import sys
 import tarfile
 from pathlib import PurePosixPath
@@ -27,6 +28,7 @@ def fail(message: str) -> None:
 with tarfile.open(archive, "r:gz") as bundle:
     members = bundle.getmembers()
     core_metadata_name = f"{root}/deps/neat-core.json"
+    apps_metadata_name = f"{root}/deps/neat-apps.json"
     text_suffixes = {
         ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp",
         ".json", ".md", ".py", ".sh", ".yaml", ".yml",
@@ -49,6 +51,8 @@ with tarfile.open(archive, "r:gz") as bundle:
             fail(f"runtime archive member is outside {root}/: {member.name}")
         if path.name == "neat-core.json" and member.name != core_metadata_name:
             fail(f"Core metadata is outside {core_metadata_name}: {member.name}")
+        if path.name == "neat-apps.json" and member.name != apps_metadata_name:
+            fail(f"Apps metadata is outside {apps_metadata_name}: {member.name}")
         if member.isfile() and member.name.endswith(model_suffixes):
             fail(f"runtime archive contains a packaged model: {member.name}")
         if (
@@ -89,6 +93,24 @@ with tarfile.open(archive, "r:gz") as bundle:
         fail(f"invalid Core ref in {core_metadata_name}")
     if not isinstance(spec, str) or not spec.strip() or spec == "latest":
         fail(f"invalid Core spec in {core_metadata_name}")
+
+    try:
+        apps_metadata = bundle.getmember(apps_metadata_name)
+    except KeyError:
+        fail(f"runtime archive is missing {apps_metadata_name}")
+    if not apps_metadata.isfile():
+        fail(f"runtime archive is missing {apps_metadata_name}")
+    source = bundle.extractfile(apps_metadata)
+    data = json.load(source)
+    apps = data.get("neat-apps")
+    if not isinstance(apps, dict):
+        fail(f"invalid Apps metadata in {apps_metadata_name}")
+    ref = apps.get("ref")
+    spec = apps.get("spec")
+    if not isinstance(ref, str) or not ref.strip():
+        fail(f"invalid Apps ref in {apps_metadata_name}")
+    if not isinstance(spec, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", spec):
+        fail(f"invalid Apps spec in {apps_metadata_name}")
 PY
 
 members="$(tar -tzf "${archive}")"

--- a/scripts/install-vulcan-apps-package.sh
+++ b/scripts/install-vulcan-apps-package.sh
@@ -2,19 +2,23 @@
 set -euo pipefail
 
 DEST_DIR="${NEAT_APPS_INSTALL_DIR:-prebuilt-apps}"
-RUNTIME_SRC="${NEAT_APPS_RUNTIME_SRC:-prebuilt-apps}"
+RUNTIME_SRC="${1:-}"
 INSTALL_ROOT="$(dirname "${DEST_DIR}")"
 LEGACY_RUNTIME_DIR="${INSTALL_ROOT}/neat-apps/neat-apps-runtime"
-DEPS_DIR="${INSTALL_ROOT}/deps"
-DEPS_MARKER="${DEPS_DIR}/.neat-apps-installer-owned"
-DEPS_MARKER_VALUE="sima-neat/apps"
+DEPS_DIR="${RUNTIME_SRC}/deps"
 CORE_INSTALL_DIR="${DEPS_DIR}/core"
 INSIGHT_INSTALL_DIR="${DEPS_DIR}/insight"
-DEPS_WORKSPACE_ACTIVE=0
 PACKAGE_DIR="$(pwd -P)"
 CORE_METADATA_PATH=""
+APPS_METADATA_PATH=""
 PACKAGE_EXTRACT_DIR=""
 PACKAGE_ARCHIVE=""
+BACKUP_DIR="${INSTALL_ROOT}/.prebuilt-apps-backup"
+
+if [[ -z "${RUNTIME_SRC}" || ! -d "${RUNTIME_SRC}" || -L "${RUNTIME_SRC}" ]]; then
+  echo "Usage: install-vulcan-apps-package.sh <runtime-source>" >&2
+  exit 1
+fi
 
 resolve_sima_cli_bin() {
   if [[ -n "${SIMA_CLI_BIN:-}" && -x "${SIMA_CLI_BIN}" ]]; then
@@ -66,39 +70,8 @@ print(spec)
 PY
 }
 
-dependency_workspace_is_owned() {
-  [[ -d "${DEPS_DIR}" && ! -L "${DEPS_DIR}" \
-    && -f "${DEPS_MARKER}" && ! -L "${DEPS_MARKER}" ]] \
-    && grep -Fqx "${DEPS_MARKER_VALUE}" "${DEPS_MARKER}"
-}
-
 cleanup_dependency_workspace() {
-  if [[ "${DEPS_WORKSPACE_ACTIVE}" != "1" ]]; then
-    return 0
-  fi
-  if ! dependency_workspace_is_owned; then
-    echo "ERROR: refusing to remove dependency workspace without its ownership marker: ${DEPS_DIR}" >&2
-    return 1
-  fi
-  rm -rf "${DEPS_DIR}"
-  DEPS_WORKSPACE_ACTIVE=0
-}
-
-prepare_dependency_workspace() {
-  if [[ -e "${DEPS_DIR}" || -L "${DEPS_DIR}" ]]; then
-    if ! dependency_workspace_is_owned; then
-      echo "ERROR: refusing to replace unowned dependency workspace: ${DEPS_DIR}" >&2
-      return 1
-    fi
-    rm -rf "${DEPS_DIR}"
-  fi
-
-  mkdir -p "${DEPS_DIR}"
-  if ! printf '%s\n' "${DEPS_MARKER_VALUE}" >"${DEPS_MARKER}"; then
-    rmdir "${DEPS_DIR}" 2>/dev/null || true
-    return 1
-  fi
-  DEPS_WORKSPACE_ACTIVE=1
+  rm -rf "${CORE_INSTALL_DIR}" "${INSIGHT_INSTALL_DIR}"
 }
 
 run_sima_cli_install() {
@@ -121,6 +94,38 @@ run_sima_cli_install() {
     fi
     rm -f "${log_path}"
   )
+}
+
+confirm_runtime_replacement() {
+  local previous_dir=""
+  local response=""
+
+  if [[ -e "${DEST_DIR}" || -L "${DEST_DIR}" ]]; then
+    previous_dir="${DEST_DIR}"
+  elif [[ -e "${LEGACY_RUNTIME_DIR}" || -L "${LEGACY_RUNTIME_DIR}" ]]; then
+    previous_dir="${LEGACY_RUNTIME_DIR}"
+  fi
+  if [[ -z "${previous_dir}" ]]; then
+    return 0
+  fi
+
+  echo
+  echo "The existing prebuilt-apps installation will be replaced."
+  echo "  Preserved models: ${DEST_DIR}/models"
+  echo "  Previous files  : ${BACKUP_DIR}"
+  if [[ -e "${BACKUP_DIR}" || -L "${BACKUP_DIR}" ]]; then
+    echo "  Existing backup : will be replaced"
+  fi
+
+  if [[ "${NEAT_APPS_OVERWRITE:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  printf 'Continue? [y/N] '
+  if ! IFS= read -r response || [[ ! "${response}" =~ ^[Yy]$ ]]; then
+    echo "Apps installation cancelled."
+    return 1
+  fi
 }
 
 locate_package_staging() {
@@ -158,7 +163,7 @@ promote_apps_runtime() {
   local source_dir="$1"
   local dest_dir="$2"
   local legacy_dir="$3"
-  local dest_parent stage_root staged_runtime backup_dir="" previous_dir=""
+  local dest_parent stage_root staged_runtime previous_dir=""
   local models_preserved=0
 
   dest_parent="$(dirname "${dest_dir}")"
@@ -184,28 +189,25 @@ promote_apps_runtime() {
   fi
 
   if [[ -n "${previous_dir}" ]]; then
-    if ! backup_dir="$(mktemp -d "${dest_parent}/.prebuilt-apps-backup.XXXXXX")"; then
-      echo "ERROR: failed to create an Apps rollback path under ${dest_parent}." >&2
-      rm -rf "${stage_root}"
-      return 1
+    if [[ -e "${BACKUP_DIR}" || -L "${BACKUP_DIR}" ]]; then
+      if ! rm -rf "${BACKUP_DIR}"; then
+        echo "ERROR: failed to replace the previous Apps backup: ${BACKUP_DIR}" >&2
+        rm -rf "${stage_root}"
+        return 1
+      fi
     fi
-    if ! rmdir "${backup_dir}"; then
-      echo "ERROR: failed to prepare the Apps rollback path: ${backup_dir}" >&2
-      rm -rf "${stage_root}" "${backup_dir}"
-      return 1
-    fi
-    if ! mv "${previous_dir}" "${backup_dir}"; then
+    if ! mv "${previous_dir}" "${BACKUP_DIR}"; then
       echo "ERROR: failed to stage the existing Apps runtime for rollback." >&2
       rm -rf "${stage_root}"
       return 1
     fi
 
-    if [[ -e "${backup_dir}/models" || -L "${backup_dir}/models" ]]; then
+    if [[ -e "${BACKUP_DIR}/models" || -L "${BACKUP_DIR}/models" ]]; then
       rm -rf "${staged_runtime}/models"
-      if ! mv "${backup_dir}/models" "${staged_runtime}/models"; then
+      if ! mv "${BACKUP_DIR}/models" "${staged_runtime}/models"; then
         echo "ERROR: failed to preserve the existing Apps models directory." >&2
-        if ! mv "${backup_dir}" "${previous_dir}"; then
-          echo "ERROR: previous Apps runtime remains at ${backup_dir}." >&2
+        if ! mv "${BACKUP_DIR}" "${previous_dir}"; then
+          echo "ERROR: previous Apps runtime remains at ${BACKUP_DIR}." >&2
         fi
         rm -rf "${stage_root}"
         return 1
@@ -217,13 +219,13 @@ promote_apps_runtime() {
   if ! mv "${staged_runtime}" "${dest_dir}"; then
     echo "ERROR: failed to promote the candidate Apps runtime." >&2
     if [[ "${models_preserved}" == "1" ]]; then
-      if ! mv "${staged_runtime}/models" "${backup_dir}/models"; then
+      if ! mv "${staged_runtime}/models" "${BACKUP_DIR}/models"; then
         echo "ERROR: preserved models remain at ${staged_runtime}/models." >&2
         return 1
       fi
     fi
-    if [[ -n "${backup_dir}" ]] && ! mv "${backup_dir}" "${previous_dir}"; then
-      echo "ERROR: previous Apps runtime remains at ${backup_dir}." >&2
+    if [[ -n "${previous_dir}" ]] && ! mv "${BACKUP_DIR}" "${previous_dir}"; then
+      echo "ERROR: previous Apps runtime remains at ${BACKUP_DIR}." >&2
       return 1
     fi
     rm -rf "${stage_root}"
@@ -231,31 +233,19 @@ promote_apps_runtime() {
   fi
 
   rm -rf "${stage_root}"
-  if [[ -n "${backup_dir}" ]]; then
-    rm -rf "${backup_dir}"
-  fi
   if [[ -n "${previous_dir}" && "${previous_dir}" != "${dest_dir}" ]]; then
     rmdir "$(dirname "${previous_dir}")" 2>/dev/null || true
   fi
 }
 
-if [[ ! -d "${RUNTIME_SRC}" ]]; then
-  runtime_candidates=()
-  while IFS= read -r candidate; do
-    runtime_candidates+=("${candidate}")
-  done < <(find . -mindepth 1 -maxdepth 3 -type d -name "${RUNTIME_SRC}" | sort)
-  if [[ "${#runtime_candidates[@]}" -eq 1 ]]; then
-    RUNTIME_SRC="${runtime_candidates[0]}"
-  else
-    echo "ERROR: ${RUNTIME_SRC} was not extracted from the apps package." >&2
-    printf 'Found candidates:\n' >&2
-    printf '  %s\n' "${runtime_candidates[@]}" >&2
-    exit 1
-  fi
-fi
-
 locate_package_staging
+trap 'cleanup_dependency_workspace; cleanup_package_staging' EXIT
 
+APPS_METADATA_PATH="${RUNTIME_SRC}/deps/neat-apps.json"
+if [[ ! -f "${APPS_METADATA_PATH}" || -L "${APPS_METADATA_PATH}" ]]; then
+  echo "ERROR: Apps package is missing ${APPS_METADATA_PATH}." >&2
+  exit 1
+fi
 CORE_METADATA_PATH="${RUNTIME_SRC}/deps/neat-core.json"
 if [[ ! -f "${CORE_METADATA_PATH}" || -L "${CORE_METADATA_PATH}" ]]; then
   echo "ERROR: Apps package is missing ${CORE_METADATA_PATH}." >&2
@@ -267,6 +257,8 @@ if ! CORE_TARGET="$(extract_neat_core_target)"; then
 fi
 CORE_REF="$(printf '%s\n' "${CORE_TARGET}" | sed -n '1p')"
 CORE_SPEC="$(printf '%s\n' "${CORE_TARGET}" | sed -n '2p')"
+
+confirm_runtime_replacement || exit 1
 
 if [[ "${NEAT_APPS_SKIP_DEPENDENCIES:-0}" == "1" ]]; then
   echo
@@ -281,8 +273,8 @@ else
   echo "Installing the Core selected by Apps:"
   echo "  Ref        : ${CORE_REF}"
   echo "  Spec       : ${CORE_SPEC}"
-  trap cleanup_dependency_workspace EXIT
-  prepare_dependency_workspace
+  cleanup_dependency_workspace
+  mkdir -p "${CORE_INSTALL_DIR}" "${INSIGHT_INSTALL_DIR}"
   echo "  Scratch dir: ${CORE_INSTALL_DIR}"
   run_sima_cli_install "${CORE_INSTALL_DIR}" "${SIMA_CLI_RESOLVED}" \
     -d . \
@@ -297,7 +289,6 @@ else
     insight
 
   cleanup_dependency_workspace
-  trap - EXIT
 fi
 
 if ! promote_apps_runtime "${RUNTIME_SRC}" "${DEST_DIR}" "${LEGACY_RUNTIME_DIR}"; then
@@ -309,3 +300,7 @@ INSTALLED_DIR="$(cd "$(dirname "${DEST_DIR}")" && pwd -P)/$(basename "${DEST_DIR
 echo
 echo "Installed apps runtime under:"
 echo "  ${INSTALLED_DIR}"
+if [[ -d "${BACKUP_DIR}" && ! -L "${BACKUP_DIR}" ]]; then
+  echo "Previous apps runtime retained under:"
+  echo "  ${BACKUP_DIR}"
+fi

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -22,6 +22,12 @@ VULCAN_INSTALLER = APPS_ROOT / "scripts/install-vulcan-apps-package.sh"
 VULCAN_WORKFLOW = APPS_ROOT / ".github/workflows/vulcan-ci.yml"
 RELEASE_WORKFLOW = APPS_ROOT / ".github/workflows/release.yml"
 RUNTIME_ARCHIVE_VALIDATOR = APPS_ROOT / "scripts/ci/validate_apps_runtime_archive.sh"
+APPS_TEST_METADATA = {
+    "neat-apps": {
+        "ref": "develop",
+        "spec": "0123456789abcdef0123456789abcdef01234567",
+    }
+}
 
 
 def _write_runtime_archive(
@@ -32,6 +38,7 @@ def _write_runtime_archive(
     extra_archive_members: tuple[str, ...] = (),
     member_contents: dict[str, str] | None = None,
     include_core_metadata: bool = True,
+    include_apps_metadata: bool = True,
 ) -> Path:
     archive_root = tmp_path / "archive-root" / root_name
     archive_root.mkdir(parents=True)
@@ -40,6 +47,13 @@ def _write_runtime_archive(
         core_metadata.parent.mkdir(parents=True)
         core_metadata.write_text(
             json.dumps({"neat-core": {"ref": "develop", "spec": "core-sha"}}),
+            encoding="utf-8",
+        )
+    if include_apps_metadata:
+        apps_metadata = archive_root / "deps/neat-apps.json"
+        apps_metadata.parent.mkdir(parents=True, exist_ok=True)
+        apps_metadata.write_text(
+            json.dumps(APPS_TEST_METADATA),
             encoding="utf-8",
         )
     for member in members:
@@ -79,6 +93,29 @@ def test_runtime_archive_validator_accepts_shipped_datasets(tmp_path):
 
 def test_runtime_archive_validator_rejects_missing_core_metadata(tmp_path):
     archive = _write_runtime_archive(tmp_path, include_core_metadata=False)
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
+
+
+def test_runtime_archive_validator_rejects_missing_apps_metadata(tmp_path):
+    archive = _write_runtime_archive(tmp_path, include_apps_metadata=False)
+    proc = _validate_runtime_archive(archive)
+
+    assert proc.returncode != 0
+
+
+def test_runtime_archive_validator_rejects_non_exact_apps_commit(tmp_path):
+    metadata_path = "deps/neat-apps.json"
+    archive = _write_runtime_archive(
+        tmp_path,
+        metadata_path,
+        member_contents={
+            metadata_path: json.dumps(
+                {"neat-apps": {"ref": "develop", "spec": "short-sha"}}
+            )
+        },
+    )
     proc = _validate_runtime_archive(archive)
 
     assert proc.returncode != 0
@@ -387,6 +424,10 @@ def _write_vulcan_runtime(
         json.dumps({"neat-core": core}),
         encoding="utf-8",
     )
+    (deps_dir / "neat-apps.json").write_text(
+        json.dumps(APPS_TEST_METADATA),
+        encoding="utf-8",
+    )
     return runtime_dir
 
 
@@ -395,6 +436,9 @@ def _run_vulcan_installer(
     package_dir: Path,
     *,
     install_dir: Path | None = None,
+    runtime_src: Path | None = None,
+    allow_overwrite: bool = True,
+    input_text: str | None = None,
     sima_cli_status: int = 0,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
@@ -411,12 +455,19 @@ def _run_vulcan_installer(
     )
     if install_dir is not None:
         env["NEAT_APPS_INSTALL_DIR"] = str(install_dir)
+    if allow_overwrite:
+        env["NEAT_APPS_OVERWRITE"] = "1"
+    else:
+        env.pop("NEAT_APPS_OVERWRITE", None)
     if extra_env:
         env.update(extra_env)
+    if runtime_src is None:
+        runtime_src = package_dir / "prebuilt-apps"
     return subprocess.run(
-        ["bash", str(VULCAN_INSTALLER)],
+        ["bash", str(VULCAN_INSTALLER), str(runtime_src)],
         cwd=package_dir,
         env=env,
+        input=input_text,
         check=False,
         capture_output=True,
         text=True,
@@ -828,9 +879,13 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
     assert json.loads(
         (install_dir / "deps/neat-core.json").read_text(encoding="utf-8")
     ) == {"neat-core": {"ref": "develop", "spec": "core-sha"}}
+    assert (
+        json.loads((install_dir / "deps/neat-apps.json").read_text(encoding="utf-8"))
+        == APPS_TEST_METADATA
+    )
     assert (tmp_path / "sima-cli-cwd.txt").read_text(encoding="utf-8").splitlines() == [
-        str(package_dir / "deps" / "core"),
-        str(package_dir / "deps" / "insight"),
+        str(runtime_dir / "deps" / "core"),
+        str(runtime_dir / "deps" / "insight"),
     ]
     assert (tmp_path / "sima-cli-args.txt").read_text(
         encoding="utf-8"
@@ -838,7 +893,8 @@ def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):
         "neat install -d . -t minimal core@develop:core-sha",
         "neat install -d . insight",
     ]
-    assert not (package_dir / "deps").exists()
+    assert not (runtime_dir / "deps/core").exists()
+    assert not (runtime_dir / "deps/insight").exists()
     assert f"  {install_dir}" in proc.stdout
 
 
@@ -847,6 +903,21 @@ def test_vulcan_installer_rejects_missing_core_metadata_before_promotion(tmp_pat
     runtime_dir = _write_vulcan_runtime(package_dir)
     (runtime_dir / "deps" / "neat-core.json").unlink()
     install_dir = tmp_path / "installed" / "prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
+
+    assert proc.returncode != 0
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+
+
+def test_vulcan_installer_rejects_missing_apps_metadata_before_promotion(tmp_path):
+    package_dir = tmp_path / "package"
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "deps/neat-apps.json").unlink()
+    install_dir = tmp_path / "installed/prebuilt-apps"
     install_dir.mkdir(parents=True)
     (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
 
@@ -880,7 +951,11 @@ def test_vulcan_installer_removes_downloaded_package_staging(tmp_path):
     unrelated = package_dir / "keep.txt"
     unrelated.write_text("keep\n", encoding="utf-8")
 
-    proc = _run_vulcan_installer(tmp_path, package_dir)
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        runtime_src=runtime_dir,
+    )
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert (package_dir / "prebuilt-apps" / "runtime-marker").read_text(
@@ -892,6 +967,94 @@ def test_vulcan_installer_removes_downloaded_package_staging(tmp_path):
     assert not (package_dir / "deps").exists()
     assert (package_dir / "prebuilt-apps/deps/neat-core.json").is_file()
     assert unrelated.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_vulcan_installer_promotes_explicit_candidate_over_existing_installation(
+    tmp_path,
+):
+    package_dir = tmp_path / "package"
+    installed_runtime = _write_vulcan_runtime(package_dir)
+    (installed_runtime / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    package_name = "neat-apps-release-0.4.0-prep-deadbeef"
+    extracted_dir = package_dir / package_name
+    candidate_runtime = _write_vulcan_runtime(
+        extracted_dir,
+        {"ref": "v0.3.0", "spec": "release-core-sha"},
+    )
+    (candidate_runtime / "runtime-marker").write_text("new\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        runtime_src=candidate_runtime,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (installed_runtime / "runtime-marker").read_text(encoding="utf-8") == (
+        "new\n"
+    )
+    assert json.loads(
+        (installed_runtime / "deps/neat-core.json").read_text(encoding="utf-8")
+    ) == {"neat-core": {"ref": "v0.3.0", "spec": "release-core-sha"}}
+
+
+def test_vulcan_installer_declines_upgrade_before_installing_dependencies(tmp_path):
+    package_dir = tmp_path / "package"
+    candidate_runtime = _write_vulcan_runtime(package_dir)
+    (candidate_runtime / "runtime-marker").write_text("new\n", encoding="utf-8")
+
+    install_dir = tmp_path / "installed/prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        install_dir=install_dir,
+        allow_overwrite=False,
+        input_text="n\n",
+    )
+
+    assert proc.returncode != 0
+    assert "The existing prebuilt-apps installation will be replaced" in proc.stdout
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert (candidate_runtime / "runtime-marker").read_text(encoding="utf-8") == (
+        "new\n"
+    )
+    assert not (tmp_path / "sima-cli-args.txt").exists()
+
+
+def test_vulcan_installer_cleans_package_staging_when_upgrade_is_declined(tmp_path):
+    package_dir = tmp_path / "package"
+    package_name = "neat-apps-fix-prebuilt-apps-upgrade-deadbeef"
+    extracted_dir = package_dir / package_name
+    candidate_runtime = _write_vulcan_runtime(extracted_dir)
+    (candidate_runtime / "runtime-marker").write_text("new\n", encoding="utf-8")
+    archive = package_dir / f"{package_name}.tar.gz"
+    archive.write_text("archive\n", encoding="utf-8")
+    install_script = package_dir / "install_vulcan_apps_package.sh"
+    install_script.write_text("installer\n", encoding="utf-8")
+
+    install_dir = tmp_path / "installed/prebuilt-apps"
+    install_dir.mkdir(parents=True)
+    (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+
+    proc = _run_vulcan_installer(
+        tmp_path,
+        package_dir,
+        runtime_src=candidate_runtime,
+        install_dir=install_dir,
+        allow_overwrite=False,
+        input_text="n\n",
+    )
+
+    assert proc.returncode != 0
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert not extracted_dir.exists()
+    assert not archive.exists()
+    assert not install_script.exists()
+    assert not (tmp_path / "sima-cli-args.txt").exists()
 
 
 def test_vulcan_installer_can_skip_dependency_installation(tmp_path):
@@ -924,6 +1087,25 @@ def test_vulcan_runtime_gate_uses_packaged_core_without_customer_dependencies():
     assert "--neat-core-version" in workflow
     assert "NEAT_CORE_INSTALL_MODE=vulcan" in workflow
     assert "NEAT_APPS_SKIP_DEPENDENCIES=1" in workflow
+    assert (
+        'bash "${GITHUB_WORKSPACE}/scripts/install-vulcan-apps-package.sh" '
+        '"./prebuilt-apps"' in workflow
+    )
+
+
+def test_vulcan_package_shell_quotes_exact_runtime_candidate():
+    workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'runtime_extract_dir="${runtime_archive_name%.tar.gz}"' in workflow
+    assert 'runtime_install_path="./${runtime_extract_dir}/prebuilt-apps"' in workflow
+    assert (
+        "printf -v quoted_runtime_install_path '%q' "
+        '"${runtime_install_path}"' in workflow
+    )
+    assert (
+        '--install-script "bash ./install_vulcan_apps_package.sh '
+        '${quoted_runtime_install_path}"' in workflow
+    )
 
 
 def test_vulcan_does_not_override_manifest_core_context():
@@ -1000,9 +1182,10 @@ def test_vulcan_installer_keeps_existing_runtime_when_insight_install_fails(tmp_
     assert not (install_dir.parent / "deps").exists()
 
 
-def test_vulcan_installer_refuses_unowned_dependency_workspace(tmp_path):
+def test_vulcan_installer_leaves_root_dependency_directory_untouched(tmp_path):
     package_dir = tmp_path / "package"
-    _write_vulcan_runtime(package_dir)
+    runtime_dir = _write_vulcan_runtime(package_dir)
+    (runtime_dir / "runtime-marker").write_text("new\n", encoding="utf-8")
     install_dir = tmp_path / "installed" / "prebuilt-apps"
     install_dir.mkdir(parents=True)
     (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
@@ -1012,24 +1195,18 @@ def test_vulcan_installer_refuses_unowned_dependency_workspace(tmp_path):
 
     proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
 
-    assert proc.returncode != 0
+    assert proc.returncode == 0, proc.stderr + proc.stdout
     assert unowned_file.read_text(encoding="utf-8") == "keep\n"
-    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
-    assert not (tmp_path / "sima-cli-args.txt").exists()
-    assert "refusing to replace unowned dependency workspace" in proc.stderr
+    assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
 
 
-def test_vulcan_installer_recreates_owned_dependency_workspace(tmp_path):
+def test_vulcan_installer_recreates_candidate_dependency_scratch(tmp_path):
     package_dir = tmp_path / "package"
-    _write_vulcan_runtime(package_dir)
+    runtime_dir = _write_vulcan_runtime(package_dir)
     install_dir = tmp_path / "installed" / "prebuilt-apps"
-    deps_dir = install_dir.parent / "deps"
-    stale_file = deps_dir / "core" / "stale-resource"
+    stale_file = runtime_dir / "deps/core/stale-resource"
     stale_file.parent.mkdir(parents=True)
     stale_file.write_text("stale\n", encoding="utf-8")
-    (deps_dir / ".neat-apps-installer-owned").write_text(
-        "sima-neat/apps\n", encoding="utf-8"
-    )
 
     proc = _run_vulcan_installer(
         tmp_path,
@@ -1040,12 +1217,13 @@ def test_vulcan_installer_recreates_owned_dependency_workspace(tmp_path):
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert install_dir.is_dir()
-    assert not deps_dir.exists()
+    assert not (install_dir / "deps/core").exists()
+    assert not (install_dir / "deps/insight").exists()
 
 
 def test_vulcan_installer_cleans_dependency_workspace_on_termination(tmp_path):
     package_dir = tmp_path / "package"
-    _write_vulcan_runtime(package_dir)
+    runtime_dir = _write_vulcan_runtime(package_dir)
     install_dir = tmp_path / "installed" / "prebuilt-apps"
     install_dir.mkdir(parents=True)
     (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
@@ -1058,12 +1236,13 @@ def test_vulcan_installer_cleans_dependency_workspace_on_termination(tmp_path):
             "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(tmp_path / "sima-cli-args.txt"),
             "NEAT_APPS_TEST_SIMA_CLI_CWD": str(tmp_path / "sima-cli-cwd.txt"),
             "NEAT_APPS_TEST_SIMA_CLI_READY": str(ready_file),
+            "NEAT_APPS_OVERWRITE": "1",
             "PATH": f"{bin_dir}:{env['PATH']}",
             "SIMA_CLI_BIN": str(bin_dir / "sima-cli"),
         }
     )
     proc = subprocess.Popen(
-        ["bash", str(VULCAN_INSTALLER)],
+        ["bash", str(VULCAN_INSTALLER), str(runtime_dir)],
         cwd=package_dir,
         env=env,
         start_new_session=True,
@@ -1085,7 +1264,8 @@ def test_vulcan_installer_cleans_dependency_workspace_on_termination(tmp_path):
     proc.communicate(timeout=5)
 
     assert proc.returncode != 0
-    assert not (install_dir.parent / "deps").exists()
+    assert not (runtime_dir / "deps/core").exists()
+    assert not (runtime_dir / "deps/insight").exists()
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
 
 
@@ -1097,13 +1277,25 @@ def test_vulcan_installer_preserves_models_during_reinstall(tmp_path):
     models_dir = install_dir / "models"
     models_dir.mkdir(parents=True)
     (install_dir / "runtime-marker").write_text("old\n", encoding="utf-8")
+    (install_dir / "custom-config.yaml").write_text("custom\n", encoding="utf-8")
     (models_dir / "user-model.mpk").write_text("model\n", encoding="utf-8")
+    previous_backup = install_dir.parent / ".prebuilt-apps-backup"
+    previous_backup.mkdir()
+    (previous_backup / "obsolete-backup").write_text("obsolete\n", encoding="utf-8")
 
     proc = _run_vulcan_installer(tmp_path, package_dir, install_dir=install_dir)
 
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert (install_dir / "runtime-marker").read_text(encoding="utf-8") == "new\n"
     assert (models_dir / "user-model.mpk").read_text(encoding="utf-8") == "model\n"
+    backup_dir = install_dir.parent / ".prebuilt-apps-backup"
+    assert (backup_dir / "runtime-marker").read_text(encoding="utf-8") == "old\n"
+    assert (backup_dir / "custom-config.yaml").read_text(encoding="utf-8") == (
+        "custom\n"
+    )
+    assert not (backup_dir / "models").exists()
+    assert not (backup_dir / "obsolete-backup").exists()
+    assert "Existing backup : will be replaced" in proc.stdout
 
 
 def test_vulcan_installer_migrates_legacy_runtime_and_models(tmp_path):


### PR DESCRIPTION
## Why

Apps 0.4.0 must include the deterministic and recoverable installation flow already merged into `develop` through #383.

## What Changed

- Install the exact Apps artifact selected by package metadata.
- Confirm replacements, preserve models, retain one previous bundle, and restore it if promotion fails.
- Keep dependency scratch files inside the selected candidate and clean current installation artifacts afterward.
- Record the installed Apps ref and commit.
- Shell-escape the candidate path stored in package metadata.
- Preserve the release configuration: Core `v0.3.0` at `17a7c7788b07` and platform `2.1.2`.

## Validation

- 65 installer and manifest contract tests passed.
- 14 README validation checks passed.
- Shell syntax and diff hygiene checks passed.
- The cherry-pick applied without conflicts.

Cherry-picks #383 into `release-0.4.0-prep`.

Refs #382
