### PR TITLE
ci(vulcan): remove duplicate PR runs

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -1,6 +1,6 @@
 name: Vulcan CI
 
-run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'production' }})
+run-name: ${{ github.event.head_commit.message || github.ref_name || 'Vulcan CI' }} (${{ vars.VULCAN_ENV || 'production' }})
 
 on:
   push:
@@ -8,9 +8,6 @@ on:
       - "**"
     tags:
       - "*"
-  pull_request:
-    branches:
-      - main
   workflow_dispatch: {}
 
 permissions:
@@ -36,7 +33,6 @@ jobs:
 
   build:
     name: Build Apps on Vulcan
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: resolve-vulcan-config
     uses: sima-neat/.github/.github/workflows/vulcan-build.yml@main
     with:
@@ -71,12 +67,9 @@ jobs:
 
         docker exec \
           -e SIMA_CLI_CHECK_FOR_UPDATE=0 \
-          -e GITHUB_HEAD_REF="${{ github.head_ref }}" \
           -e GITHUB_REF_NAME="${{ github.ref_name }}" \
           -e GITHUB_REF_TYPE="${{ github.ref_type }}" \
           -e GITHUB_SHA="${{ github.sha }}" \
-          -e NEAT_APPS_ARTIFACT_BRANCH_KEY="${{ github.head_ref || github.ref_name }}" \
-          -e NEAT_APPS_ARTIFACT_SHORT_SHA="${{ github.sha }}" \
           -e NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
           -e NEAT_CORE_INSTALL_MODE="vulcan" \
           -e NEAT_VULCAN_ENV="${{ needs.resolve-vulcan-config.outputs.vulcan_env }}" \

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -1108,21 +1108,19 @@ def test_vulcan_package_shell_quotes_exact_runtime_candidate():
     )
 
 
-def test_vulcan_does_not_override_manifest_core_context():
+def test_vulcan_uses_push_context_without_manifest_override():
     workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "pull_request:\n    branches:\n      - main" in workflow
-    assert (
-        "if: ${{ github.event_name != 'pull_request' || "
-        "github.event.pull_request.head.repo.full_name == github.repository }}"
-        in workflow
-    )
+    assert "pull_request:" not in workflow
+    assert "github.event.pull_request" not in workflow
+    assert "github.head_ref" not in workflow
+    assert "GITHUB_HEAD_REF" not in workflow
+    assert "NEAT_APPS_ARTIFACT_BRANCH_KEY" not in workflow
+    assert "NEAT_APPS_ARTIFACT_SHORT_SHA" not in workflow
+    assert '-e GITHUB_REF_NAME="${{ github.ref_name }}"' in workflow
+    assert '-e GITHUB_SHA="${{ github.sha }}"' in workflow
     assert "resolve-core-context" not in workflow
     assert "NEAT_APPS_DEPENDENCY_BRANCH" not in workflow
-    assert (
-        'NEAT_APPS_ARTIFACT_BRANCH_KEY="${{ github.head_ref || github.ref_name }}"'
-        in workflow
-    )
 
 
 def test_release_dispatches_vulcan_for_the_created_tag():


### PR DESCRIPTION
## Why

Vulcan already runs for every branch push. The additional trigger for pull requests targeting `main` starts a second full SDK build and Modalix test whenever the source branch changes.

That trigger was introduced when the PR destination selected Core `main`. Core selection now comes from the source manifest, so the second run no longer provides a different dependency context.

## What Changed

- Remove the Vulcan trigger for pull requests targeting `main`.
- Remove the now-unreachable fork-PR guard and PR-only workflow context.
- Continue deriving branch and tag artifacts from `GITHUB_REF_NAME` and `GITHUB_SHA`.
- Keep push, tag, and manual Vulcan runs unchanged.
- Update the workflow contract test for the push-based behavior.

## Validation

- `python3 -m pytest tests/scripts/test_manifest_contract.py -q` — 65 passed
- Workflow YAML parsed successfully.
- Pre-commit and scoped pre-push checks passed.
- Diff hygiene passed.

## Notes

The PR merge result against `main` no longer receives a separate Vulcan run. The source-branch push remains the authoritative build, runtime test, and artifact publication path.

After this PR is merged into `develop`, cherry-pick the merged commit into `release-0.4.0-prep`.

Refs #368
