### PR TITLE
refactor(examples): select the RTSP codec once

### DIFF
--- a/examples/object-detection/high-density-multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/high-density-multi-stream-object-detector/src/cpp/main.cpp
@@ -75,7 +75,8 @@ struct AppConfig {
   std::string decode_type = "yolo26";
   fs::path labels_path;
   std::vector<std::string> rtsp_urls;
-  bool use_h265 = false;
+  /// Encoded RTSP path used for every stream in this application.
+  simaai::neat::nodes::groups::RtspCodec codec = simaai::neat::nodes::groups::RtspCodec::H264;
   int workers = 1;
   int queue_depth = kDefaultQueueDepth;
   int internal_queue_depth = kDefaultInternalQueueDepth;
@@ -104,13 +105,20 @@ struct AppConfig {
   bool video_enabled = true;
 };
 
-bool parse_use_h265(std::string value) {
+std::string lower_copy(std::string value) {
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  if (value == "h264" || value == "avc" || value == "h.264")
-    return false;
-  if (value == "h265" || value == "hevc" || value == "h.265")
-    return true;
+  return value;
+}
+
+simaai::neat::nodes::groups::RtspCodec parse_input_codec(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "h264" || lowered == "avc" || lowered == "h.264") {
+    return simaai::neat::nodes::groups::RtspCodec::H264;
+  }
+  if (lowered == "h265" || lowered == "hevc" || lowered == "h.265") {
+    return simaai::neat::nodes::groups::RtspCodec::H265;
+  }
   throw std::runtime_error("input.codec must be h264/avc or h265/hevc");
 }
 
@@ -471,7 +479,7 @@ AppConfig load_app_config(const fs::path& config_path) {
   cfg.decode_type = raw.string_or("model.decode_type", "yolo26");
   cfg.labels_path = raw.string_or("model.labels", "coco_label.txt");
   cfg.rtsp_urls = parse_streams(config_path);
-  cfg.use_h265 = parse_use_h265(raw.string_or("input.codec", "h264"));
+  cfg.codec = parse_input_codec(raw.string_or("input.codec", "h264"));
   cfg.tcp = raw.bool_or("input.tcp", true);
   cfg.latency_ms = raw.int_or("input.latency_ms", 100);
   cfg.decoder_buffers = raw.int_or("input.decoder_buffers", kDefaultDecoderBuffers);
@@ -796,12 +804,11 @@ make_source_options(const AppConfig& cfg, const std::string& url, int& fps_out, 
       cfg.decoder_tuning == "low-memory" || cfg.decoder_tuning == "throughput-low-latency";
   opt.auto_caps_from_stream = !cfg.skip_rtsp_probe;
   opt.num_buffers = cfg.decoder_buffers;
-  opt.codec = cfg.use_h265 ? simaai::neat::nodes::groups::RtspCodec::H265
-                           : simaai::neat::nodes::groups::RtspCodec::H264;
+  opt.codec = cfg.codec;
   if (width_out > 0 && height_out > 0) {
     opt.dec_width = width_out;
     opt.dec_height = height_out;
-    if (!cfg.use_h265) {
+    if (cfg.codec == simaai::neat::nodes::groups::RtspCodec::H264) {
       opt.fallback_h264_width = width_out;
       opt.fallback_h264_height = height_out;
     }
@@ -831,10 +838,8 @@ make_rtsp_encoded_input(const simaai::neat::nodes::groups::RtspDecodedInputOptio
   encoded.sync_mode = opt.sync_mode;
   encoded.auto_caps_from_stream = opt.auto_caps_from_stream;
   encoded.source_fps = opt.source_fps;
-  if (opt.codec == simaai::neat::nodes::groups::RtspCodec::H265) {
-    encoded.h265_payload_type = opt.payload_type;
-  } else {
-    encoded.h264_payload_type = opt.payload_type;
+  encoded.payload_type = opt.payload_type;
+  if (opt.codec != simaai::neat::nodes::groups::RtspCodec::H265) {
     encoded.h264_parse_config_interval = opt.h264_parse_config_interval;
     encoded.fallback_h264_width = opt.fallback_h264_width;
     encoded.fallback_h264_height = opt.fallback_h264_height;
@@ -888,9 +893,7 @@ std::unique_ptr<simaai::neat::Model> make_model(const AppConfig& cfg) {
 
 simaai::neat::nodes::groups::VideoSenderOptions make_video_options(const AppConfig& cfg,
                                                                    const SourceRuntime& source) {
-  auto video_options =
-      cfg.use_h265 ? simaai::neat::nodes::groups::VideoSenderOptions::H265RtpUdpFromEncoded()
-                   : simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromEncoded();
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::Passthrough(cfg.codec);
   video_options.host = cfg.insight_host;
   video_options.channel = source.index;
   video_options.video_port_base = cfg.video_port_base;

--- a/examples/object-detection/high-density-multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/high-density-multi-stream-object-detector/src/python/main.py
@@ -39,7 +39,9 @@ class AppConfig:
     model_path: str
     labels_path: Path
     rtsp_urls: list[str]
-    use_h265: bool = False
+    # Encoded RTSP path used for every stream: "h264" or "h265". Kept as a
+    # string because load_app_config runs before the lazy pyneat import.
+    codec: str = "h264"
     decode_type: str = "yolo26"
     workers: int = 1
     queue_depth: int = DEFAULT_QUEUE_DEPTH
@@ -297,12 +299,12 @@ def bool_or(raw: dict, key: str, default: bool) -> bool:
     return value
 
 
-def parse_use_h265(value: str) -> bool:
+def parse_input_codec(value: str) -> str:
     lowered = value.lower()
     if lowered in {"h264", "avc", "h.264"}:
-        return False
+        return "h264"
     if lowered in {"h265", "hevc", "h.265"}:
-        return True
+        return "h265"
     raise ValueError("input.codec must be h264/avc or h265/hevc")
 
 
@@ -500,7 +502,7 @@ def load_app_config(config_path: Path) -> AppConfig:
         decode_type=normalize_box_decode_type(string_or(model, "decode_type", "yolo26")),
         labels_path=Path(labels_path_value).expanduser(),
         rtsp_urls=rtsp_urls,
-        use_h265=parse_use_h265(string_or(input_cfg, "codec", "h264")),
+        codec=parse_input_codec(string_or(input_cfg, "codec", "h264")),
         workers=int_or(inference, "workers", 1),
         queue_depth=queue_depth,
         internal_queue_depth=int_or(
@@ -840,6 +842,11 @@ def probe_rtsp(url: str) -> tuple[int, int, int]:
     return width, height, fps
 
 
+def rtsp_codec(codec: str):
+    """Map the parsed `input.codec` config token onto the Core RTSP codec selector."""
+    return pyneat.RtspCodec.H265 if codec == "h265" else pyneat.RtspCodec.H264
+
+
 def make_source_options(
     cfg: AppConfig,
     url: str,
@@ -870,7 +877,7 @@ def make_source_options(
     opt.decoder_next_element = "CVU"
     opt.auto_caps_from_stream = not cfg.skip_rtsp_probe
     opt.num_buffers = cfg.decoder_buffers
-    opt.codec = pyneat.RtspCodec.H265 if cfg.use_h265 else pyneat.RtspCodec.H264
+    opt.codec = rtsp_codec(cfg.codec)
 
     opt.output_caps.enable = True
     opt.output_caps.format = pyneat.Format.NV12
@@ -879,7 +886,7 @@ def make_source_options(
     if width_out > 0 and height_out > 0:
         opt.dec_width = width_out
         opt.dec_height = height_out
-        if not cfg.use_h265:
+        if cfg.codec == "h264":
             opt.fallback_h264_width = width_out
             opt.fallback_h264_height = height_out
         opt.output_caps.width = width_out
@@ -903,10 +910,8 @@ def make_rtsp_encoded_input(opt):
     encoded.sync_mode = opt.sync_mode
     encoded.auto_caps_from_stream = opt.auto_caps_from_stream
     encoded.source_fps = opt.source_fps
-    if opt.codec == pyneat.RtspCodec.H265:
-        encoded.h265_payload_type = opt.payload_type
-    else:
-        encoded.h264_payload_type = opt.payload_type
+    encoded.payload_type = opt.payload_type
+    if opt.codec != pyneat.RtspCodec.H265:
         encoded.h264_parse_config_interval = opt.h264_parse_config_interval
         encoded.fallback_h264_width = opt.fallback_h264_width
         encoded.fallback_h264_height = opt.fallback_h264_height
@@ -982,11 +987,7 @@ def make_model(cfg: AppConfig):
 
 
 def make_video_options(cfg: AppConfig, source: SourceRuntime):
-    video_options = (
-        pyneat.VideoSenderOptions.h265_rtp_udp_from_encoded()
-        if cfg.use_h265
-        else pyneat.VideoSenderOptions.h264_rtp_udp_from_encoded()
-    )
+    video_options = pyneat.VideoSenderOptions.passthrough(rtsp_codec(cfg.codec))
     video_options.host = cfg.insight_host
     video_options.channel = source.index
     video_options.video_port_base = cfg.video_port_base

--- a/examples/object-detection/high-density-multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/high-density-multi-stream-object-detector/tests/python/test_unit.py
@@ -393,7 +393,7 @@ output:
         assert cfg.decoder_buffers == 7
         assert cfg.decoder_input_buffers == 2
         assert cfg.decoder_tuning == "throughput-low-latency"
-        assert cfg.use_h265
+        assert cfg.codec == "h265"
 
     @pytest.mark.parametrize("depth", [-1, 33])
     def test_load_app_config_rejects_invalid_internal_queue_depth(
@@ -599,7 +599,7 @@ class TestRuntimeOptions:
             model_path=MODEL_PATH,
             labels_path=Path("labels.txt"),
             rtsp_urls=["rtsp://127.0.0.1:8554/src1"],
-            use_h265=True,
+            codec="h265",
         )
 
         opt, fps, width, height = main.make_source_options(
@@ -700,23 +700,22 @@ class TestRuntimeOptions:
 
         class FakeVideoSenderOptions:
             @staticmethod
-            def h264_rtp_udp_from_encoded():
-                return SimpleNamespace(codec="h264", async_=True)
-
-            @staticmethod
-            def h265_rtp_udp_from_encoded():
-                return SimpleNamespace(codec="h265", async_=True)
+            def passthrough(codec):
+                return SimpleNamespace(codec=codec, async_=True)
 
         monkeypatch.setattr(
             main,
             "pyneat",
-            SimpleNamespace(VideoSenderOptions=FakeVideoSenderOptions),
+            SimpleNamespace(
+                VideoSenderOptions=FakeVideoSenderOptions,
+                RtspCodec=SimpleNamespace(H264="h264", H265="h265"),
+            ),
         )
         cfg = main.AppConfig(
             model_path=MODEL_PATH,
             labels_path=Path("labels.txt"),
             rtsp_urls=["rtsp://127.0.0.1:8554/src1"],
-            use_h265=True,
+            codec="h265",
             insight_host="192.0.2.10",
             video_port_base=9200,
         )

--- a/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/multi-stream-object-detector/src/cpp/main.cpp
@@ -53,7 +53,8 @@ struct AppConfig {
   std::string model_path;
   fs::path labels_path;
   std::vector<std::string> rtsp_urls;
-  bool use_h265 = false;
+  /// Encoded RTSP path used for every stream in this application.
+  simaai::neat::nodes::groups::RtspCodec codec = simaai::neat::nodes::groups::RtspCodec::H264;
   int latency_ms = 100;
   bool tcp = true;
   int frames = 0;
@@ -73,13 +74,20 @@ struct AppConfig {
   int save_every = 0;
 };
 
-bool parse_use_h265(std::string value) {
+std::string lower_copy(std::string value) {
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  if (value == "h264" || value == "avc" || value == "h.264")
-    return false;
-  if (value == "h265" || value == "hevc" || value == "h.265")
-    return true;
+  return value;
+}
+
+simaai::neat::nodes::groups::RtspCodec parse_input_codec(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "h264" || lowered == "avc" || lowered == "h.264") {
+    return simaai::neat::nodes::groups::RtspCodec::H264;
+  }
+  if (lowered == "h265" || lowered == "hevc" || lowered == "h.265") {
+    return simaai::neat::nodes::groups::RtspCodec::H265;
+  }
   throw std::runtime_error("input.codec must be h264/avc or h265/hevc");
 }
 
@@ -281,7 +289,7 @@ AppConfig load_app_config(const fs::path& config_path) {
   cfg.model_path = raw.string_or("model.path", "");
   cfg.labels_path = raw.string_or("model.labels", default_labels.string());
   cfg.rtsp_urls = parse_streams(config_path);
-  cfg.use_h265 = parse_use_h265(raw.string_or("input.codec", "h264"));
+  cfg.codec = parse_input_codec(raw.string_or("input.codec", "h264"));
   cfg.tcp = raw.bool_or("input.tcp", true);
   cfg.latency_ms = raw.int_or("input.latency_ms", 100);
   cfg.frames = raw.int_or("inference.frames", 0);
@@ -394,12 +402,11 @@ build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out,
   opt.decoder_name = "decoder";
   opt.decoder_raw_output = true;
   opt.auto_caps_from_stream = true;
-  opt.codec = cfg.use_h265 ? simaai::neat::nodes::groups::RtspCodec::H265
-                           : simaai::neat::nodes::groups::RtspCodec::H264;
+  opt.codec = cfg.codec;
   if (probe.width > 0 && probe.height > 0) {
     opt.dec_width = probe.width;
     opt.dec_height = probe.height;
-    if (!cfg.use_h265) {
+    if (cfg.codec == simaai::neat::nodes::groups::RtspCodec::H264) {
       opt.fallback_h264_width = probe.width;
       opt.fallback_h264_height = probe.height;
     }
@@ -426,28 +433,25 @@ bool output_caps_enabled(
   return caps.enable || caps.width > 0 || caps.height > 0 || caps.fps > 0;
 }
 
-simaai::neat::InputOptions encoded_decode_input_options(bool use_h265) {
+simaai::neat::FormatTag encoded_format_tag(simaai::neat::nodes::groups::RtspCodec codec) {
+  return codec == simaai::neat::nodes::groups::RtspCodec::H265 ? simaai::neat::FormatTag::H265
+                                                               : simaai::neat::FormatTag::H264;
+}
+
+simaai::neat::InputOptions
+encoded_decode_input_options(simaai::neat::nodes::groups::RtspCodec codec) {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  if (use_h265) {
-    opt.caps_override = "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-                        "alignment=(string)au";
-  } else {
-    opt.format = simaai::neat::FormatTag::H264;
-  }
+  opt.format = encoded_format_tag(codec);
   opt.memory_policy = simaai::neat::InputMemoryPolicy::Ev74;
   return opt;
 }
 
-simaai::neat::InputOptions encoded_video_input_options(bool use_h265) {
+simaai::neat::InputOptions
+encoded_video_input_options(simaai::neat::nodes::groups::RtspCodec codec) {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  if (use_h265) {
-    opt.caps_override = "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-                        "alignment=(string)au";
-  } else {
-    opt.format = simaai::neat::FormatTag::H264;
-  }
+  opt.format = encoded_format_tag(codec);
   opt.memory_policy = simaai::neat::InputMemoryPolicy::SystemMemory;
   return opt;
 }
@@ -491,7 +495,7 @@ build_decode_graph(const std::string& input_name,
   dec.decoder_tuning = opt.decoder_tuning;
   dec.memory_opt = opt.decoder_memory_opt;
 
-  decode.connect(simaai::neat::nodes::Input(input_name, encoded_decode_input_options(use_h265)),
+  decode.connect(simaai::neat::nodes::Input(input_name, encoded_decode_input_options(opt.codec)),
                  simaai::neat::nodes::SimaDecode(dec));
   if (opt.use_videoconvert) {
     decode.add(simaai::neat::nodes::VideoConvert());
@@ -511,10 +515,11 @@ build_decode_graph(const std::string& input_name,
 }
 
 simaai::neat::Graph
-build_video_sender_graph(const std::string& input_name, bool use_h265,
+build_video_sender_graph(const std::string& input_name,
+                         simaai::neat::nodes::groups::RtspCodec codec,
                          const simaai::neat::nodes::groups::VideoSenderOptions& video_options) {
   simaai::neat::Graph video("video_sender");
-  video.connect(simaai::neat::nodes::Input(input_name, encoded_video_input_options(use_h265)),
+  video.connect(simaai::neat::nodes::Input(input_name, encoded_video_input_options(codec)),
                 simaai::neat::nodes::groups::VideoSender(video_options));
   return video;
 }
@@ -607,6 +612,16 @@ simaai::neat::Graph build_debug_frame_graph(int stream_index) {
   return frames;
 }
 
+simaai::neat::nodes::groups::VideoSenderOptions make_video_options(const AppConfig& cfg,
+                                                                   int stream_index) {
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::Passthrough(cfg.codec);
+  video_options.host = cfg.insight_host;
+  video_options.channel = stream_index;
+  video_options.video_port_base = cfg.video_port_base;
+  video_options.async = true;
+  return video_options;
+}
+
 StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const std::string& url,
                                    const std::vector<std::string>& labels) {
   StreamRuntime runtime;
@@ -626,13 +641,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   runtime.profile.stream_index = stream_index;
   runtime.source_options = source_options;
   if (cfg.video_enabled) {
-    auto video_options =
-        cfg.use_h265 ? simaai::neat::nodes::groups::VideoSenderOptions::H265RtpUdpFromEncoded()
-                     : simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromEncoded();
-    video_options.host = cfg.insight_host;
-    video_options.channel = stream_index;
-    video_options.video_port_base = cfg.video_port_base;
-    runtime.video_port = video_options.video_port();
+    runtime.video_port = make_video_options(cfg, stream_index).video_port();
   }
 
   simaai::neat::MetadataSenderOptions metadata_options;
@@ -666,15 +675,9 @@ void connect_stream_graph(AppRuntime& app, const AppConfig& cfg, const StreamRun
     app.graph.connect(source, encoded_branch);
     app.graph.connect(encoded_branch, decoder, realtime_link(stream.index, 3));
 
-    auto video_options =
-        cfg.use_h265 ? simaai::neat::nodes::groups::VideoSenderOptions::H265RtpUdpFromEncoded()
-                     : simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromEncoded();
-    video_options.host = cfg.insight_host;
-    video_options.channel = stream.index;
-    video_options.video_port_base = cfg.video_port_base;
-    video_options.async = true;
+    const auto video_options = make_video_options(cfg, stream.index);
     app.graph.connect(encoded_branch,
-                      build_video_sender_graph("video_h264", cfg.use_h265, video_options),
+                      build_video_sender_graph("video_h264", cfg.codec, video_options),
                       realtime_link(stream.index, 3));
   } else {
     app.graph.connect(source, decoder, realtime_link(stream.index, 3));

--- a/examples/object-detection/multi-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/multi-stream-object-detector/src/python/main.py
@@ -26,7 +26,9 @@ class AppConfig:
     model_path: str
     labels_path: Path
     rtsp_urls: list[str]
-    use_h265: bool = False
+    # Encoded RTSP path used for every stream: "h264" or "h265". Kept as a
+    # string because load_app_config runs before the lazy pyneat import.
+    codec: str = "h264"
     latency_ms: int = 100
     tcp: bool = True
     frames: int = 0
@@ -186,12 +188,12 @@ def bool_or(raw: dict, key: str, default: bool) -> bool:
     return value
 
 
-def parse_use_h265(value: str) -> bool:
+def parse_input_codec(value: str) -> str:
     lowered = value.lower()
     if lowered in {"h264", "avc", "h.264"}:
-        return False
+        return "h264"
     if lowered in {"h265", "hevc", "h.265"}:
-        return True
+        return "h265"
     raise ValueError("input.codec must be h264/avc or h265/hevc")
 
 
@@ -258,7 +260,7 @@ def load_app_config(config_path: Path) -> AppConfig:
         model_path=string_or(model, "path"),
         labels_path=Path(string_or(model, "labels", str(default_labels))),
         rtsp_urls=rtsp_urls,
-        use_h265=parse_use_h265(string_or(input_cfg, "codec", "h264")),
+        codec=parse_input_codec(string_or(input_cfg, "codec", "h264")),
         latency_ms=int_or(input_cfg, "latency_ms", 100),
         tcp=bool_or(input_cfg, "tcp", True),
         frames=int_or(inference, "frames", 0),
@@ -376,6 +378,11 @@ def build_metadata_boxes(boxes: list[dict], labels: list[str], frame_w: int, fra
     return metadata_boxes
 
 
+def rtsp_codec(codec: str):
+    """Map the parsed `input.codec` config token onto the Core RTSP codec selector."""
+    return pyneat.RtspCodec.H265 if codec == "h265" else pyneat.RtspCodec.H264
+
+
 def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap = cv2.VideoCapture(url)
     if not cap.isOpened():
@@ -401,10 +408,10 @@ def build_source_options(cfg: AppConfig, url: str, fps: int, width: int, height:
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
     opt.auto_caps_from_stream = True
-    opt.codec = pyneat.RtspCodec.H265 if cfg.use_h265 else pyneat.RtspCodec.H264
+    opt.codec = rtsp_codec(cfg.codec)
     opt.dec_width = width
     opt.dec_height = height
-    if not cfg.use_h265:
+    if cfg.codec == "h264":
         opt.fallback_h264_width = width
         opt.fallback_h264_height = height
     opt.source_fps = fps
@@ -437,31 +444,23 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
     return source
 
 
-def encoded_decode_input_options(use_h265: bool):
+def encoded_format_tag(codec):
+    return pyneat.Format.H265 if codec == pyneat.RtspCodec.H265 else pyneat.Format.H264
+
+
+def encoded_decode_input_options(codec):
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    if use_h265:
-        opt.caps_override = (
-            "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-            "alignment=(string)au"
-        )
-    else:
-        opt.format = pyneat.Format.H264
+    opt.format = encoded_format_tag(codec)
     if hasattr(pyneat, "InputMemoryPolicy") and hasattr(opt, "memory_policy"):
         opt.memory_policy = pyneat.InputMemoryPolicy.Ev74
     return opt
 
 
-def encoded_video_input_options(use_h265: bool):
+def encoded_video_input_options(codec):
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    if use_h265:
-        opt.caps_override = (
-            "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-            "alignment=(string)au"
-        )
-    else:
-        opt.format = pyneat.Format.H264
+    opt.format = encoded_format_tag(codec)
     if hasattr(pyneat, "InputMemoryPolicy") and hasattr(opt, "memory_policy"):
         opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
     elif hasattr(opt, "use_simaai_pool"):
@@ -485,7 +484,7 @@ def build_decode_graph(input_name: str, opt) -> pyneat.Graph:
     dec.dec_fps = opt.source_fps
     dec.num_buffers = opt.num_buffers
     decode.connect(
-        pyneat.nodes.input(input_name, encoded_decode_input_options(use_h265)),
+        pyneat.nodes.input(input_name, encoded_decode_input_options(opt.codec)),
         pyneat.nodes.sima_decode(dec),
     )
     if opt.use_videoconvert:
@@ -507,10 +506,10 @@ def build_decode_graph(input_name: str, opt) -> pyneat.Graph:
     return decode
 
 
-def build_video_sender_graph(input_name: str, use_h265: bool, video_options) -> pyneat.Graph:
+def build_video_sender_graph(input_name: str, codec, video_options) -> pyneat.Graph:
     video = pyneat.Graph("video_sender")
     video.connect(
-        pyneat.nodes.input(input_name, encoded_video_input_options(use_h265)),
+        pyneat.nodes.input(input_name, encoded_video_input_options(codec)),
         pyneat.groups.video_sender(video_options),
     )
     return video
@@ -602,6 +601,15 @@ def build_debug_frame_graph(stream_index: int) -> pyneat.Graph:
     return frames
 
 
+def make_video_options(cfg: AppConfig, stream_index: int):
+    video_options = pyneat.VideoSenderOptions.passthrough(rtsp_codec(cfg.codec))
+    video_options.host = cfg.insight_host
+    video_options.channel = stream_index
+    video_options.video_port_base = cfg.video_port_base
+    video_options.async_ = True
+    return video_options
+
+
 def build_stream_runtime(
     cfg: AppConfig, stream_index: int, url: str, labels: list[str]
 ) -> StreamRuntime:
@@ -612,15 +620,7 @@ def build_stream_runtime(
 
     video_port = 0
     if cfg.video_enabled:
-        video_options = (
-            pyneat.VideoSenderOptions.h265_rtp_udp_from_encoded()
-            if cfg.use_h265
-            else pyneat.VideoSenderOptions.h264_rtp_udp_from_encoded()
-        )
-        video_options.host = cfg.insight_host
-        video_options.channel = stream_index
-        video_options.video_port_base = cfg.video_port_base
-        video_port = video_options.video_port
+        video_port = make_video_options(cfg, stream_index).video_port
 
     metadata_options = pyneat.MetadataSenderOptions()
     metadata_options.host = cfg.insight_host
@@ -660,18 +660,10 @@ def connect_stream_graph(
         app.graph.connect(source, encoded_branch)
         app.graph.connect(encoded_branch, decoder, realtime_link(stream.index, 3))
 
-        video_options = (
-            pyneat.VideoSenderOptions.h265_rtp_udp_from_encoded()
-            if cfg.use_h265
-            else pyneat.VideoSenderOptions.h264_rtp_udp_from_encoded()
-        )
-        video_options.host = cfg.insight_host
-        video_options.channel = stream.index
-        video_options.video_port_base = cfg.video_port_base
-        video_options.async_ = True
+        video_options = make_video_options(cfg, stream.index)
         app.graph.connect(
             encoded_branch,
-            build_video_sender_graph("video_h264", cfg.use_h265, video_options),
+            build_video_sender_graph("video_h264", rtsp_codec(cfg.codec), video_options),
             realtime_link(stream.index, 3),
         )
     else:

--- a/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/multi-stream-object-detector/tests/cpp/test_e2e.cpp
@@ -13,7 +13,105 @@ namespace fs = std::filesystem;
 using namespace sima_examples::testing;
 
 namespace {
+
+constexpr const char* kExampleName = "multi-stream-object-detector";
 constexpr const char* kE2eInsightHost = "127.0.0.1";
+
+struct SourceCase {
+  std::string codec;
+  std::vector<std::string> urls;
+};
+
+void record_unavailable_source(const std::string& fail_reason, const std::string& skip_reason,
+                               int& rc) {
+  if (require_e2e_mode()) {
+    std::cerr << "[FAIL] " << fail_reason << "\n";
+    rc = 1;
+  } else {
+    std::cerr << "[SKIP] " << skip_reason << "\n";
+  }
+}
+
+int run_source_case(const std::string& binary, const std::string& model_path,
+                    const fs::path& labels_file, const SourceCase& source_case) {
+  const std::string output_dir = create_test_output_dir(
+      kExampleName, "test_multi_stream_" + source_case.codec + "_insight_and_save_pipeline");
+  if (output_dir.empty()) {
+    return 1;
+  }
+
+  const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
+  const int metadata_port_base =
+      env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
+  const int total_saved_frames = e2e_int(kExampleName, "testing.e2e.output", "total_saved_frames");
+  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
+
+  const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
+  write_e2e_config(kExampleName, config_path,
+                   {{"model.path", model_path},
+                    {"model.labels", labels_file.string()},
+                    {"input.codec", source_case.codec},
+                    {"output.debug_dir", output_dir},
+                    {"output.insight.host", kE2eInsightHost},
+                    {"output.insight.video_port_base", std::to_string(video_port_base)},
+                    {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
+                    {"inference.frames", "140"}},
+                   {{"streams", {source_case.urls[0], source_case.urls[1]}}});
+
+  MetadataJsonListenerOptions metadata_options;
+  metadata_options.host = kE2eInsightHost;
+  metadata_options.base_port = metadata_port_base;
+  metadata_options.num_ports = 2;
+  metadata_options.timeout_ms = 5000;
+  metadata_options.require_all_ports = true;
+  MetadataJsonListener metadata_listener(metadata_options);
+  if (!metadata_listener.ok()) {
+    std::cerr << "[FAIL] " << source_case.codec
+              << " metadata listener failed: " << metadata_listener.error() << "\n";
+    remove_dir(output_dir);
+    return 1;
+  }
+
+  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
+                                                        output_dir, total_saved_frames, timeout_ms);
+
+  int rc = 0;
+  if (result.exit_code != 0) {
+    std::cerr << "[FAIL] " << source_case.codec << " exit code " << result.exit_code << "\n";
+    std::cerr << "stdout:\n" << result.stdout_text << "\n";
+    std::cerr << "stderr:\n" << result.stderr_text << "\n";
+    rc = 1;
+  } else {
+    const int files = count_output_files(output_dir);
+    if (files < total_saved_frames) {
+      std::cerr << "[FAIL] " << source_case.codec << " expected at least " << total_saved_frames
+                << " sampled output files, got " << files << "\n";
+      rc = 1;
+    } else if (!all_output_files_nonempty(output_dir)) {
+      std::cerr << "[FAIL] " << source_case.codec << " some sampled output files are empty\n";
+      rc = 1;
+    } else {
+      std::cout << "[OK] " << source_case.codec << " multi-camera object detector produced "
+                << files << " sampled output files\n";
+    }
+  }
+  if (rc == 0) {
+    const MetadataJsonListenerResult metadata = metadata_listener.wait_for_messages();
+    if (!metadata.success) {
+      std::cerr << "[FAIL] " << source_case.codec
+                << " object-detection metadata was not received on all streams: " << metadata.error
+                << "\n";
+      rc = 1;
+    } else {
+      std::cout << "[OK] " << source_case.codec << " object-detection metadata received on "
+                << metadata.ports_with_valid_json.size() << " streams\n";
+    }
+  }
+
+  remove_dir(output_dir);
+  return rc;
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -25,109 +123,47 @@ int main(int argc, char** argv) {
   const std::string binary = argv[1];
   const char* models_dir_raw = env_or_null("SIMANEAT_APPS_TEST_MODELS_DIR");
   const std::string models_dir = models_dir_raw ? models_dir_raw : "models";
-  const std::string model_path = configured_model_path("multi-stream-object-detector", models_dir);
+  const std::string model_path = configured_model_path(kExampleName, models_dir);
   if (model_path.empty() || !fs::exists(model_path)) {
     return skip_or_fail("configured detector model not found under SIMANEAT_APPS_TEST_MODELS_DIR");
   }
 
   const fs::path labels_file =
-      example_common_config_path("multi-stream-object-detector").parent_path() / "coco_label.txt";
+      example_common_config_path(kExampleName).parent_path() / "coco_label.txt";
   if (!fs::exists(labels_file)) {
     return skip_or_fail("src/common/coco_label.txt not found for multi-stream-object-detector");
   }
 
-  const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
-  const int metadata_port_base =
-      env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
-  const int total_saved_frames =
-      e2e_int("multi-stream-object-detector", "testing.e2e.output", "total_saved_frames");
-  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
-
-  struct SourceCase {
-    std::string codec;
-    std::vector<std::string> urls;
-  };
   const std::vector<SourceCase> source_cases = {
       {"h264", rtsp_h264_urls_from_env()},
       {"h265", rtsp_h265_urls_from_env()},
   };
 
-  for (const auto& source : source_cases) {
-    if (source.urls.size() < 2) {
-      return skip_or_fail("need at least two RTSP " + source.codec + " URLs for multistream e2e");
+  int cases_run = 0;
+  int rc = 0;
+  for (const SourceCase& source_case : source_cases) {
+    if (source_case.urls.size() < 2) {
+      record_unavailable_source("need at least two RTSP " + source_case.codec +
+                                    " URLs for multistream e2e",
+                                "set at least two RTSP " + source_case.codec + " URLs to run " +
+                                    source_case.codec + " multistream e2e",
+                                rc);
+      continue;
     }
-
-    const std::string output_dir =
-        create_test_output_dir("multi-stream-object-detector",
-                               "test_multi_stream_" + source.codec + "_insight_and_save_pipeline");
-    if (output_dir.empty()) {
-      return 1;
-    }
-
-    const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
-    write_e2e_config("multi-stream-object-detector", config_path,
-                     {{"model.path", model_path},
-                      {"model.labels", labels_file.string()},
-                      {"input.codec", source.codec},
-                      {"output.debug_dir", output_dir},
-                      {"output.insight.host", kE2eInsightHost},
-                      {"output.insight.video_port_base", std::to_string(video_port_base)},
-                      {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
-                      {"inference.frames", "140"}},
-                     {{"streams", {source.urls[0], source.urls[1]}}});
-
-    MetadataJsonListenerOptions metadata_options;
-    metadata_options.host = kE2eInsightHost;
-    metadata_options.base_port = metadata_port_base;
-    metadata_options.num_ports = 2;
-    metadata_options.timeout_ms = 5000;
-    metadata_options.require_all_ports = true;
-    MetadataJsonListener metadata_listener(metadata_options);
-    if (!metadata_listener.ok()) {
-      std::cerr << "[FAIL] metadata listener failed: " << metadata_listener.error() << "\n";
-      remove_dir(output_dir);
-      return 1;
-    }
-
-    const ProcessResult result = spawn_until_output_files(
-        binary, {"--config", config_path.string()}, output_dir, total_saved_frames, timeout_ms);
-
-    int rc = 0;
-    if (result.exit_code != 0) {
-      std::cerr << "[FAIL] exit code " << result.exit_code << "\n";
-      std::cerr << "stdout:\n" << result.stdout_text << "\n";
-      std::cerr << "stderr:\n" << result.stderr_text << "\n";
+    ++cases_run;
+    if (run_source_case(binary, model_path, labels_file, source_case) != 0) {
       rc = 1;
-    } else {
-      const int files = count_output_files(output_dir);
-      if (files < total_saved_frames) {
-        std::cerr << "[FAIL] expected at least " << total_saved_frames
-                  << " sampled output files, got " << files << "\n";
-        rc = 1;
-      } else if (!all_output_files_nonempty(output_dir)) {
-        std::cerr << "[FAIL] some sampled output files are empty\n";
-        rc = 1;
-      } else {
-        std::cout << "[OK] " << source.codec << " multi-camera object detector produced " << files
-                  << " sampled output files\n";
-      }
-    }
-    if (rc == 0) {
-      const MetadataJsonListenerResult metadata = metadata_listener.wait_for_messages();
-      if (!metadata.success) {
-        std::cerr << "[FAIL] object-detection metadata was not received on all streams: "
-                  << metadata.error << "\n";
-        rc = 1;
-      } else {
-        std::cout << "[OK] " << source.codec << " object-detection metadata received on "
-                  << metadata.ports_with_valid_json.size() << " streams\n";
-      }
-    }
-
-    remove_dir(output_dir);
-    if (rc != 0) {
-      return rc;
     }
   }
-  return 0;
+
+  if (cases_run == 0) {
+    if (require_e2e_mode()) {
+      std::cerr << "[FAIL] no multi-stream object detector RTSP e2e URLs configured\n";
+      return 1;
+    }
+    std::cerr << "[SKIP] no multi-stream object detector RTSP e2e URLs configured\n";
+    return kSkipCode;
+  }
+
+  return rc;
 }

--- a/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/multi-stream-object-detector/tests/python/test_unit.py
@@ -108,14 +108,14 @@ class TestConfigLoading:
         assert cfg.max_inflight_per_stream == 4
         assert cfg.max_inflight_total == 16
 
-    @pytest.mark.parametrize(("codec", "use_h265"), [("avc", False), ("hevc", True)])
-    def test_load_app_config_accepts_codec_alias(self, tmp_path: Path, codec: str, use_h265: bool):
+    @pytest.mark.parametrize(("codec", "expected"), [("avc", "h264"), ("hevc", "h265")])
+    def test_load_app_config_accepts_codec_alias(self, tmp_path: Path, codec: str, expected: str):
         from main import load_app_config
 
         cfg = load_app_config(
             write_config(tmp_path, ["rtsp://127.0.0.1:8554/src1"], codec=codec)
         )
-        assert cfg.use_h265 is use_h265
+        assert cfg.codec == expected
 
     def test_load_app_config_accepts_custom_inflight_limits(self, tmp_path: Path):
         from main import load_app_config
@@ -206,31 +206,28 @@ class TestConfigLoading:
 
 
 class TestRuntimeOptions:
-    def test_h265_input_options_use_encoded_caps(self, monkeypatch):
+    def test_encoded_input_options_carry_codec_format(self, monkeypatch):
         import main
 
         class FakeInputOptions:
-            caps_override = ""
+            format = ""
 
         fake_pyneat = SimpleNamespace(
             InputOptions=FakeInputOptions,
             PayloadType=SimpleNamespace(Encoded="encoded"),
-            Format=SimpleNamespace(H264="h264"),
+            Format=SimpleNamespace(H264="h264", H265="h265"),
+            RtspCodec=SimpleNamespace(H264="codec-h264", H265="codec-h265"),
             InputMemoryPolicy=SimpleNamespace(Ev74="ev74", SystemMemory="system"),
         )
         monkeypatch.setattr(main, "pyneat", fake_pyneat)
 
-        decode = main.encoded_decode_input_options(True)
-        video = main.encoded_video_input_options(True)
-        h264_decode = main.encoded_decode_input_options(False)
-        h264_video = main.encoded_video_input_options(False)
+        decode = main.encoded_decode_input_options(fake_pyneat.RtspCodec.H265)
+        video = main.encoded_video_input_options(fake_pyneat.RtspCodec.H265)
+        h264_decode = main.encoded_decode_input_options(fake_pyneat.RtspCodec.H264)
+        h264_video = main.encoded_video_input_options(fake_pyneat.RtspCodec.H264)
 
-        expected = (
-            "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-            "alignment=(string)au"
-        )
-        assert decode.caps_override == expected
-        assert video.caps_override == expected
+        assert decode.format == "h265"
+        assert video.format == "h265"
         assert h264_decode.format == "h264"
         assert h264_video.format == "h264"
 

--- a/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
+++ b/examples/segmentation/single-stream-instance-segmenter/src/cpp/main.cpp
@@ -485,17 +485,14 @@ make_rtsp_source_options(const AppConfig& cfg, const SourceGeometry& geometry) {
                   : simaai::neat::nodes::groups::RtspCodec::MJPEG;
   opt.source_fps = geometry.fps;
   if (cfg.source_codec == SourceCodec::H264) {
-    opt.payload_type = 96;
     opt.auto_caps_from_stream = true;
     opt.fallback_h264_width = geometry.width;
     opt.fallback_h264_height = geometry.height;
   } else if (cfg.source_codec == SourceCodec::H265) {
-    opt.payload_type = 96;
     opt.auto_caps_from_stream = true;
     opt.dec_width = geometry.width;
     opt.dec_height = geometry.height;
   } else {
-    opt.mjpeg_payload_type = 26;
     opt.dec_width = geometry.width;
     opt.dec_height = geometry.height;
   }
@@ -540,7 +537,6 @@ simaai::neat::Graph make_source_graph(const AppConfig& cfg, const SourceGeometry
 SourceGeometry probe_rtsp_h264_geometry(const AppConfig& cfg) {
   sima_examples::RtspStreamInfo probe;
   sima_examples::RtspProbeOptions probe_options;
-  probe_options.payload_type = 96;
   probe_options.latency_ms = cfg.latency_ms;
   probe_options.rtsp_tcp = cfg.tcp;
   probe_options.debug = cfg.profile;

--- a/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
+++ b/examples/segmentation/single-stream-instance-segmenter/src/python/main.py
@@ -546,17 +546,14 @@ def make_rtsp_source_options(cfg: AppConfig, fps: int, width: int, height: int):
     )
     opt.source_fps = fps
     if cfg.source_codec == "h264":
-        opt.payload_type = 96
         opt.auto_caps_from_stream = True
         opt.fallback_h264_width = width
         opt.fallback_h264_height = height
     elif cfg.source_codec == "h265":
-        opt.payload_type = 96
         opt.auto_caps_from_stream = True
         opt.dec_width = width
         opt.dec_height = height
     else:
-        opt.mjpeg_payload_type = 26
         opt.dec_width = width
         opt.dec_height = height
     set_output_caps(opt.output_caps, fps, width, height)

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -56,7 +56,8 @@ void request_stop(int) {
 struct AppConfig {
   std::string model_path;
   std::vector<std::string> rtsp_urls;
-  bool use_h265 = false;
+  /// Encoded RTSP path used for every stream in this application.
+  simaai::neat::nodes::groups::RtspCodec codec = simaai::neat::nodes::groups::RtspCodec::H264;
   int latency_ms = 100;
   bool tcp = true;
   int frames = 0;
@@ -79,13 +80,20 @@ struct AppConfig {
   int save_every = 0;
 };
 
-bool parse_use_h265(std::string value) {
+std::string lower_copy(std::string value) {
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  if (value == "h264" || value == "avc" || value == "h.264")
-    return false;
-  if (value == "h265" || value == "hevc" || value == "h.265")
-    return true;
+  return value;
+}
+
+simaai::neat::nodes::groups::RtspCodec parse_input_codec(const std::string& value) {
+  const std::string lowered = lower_copy(value);
+  if (lowered == "h264" || lowered == "avc" || lowered == "h.264") {
+    return simaai::neat::nodes::groups::RtspCodec::H264;
+  }
+  if (lowered == "h265" || lowered == "hevc" || lowered == "h.265") {
+    return simaai::neat::nodes::groups::RtspCodec::H265;
+  }
   throw std::runtime_error("input.codec must be h264/avc or h265/hevc");
 }
 
@@ -291,7 +299,7 @@ AppConfig load_app_config(const fs::path& config_path) {
   AppConfig cfg;
   cfg.model_path = raw.string_or("model.path", "");
   cfg.rtsp_urls = parse_streams(config_path);
-  cfg.use_h265 = parse_use_h265(raw.string_or("input.codec", "h264"));
+  cfg.codec = parse_input_codec(raw.string_or("input.codec", "h264"));
   cfg.tcp = raw.bool_or("input.tcp", true);
   cfg.latency_ms = raw.int_or("input.latency_ms", 100);
   cfg.frames = raw.int_or("inference.frames", 0);
@@ -397,12 +405,11 @@ build_source_options(const AppConfig& cfg, const std::string& url, int& fps_out,
   opt.decoder_name = "decoder";
   opt.decoder_raw_output = true;
   opt.auto_caps_from_stream = true;
-  opt.codec = cfg.use_h265 ? simaai::neat::nodes::groups::RtspCodec::H265
-                           : simaai::neat::nodes::groups::RtspCodec::H264;
+  opt.codec = cfg.codec;
   if (probe.width > 0 && probe.height > 0) {
     opt.dec_width = probe.width;
     opt.dec_height = probe.height;
-    if (!cfg.use_h265) {
+    if (cfg.codec == simaai::neat::nodes::groups::RtspCodec::H264) {
       opt.fallback_h264_width = probe.width;
       opt.fallback_h264_height = probe.height;
     }
@@ -429,28 +436,25 @@ bool output_caps_enabled(
   return caps.enable || caps.width > 0 || caps.height > 0 || caps.fps > 0;
 }
 
-simaai::neat::InputOptions encoded_decode_input_options(bool use_h265) {
+simaai::neat::FormatTag encoded_format_tag(simaai::neat::nodes::groups::RtspCodec codec) {
+  return codec == simaai::neat::nodes::groups::RtspCodec::H265 ? simaai::neat::FormatTag::H265
+                                                               : simaai::neat::FormatTag::H264;
+}
+
+simaai::neat::InputOptions
+encoded_decode_input_options(simaai::neat::nodes::groups::RtspCodec codec) {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  if (use_h265) {
-    opt.caps_override = "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-                        "alignment=(string)au";
-  } else {
-    opt.format = simaai::neat::FormatTag::H264;
-  }
+  opt.format = encoded_format_tag(codec);
   opt.memory_policy = simaai::neat::InputMemoryPolicy::Ev74;
   return opt;
 }
 
-simaai::neat::InputOptions encoded_video_input_options(bool use_h265) {
+simaai::neat::InputOptions
+encoded_video_input_options(simaai::neat::nodes::groups::RtspCodec codec) {
   simaai::neat::InputOptions opt;
   opt.payload_type = simaai::neat::PayloadType::Encoded;
-  if (use_h265) {
-    opt.caps_override = "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-                        "alignment=(string)au";
-  } else {
-    opt.format = simaai::neat::FormatTag::H264;
-  }
+  opt.format = encoded_format_tag(codec);
   opt.memory_policy = simaai::neat::InputMemoryPolicy::SystemMemory;
   return opt;
 }
@@ -494,7 +498,7 @@ build_decode_graph(const std::string& input_name,
   dec.decoder_tuning = opt.decoder_tuning;
   dec.memory_opt = opt.decoder_memory_opt;
 
-  decode.connect(simaai::neat::nodes::Input(input_name, encoded_decode_input_options(use_h265)),
+  decode.connect(simaai::neat::nodes::Input(input_name, encoded_decode_input_options(opt.codec)),
                  simaai::neat::nodes::SimaDecode(dec));
   if (opt.use_videoconvert) {
     decode.add(simaai::neat::nodes::VideoConvert());
@@ -514,10 +518,11 @@ build_decode_graph(const std::string& input_name,
 }
 
 simaai::neat::Graph
-build_video_sender_graph(const std::string& input_name, bool use_h265,
+build_video_sender_graph(const std::string& input_name,
+                         simaai::neat::nodes::groups::RtspCodec codec,
                          const simaai::neat::nodes::groups::VideoSenderOptions& video_options) {
   simaai::neat::Graph video("video_sender");
-  video.connect(simaai::neat::nodes::Input(input_name, encoded_video_input_options(use_h265)),
+  video.connect(simaai::neat::nodes::Input(input_name, encoded_video_input_options(codec)),
                 simaai::neat::nodes::groups::VideoSender(video_options));
   return video;
 }
@@ -610,6 +615,16 @@ simaai::neat::Graph build_debug_frame_graph(int stream_index) {
   return frames;
 }
 
+simaai::neat::nodes::groups::VideoSenderOptions make_video_options(const AppConfig& cfg,
+                                                                   int stream_index) {
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::Passthrough(cfg.codec);
+  video_options.host = cfg.insight_host;
+  video_options.channel = stream_index;
+  video_options.video_port_base = cfg.video_port_base;
+  video_options.async = true;
+  return video_options;
+}
+
 StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const std::string& url) {
   StreamRuntime runtime;
   runtime.index = stream_index;
@@ -628,13 +643,7 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   runtime.profile.stream_index = stream_index;
   runtime.source_options = source_options;
   if (cfg.video_enabled) {
-    auto video_options =
-        cfg.use_h265 ? simaai::neat::nodes::groups::VideoSenderOptions::H265RtpUdpFromEncoded()
-                     : simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromEncoded();
-    video_options.host = cfg.insight_host;
-    video_options.channel = stream_index;
-    video_options.video_port_base = cfg.video_port_base;
-    runtime.video_port = video_options.video_port();
+    runtime.video_port = make_video_options(cfg, stream_index).video_port();
   }
 
   simaai::neat::MetadataSenderOptions metadata_options;
@@ -668,15 +677,9 @@ void connect_stream_graph(AppRuntime& app, const AppConfig& cfg, const StreamRun
     app.graph.connect(source, encoded_branch);
     app.graph.connect(encoded_branch, decoder, realtime_link(stream.index, 3));
 
-    auto video_options =
-        cfg.use_h265 ? simaai::neat::nodes::groups::VideoSenderOptions::H265RtpUdpFromEncoded()
-                     : simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromEncoded();
-    video_options.host = cfg.insight_host;
-    video_options.channel = stream.index;
-    video_options.video_port_base = cfg.video_port_base;
-    video_options.async = true;
+    const auto video_options = make_video_options(cfg, stream.index);
     app.graph.connect(encoded_branch,
-                      build_video_sender_graph("video_h264", cfg.use_h265, video_options),
+                      build_video_sender_graph("video_h264", cfg.codec, video_options),
                       realtime_link(stream.index, 3));
   } else {
     app.graph.connect(source, decoder, realtime_link(stream.index, 3));

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -27,7 +27,9 @@ pyneat = None
 class AppConfig:
     model_path: str
     rtsp_urls: list[str]
-    use_h265: bool = False
+    # Encoded RTSP path used for every stream: "h264" or "h265". Kept as a
+    # string because load_app_config runs before the lazy pyneat import.
+    codec: str = "h264"
     latency_ms: int = 100
     tcp: bool = True
     frames: int = 0
@@ -196,12 +198,12 @@ def bool_or(raw: dict, key: str, default: bool) -> bool:
     return value
 
 
-def parse_use_h265(value: str) -> bool:
+def parse_input_codec(value: str) -> str:
     lowered = value.lower()
     if lowered in {"h264", "avc", "h.264"}:
-        return False
+        return "h264"
     if lowered in {"h265", "hevc", "h.265"}:
-        return True
+        return "h265"
     raise ValueError("input.codec must be h264/avc or h265/hevc")
 
 
@@ -271,7 +273,7 @@ def load_app_config(config_path: Path) -> AppConfig:
     cfg = AppConfig(
         model_path=string_or(model, "path"),
         rtsp_urls=rtsp_urls,
-        use_h265=parse_use_h265(string_or(input_cfg, "codec", "h264")),
+        codec=parse_input_codec(string_or(input_cfg, "codec", "h264")),
         latency_ms=int_or(input_cfg, "latency_ms", 100),
         tcp=bool_or(input_cfg, "tcp", True),
         frames=int_or(inference, "frames", 0),
@@ -387,6 +389,11 @@ def build_metadata_tracks(
     return metadata_tracks
 
 
+def rtsp_codec(codec: str):
+    """Map the parsed `input.codec` config token onto the Core RTSP codec selector."""
+    return pyneat.RtspCodec.H265 if codec == "h265" else pyneat.RtspCodec.H264
+
+
 def probe_rtsp(url: str) -> tuple[int, int, int]:
     cap = cv2.VideoCapture(url)
     if not cap.isOpened():
@@ -412,10 +419,10 @@ def build_source_options(cfg: AppConfig, url: str, fps: int, width: int, height:
     opt.decoder_name = "decoder"
     opt.decoder_raw_output = True
     opt.auto_caps_from_stream = True
-    opt.codec = pyneat.RtspCodec.H265 if cfg.use_h265 else pyneat.RtspCodec.H264
+    opt.codec = rtsp_codec(cfg.codec)
     opt.dec_width = width
     opt.dec_height = height
-    if not cfg.use_h265:
+    if cfg.codec == "h264":
         opt.fallback_h264_width = width
         opt.fallback_h264_height = height
     opt.source_fps = fps
@@ -448,31 +455,23 @@ def build_encoded_source_graph(opt) -> pyneat.Graph:
     return source
 
 
-def encoded_decode_input_options(use_h265: bool):
+def encoded_format_tag(codec):
+    return pyneat.Format.H265 if codec == pyneat.RtspCodec.H265 else pyneat.Format.H264
+
+
+def encoded_decode_input_options(codec):
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    if use_h265:
-        opt.caps_override = (
-            "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-            "alignment=(string)au"
-        )
-    else:
-        opt.format = pyneat.Format.H264
+    opt.format = encoded_format_tag(codec)
     if hasattr(pyneat, "InputMemoryPolicy") and hasattr(opt, "memory_policy"):
         opt.memory_policy = pyneat.InputMemoryPolicy.Ev74
     return opt
 
 
-def encoded_video_input_options(use_h265: bool):
+def encoded_video_input_options(codec):
     opt = pyneat.InputOptions()
     opt.payload_type = pyneat.PayloadType.Encoded
-    if use_h265:
-        opt.caps_override = (
-            "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-            "alignment=(string)au"
-        )
-    else:
-        opt.format = pyneat.Format.H264
+    opt.format = encoded_format_tag(codec)
     if hasattr(pyneat, "InputMemoryPolicy") and hasattr(opt, "memory_policy"):
         opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
     elif hasattr(opt, "use_simaai_pool"):
@@ -496,7 +495,7 @@ def build_decode_graph(input_name: str, opt) -> pyneat.Graph:
     dec.dec_fps = opt.source_fps
     dec.num_buffers = opt.num_buffers
     decode.connect(
-        pyneat.nodes.input(input_name, encoded_decode_input_options(use_h265)),
+        pyneat.nodes.input(input_name, encoded_decode_input_options(opt.codec)),
         pyneat.nodes.sima_decode(dec),
     )
     if opt.use_videoconvert:
@@ -518,10 +517,10 @@ def build_decode_graph(input_name: str, opt) -> pyneat.Graph:
     return decode
 
 
-def build_video_sender_graph(input_name: str, use_h265: bool, video_options) -> pyneat.Graph:
+def build_video_sender_graph(input_name: str, codec, video_options) -> pyneat.Graph:
     video = pyneat.Graph("video_sender")
     video.connect(
-        pyneat.nodes.input(input_name, encoded_video_input_options(use_h265)),
+        pyneat.nodes.input(input_name, encoded_video_input_options(codec)),
         pyneat.groups.video_sender(video_options),
     )
     return video
@@ -613,6 +612,15 @@ def build_debug_frame_graph(stream_index: int) -> pyneat.Graph:
     return frames
 
 
+def make_video_options(cfg: AppConfig, stream_index: int):
+    video_options = pyneat.VideoSenderOptions.passthrough(rtsp_codec(cfg.codec))
+    video_options.host = cfg.insight_host
+    video_options.channel = stream_index
+    video_options.video_port_base = cfg.video_port_base
+    video_options.async_ = True
+    return video_options
+
+
 def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamRuntime:
     frame_w, frame_h, fps = probe_rtsp(url)
     output_fps = cfg.fps if cfg.fps > 0 else fps
@@ -620,15 +628,7 @@ def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamR
 
     video_port = 0
     if cfg.video_enabled:
-        video_options = (
-            pyneat.VideoSenderOptions.h265_rtp_udp_from_encoded()
-            if cfg.use_h265
-            else pyneat.VideoSenderOptions.h264_rtp_udp_from_encoded()
-        )
-        video_options.host = cfg.insight_host
-        video_options.channel = stream_index
-        video_options.video_port_base = cfg.video_port_base
-        video_port = video_options.video_port
+        video_port = make_video_options(cfg, stream_index).video_port
 
     metadata_options = pyneat.MetadataSenderOptions()
     metadata_options.host = cfg.insight_host
@@ -668,18 +668,10 @@ def connect_stream_graph(
         app.graph.connect(source, encoded_branch)
         app.graph.connect(encoded_branch, decoder, realtime_link(stream.index, 3))
 
-        video_options = (
-            pyneat.VideoSenderOptions.h265_rtp_udp_from_encoded()
-            if cfg.use_h265
-            else pyneat.VideoSenderOptions.h264_rtp_udp_from_encoded()
-        )
-        video_options.host = cfg.insight_host
-        video_options.channel = stream.index
-        video_options.video_port_base = cfg.video_port_base
-        video_options.async_ = True
+        video_options = make_video_options(cfg, stream.index)
         app.graph.connect(
             encoded_branch,
-            build_video_sender_graph("video_h264", cfg.use_h265, video_options),
+            build_video_sender_graph("video_h264", rtsp_codec(cfg.codec), video_options),
             realtime_link(stream.index, 3),
         )
     else:

--- a/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
+++ b/examples/tracking/multi-stream-people-tracker/tests/cpp/test_e2e.cpp
@@ -13,51 +13,50 @@ namespace fs = std::filesystem;
 using namespace sima_examples::testing;
 
 namespace {
+
+constexpr const char* kExampleName = "multi-stream-people-tracker";
 constexpr const char* kE2eInsightHost = "127.0.0.1";
-} // namespace
 
-int main(int argc, char** argv) {
-  if (argc < 2) {
-    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
-    return 2;
+struct SourceCase {
+  std::string codec;
+  std::vector<std::string> urls;
+};
+
+void record_unavailable_source(const std::string& fail_reason, const std::string& skip_reason,
+                               int& rc) {
+  if (require_e2e_mode()) {
+    std::cerr << "[FAIL] " << fail_reason << "\n";
+    rc = 1;
+  } else {
+    std::cerr << "[SKIP] " << skip_reason << "\n";
   }
+}
 
-  const std::string binary = argv[1];
-
-  const std::vector<std::string> rtsp_urls = rtsp_h264_urls_from_env();
-  if (rtsp_urls.size() < 2) {
-    return skip_or_fail("need at least two RTSP URLs for multistream e2e");
-  }
-
-  const char* models_dir_raw = env_or_null("SIMANEAT_APPS_TEST_MODELS_DIR");
-  const std::string models_dir = models_dir_raw ? models_dir_raw : "models";
-  const std::string model_path = configured_model_path("multi-stream-people-tracker", models_dir);
-  if (model_path.empty() || !fs::exists(model_path)) {
-    return skip_or_fail("configured detector model not found under SIMANEAT_APPS_TEST_MODELS_DIR");
-  }
-
+int run_source_case(const std::string& binary, const std::string& model_path,
+                    const SourceCase& source_case) {
   const std::string output_dir = create_test_output_dir(
-      "multi-stream-people-tracker", "test_multi_stream_insight_and_save_pipeline");
+      kExampleName, "test_multi_stream_" + source_case.codec + "_insight_and_save_pipeline");
   if (output_dir.empty()) {
     return 1;
   }
 
-  const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
-  const int total_saved_frames =
-      e2e_int("multi-stream-people-tracker", "testing.e2e.output", "total_saved_frames");
-  write_e2e_config("multi-stream-people-tracker", config_path,
+  const int total_saved_frames = e2e_int(kExampleName, "testing.e2e.output", "total_saved_frames");
+  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
+
+  const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
+  write_e2e_config(kExampleName, config_path,
                    {{"model.path", model_path},
+                    {"input.codec", source_case.codec},
                     {"output.debug_dir", output_dir},
                     {"output.insight.host", kE2eInsightHost},
                     {"output.insight.video_port_base", std::to_string(video_port_base)},
                     {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
                     {"inference.frames", "140"}},
-                   {{"streams", {rtsp_urls[0], rtsp_urls[1]}}});
+                   {{"streams", {source_case.urls[0], source_case.urls[1]}}});
 
-  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   MetadataJsonListenerOptions metadata_options;
   metadata_options.host = kE2eInsightHost;
   metadata_options.base_port = metadata_port_base;
@@ -68,7 +67,8 @@ int main(int argc, char** argv) {
   metadata_options.data_array_key = "tracks";
   MetadataJsonListener metadata_listener(metadata_options);
   if (!metadata_listener.ok()) {
-    std::cerr << "[FAIL] metadata listener failed: " << metadata_listener.error() << "\n";
+    std::cerr << "[FAIL] " << source_case.codec
+              << " metadata listener failed: " << metadata_listener.error() << "\n";
     remove_dir(output_dir);
     return 1;
   }
@@ -78,36 +78,87 @@ int main(int argc, char** argv) {
 
   int rc = 0;
   if (result.exit_code != 0) {
-    std::cerr << "[FAIL] exit code " << result.exit_code << "\n";
+    std::cerr << "[FAIL] " << source_case.codec << " exit code " << result.exit_code << "\n";
     std::cerr << "stdout:\n" << result.stdout_text << "\n";
     std::cerr << "stderr:\n" << result.stderr_text << "\n";
     rc = 1;
   } else {
     const int files = count_output_files(output_dir);
     if (files < total_saved_frames) {
-      std::cerr << "[FAIL] expected at least " << total_saved_frames
+      std::cerr << "[FAIL] " << source_case.codec << " expected at least " << total_saved_frames
                 << " sampled output files, got " << files << "\n";
       rc = 1;
     } else if (!all_output_files_nonempty(output_dir)) {
-      std::cerr << "[FAIL] some sampled output files are empty\n";
+      std::cerr << "[FAIL] " << source_case.codec << " some sampled output files are empty\n";
       rc = 1;
     } else {
-      std::cout << "[OK] multi-camera people tracker produced " << files
+      std::cout << "[OK] " << source_case.codec << " multi-camera people tracker produced " << files
                 << " sampled output files\n";
     }
   }
   if (rc == 0) {
     const MetadataJsonListenerResult metadata = metadata_listener.wait_for_messages();
     if (!metadata.success) {
-      std::cerr << "[FAIL] tracking metadata was not received on all streams: " << metadata.error
-                << "\n";
+      std::cerr << "[FAIL] " << source_case.codec
+                << " tracking metadata was not received on all streams: " << metadata.error << "\n";
       rc = 1;
     } else {
-      std::cout << "[OK] tracking metadata received on " << metadata.ports_with_valid_json.size()
-                << " streams\n";
+      std::cout << "[OK] " << source_case.codec << " tracking metadata received on "
+                << metadata.ports_with_valid_json.size() << " streams\n";
     }
   }
 
   remove_dir(output_dir);
+  return rc;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+
+  const std::string binary = argv[1];
+
+  const char* models_dir_raw = env_or_null("SIMANEAT_APPS_TEST_MODELS_DIR");
+  const std::string models_dir = models_dir_raw ? models_dir_raw : "models";
+  const std::string model_path = configured_model_path(kExampleName, models_dir);
+  if (model_path.empty() || !fs::exists(model_path)) {
+    return skip_or_fail("configured detector model not found under SIMANEAT_APPS_TEST_MODELS_DIR");
+  }
+
+  const std::vector<SourceCase> source_cases = {
+      {"h264", rtsp_h264_urls_from_env()},
+      {"h265", rtsp_h265_urls_from_env()},
+  };
+
+  int cases_run = 0;
+  int rc = 0;
+  for (const SourceCase& source_case : source_cases) {
+    if (source_case.urls.size() < 2) {
+      record_unavailable_source("need at least two RTSP " + source_case.codec +
+                                    " URLs for multistream e2e",
+                                "set at least two RTSP " + source_case.codec + " URLs to run " +
+                                    source_case.codec + " multistream e2e",
+                                rc);
+      continue;
+    }
+    ++cases_run;
+    if (run_source_case(binary, model_path, source_case) != 0) {
+      rc = 1;
+    }
+  }
+
+  if (cases_run == 0) {
+    if (require_e2e_mode()) {
+      std::cerr << "[FAIL] no multi-stream people tracker RTSP e2e URLs configured\n";
+      return 1;
+    }
+    std::cerr << "[SKIP] no multi-stream people tracker RTSP e2e URLs configured\n";
+    return kSkipCode;
+  }
+
   return rc;
 }

--- a/examples/tracking/multi-stream-people-tracker/tests/python/test_e2e.py
+++ b/examples/tracking/multi-stream-people-tracker/tests/python/test_e2e.py
@@ -28,23 +28,30 @@ def _env_int_or_default(name: str, default: int) -> int:
 
 @pytest.mark.e2e
 class TestE2E:
+    @pytest.mark.parametrize(
+        ("codec", "urls_fixture"),
+        [("h264", "rtsp_h264_urls"), ("h265", "rtsp_h265_urls")],
+    )
     def test_multi_stream_insight_and_save_pipeline(
         self,
+        request,
+        codec,
+        urls_fixture,
         e2e_model_path,
         tmp_output_dir,
-        rtsp_h264_urls,
         test_timeout_ms,
         skip_unless_e2e_ready,
         e2e_config_writer,
         e2e_config_section,
         run_until_output_files,
     ):
+        rtsp_urls = request.getfixturevalue(urls_fixture)
         skip_unless_e2e_ready(
             _runtime_deps_ready(),
             "python runtime dependencies (cv2, numpy, pyneat) are not available",
         )
         skip_unless_e2e_ready(
-            len(rtsp_h264_urls) >= 2, "need at least two RTSP H.264 URLs for multistream e2e"
+            len(rtsp_urls) >= 2, f"need at least two RTSP {codec.upper()} URLs for multistream e2e"
         )
         output_cfg = e2e_config_section("multi-stream-people-tracker", "testing.e2e.output")
         total_saved_frames = int(output_cfg["total_saved_frames"])
@@ -52,7 +59,8 @@ class TestE2E:
 
         config_path = e2e_config_writer(
             {
-                "streams": rtsp_h264_urls[:2],
+                "streams": rtsp_urls[:2],
+                "input": {"codec": codec},
                 "output": {
                     "insight": {
                         "host": E2E_INSIGHT_HOST,

--- a/examples/tracking/multi-stream-people-tracker/tests/python/test_unit.py
+++ b/examples/tracking/multi-stream-people-tracker/tests/python/test_unit.py
@@ -115,7 +115,7 @@ class TestConfigLoading:
         cfg = load_app_config(
             write_config(tmp_path, ["rtsp://127.0.0.1:8554/src1"], codec="hevc")
         )
-        assert cfg.use_h265
+        assert cfg.codec == "h265"
 
     def test_load_app_config_accepts_custom_inflight_limits(self, tmp_path: Path):
         from main import load_app_config
@@ -213,31 +213,28 @@ class TestConfigLoading:
 
 
 class TestRuntimeOptions:
-    def test_h265_input_options_use_encoded_caps(self, monkeypatch):
+    def test_encoded_input_options_carry_codec_format(self, monkeypatch):
         import main
 
         class FakeInputOptions:
-            caps_override = ""
+            format = ""
 
         fake_pyneat = SimpleNamespace(
             InputOptions=FakeInputOptions,
             PayloadType=SimpleNamespace(Encoded="encoded"),
-            Format=SimpleNamespace(H264="h264"),
+            Format=SimpleNamespace(H264="h264", H265="h265"),
+            RtspCodec=SimpleNamespace(H264="codec-h264", H265="codec-h265"),
             InputMemoryPolicy=SimpleNamespace(Ev74="ev74", SystemMemory="system"),
         )
         monkeypatch.setattr(main, "pyneat", fake_pyneat)
 
-        decode = main.encoded_decode_input_options(True)
-        video = main.encoded_video_input_options(True)
-        h264_decode = main.encoded_decode_input_options(False)
-        h264_video = main.encoded_video_input_options(False)
+        decode = main.encoded_decode_input_options(fake_pyneat.RtspCodec.H265)
+        video = main.encoded_video_input_options(fake_pyneat.RtspCodec.H265)
+        h264_decode = main.encoded_decode_input_options(fake_pyneat.RtspCodec.H264)
+        h264_video = main.encoded_video_input_options(fake_pyneat.RtspCodec.H264)
 
-        expected = (
-            "video/x-h265,parsed=(boolean)true,stream-format=(string)byte-stream,"
-            "alignment=(string)au"
-        )
-        assert decode.caps_override == expected
-        assert video.caps_override == expected
+        assert decode.format == "h265"
+        assert video.format == "h265"
         assert h264_decode.format == "h264"
         assert h264_video.format == "h264"
 


### PR DESCRIPTION
## Summary

An Apps user reading the RTSP examples had to follow codec handling spread across every call site. The three multi-stream examples stored a `bool use_h265` and branched at each use; four files each carried two copies of a raw GStreamer caps string; the encoded sender factory was chosen per codec; and the payload type was assigned through a per-codec field.

Each example now stores a codec value once and passes it to the Core APIs that became codec-parametric in sima-neat/core#640:

- `format = FormatTag::H265` replaces all ten `caps_override` copies, so no example contains raw GStreamer caps syntax. `grep -rn "x-h265" examples/` returns nothing.
- `Passthrough(codec)` replaces the per-codec sender factories, in both arms. No example calls `H264RtpUdpFromEncoded` or `H265RtpUdpFromEncoded`; the build is free of deprecation warnings.
- `payload_type` replaces the `h264_payload_type` / `h265_payload_type` branch.
- `single-stream-instance-segmenter` drops seven payload assignments that now match the resolved Core default exactly (96 for H.264 and H.265, 26 for MJPEG).

Two things are fixed along the way. The multi-stream object detector reported a passing H.264 run as skipped when H.265 URLs were unset, because the codec loop returned early and discarded the completed case; each codec is now reported independently. And `multi-stream-people-tracker` supported H.265 input but only tested H.264, so it gains that coverage in C++ and Python.

`VideoSenderOptions` is now constructed in one place per example via `make_video_options`, which also removed a pre-existing duplicate block between `build_stream_runtime` and `connect_stream_graph`.

Python keeps a codec string rather than the enum, because `load_app_config` runs before the lazy `pyneat` import.

## Change Type

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Docs
- [ ] Test-only
- [ ] Build/CI
- [ ] Breaking change

## Risk

- [ ] Low
- [x] Medium
- [ ] High

Risk notes:

Touches five examples across C++ and Python, including their input configuration, decode path, and encoded video output. No behavior change is intended for H.264, which remains the default. The payload assignments removed from the segmenter were verified against `resolve_payload_type()` in Core rather than assumed: with `payload_type` left at `-1`, Core resolves 96 for H.264 and H.265 and 26 for MJPEG, which is exactly what those lines set.

One deliberate behavior change: `make_video_options` sets `async = true` unconditionally, whereas the pre-existing `build_stream_runtime` block did not set it. That call site reads only `.video_port()`, which is `video_port_base + channel` and independent of `async`, so it is inert there.

## Test Evidence

Commands run and outcomes:

```text
cmake configure + build (Neat SDK, against the sima-neat/core#640 branch)
  EXIT=0, zero errors, zero warnings, 35 targets
  no -Wdeprecated-declarations for H264RtpUdpFromEncoded, confirming every
  sender call site migrated

pytest, per example (run separately; all three files share the basename
test_unit.py, which collides under a single pytest invocation)
  multi-stream-object-detector                 13 passed
  high-density-multi-stream-object-detector    41 passed
  multi-stream-people-tracker                  15 passed

clang-format --dry-run --Werror                clean on all changed C++ files
```

Not run: live e2e on Modalix. The board decoder currently accepts buffers and emits none, which fails independently of this change — the pre-change binary reproduces it identically against a Core build from the previously validated branch, and it fails the same way on H.264 with the correct model pack. That is being investigated separately and is not a regression from this PR. The per-codec reporting fix is nonetheless observable in those runs: the tests now report `h264` and `h265` outcomes separately instead of aborting on the first.

Note on the skip semantics: this follows the existing `record_unavailable_source(...)` pattern from `single-stream-object-detector`, which under `SIMANEAT_APPS_TEST_REQUIRE_E2E=1` still fails for a codec whose URLs are missing. The bug being fixed is the discarded passing run, not the strictness of that flag. Issue sima-neat/apps#388 words its criterion more loosely; say so in review if you want the flag inverted instead.

## Docs Impact

- [x] No docs update needed
- [ ] Docs updated in this PR
- [ ] Docs follow-up required (linked issue)

Docs notes:

The example READMEs already document `input.codec` as `h264/avc` or `h265/hevc`, which is unchanged. Configuration keys and their accepted values are identical; only the internal representation changed.

## Migration Impact

- [x] No migration impact
- [ ] Migration required and documented

Migration notes:

No user-facing configuration changes. Existing config files continue to work unmodified.

## Dependencies

Requires sima-neat/core#640 (PR sima-neat/core#643). This PR does not build against a Core without `FormatTag::H265`, `payload_type`, and `Passthrough`.

Because `deps/manifest.json` declares `"neat-core": {"policy": "snap"}`, Apps CI resolves Core from a branch of the same name and its `latest` artifact, so this branch is named to match and cannot go green until the Core branch has published and promoted.

## Out of scope

The `SimaDecodeType` selection remains. Six `dec.type = ... ? SimaDecodeType::H265 : SimaDecodeType::H264` sites survive, because `RtspCodec` and `SimaDecodeType` are consolidated in sima-neat/core#638. This PR therefore removes three of the four per-codec branches in each example, not all four.

Closes #388
Refs #380
Refs #381
