### PR TITLE
docs(examples): document H.265 in the multi-stream prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ to compile source or run the Apps test suite.
 streaming sources. Install videos directly from the Insight catalog or through
 YouTube support, start the required streams in the Insight Web UI, and copy
 their source URLs into the example configuration. Each example README identifies
-the required transport, including HTTP MJPEG where supported. Ensure each URL is
-reachable from the target.
+the required transport and codec. RTSP examples decode H.264 or H.265, selected
+by the example's `codec` setting; the single-stream object detector and instance
+segmenter also accept MJPEG over RTSP or HTTP. Ensure each URL is reachable from
+the target.
 
 ## Development From Source
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,8 @@ to compile source or run the Apps test suite.
 streaming sources. Install videos directly from the Insight catalog or through
 YouTube support, start the required streams in the Insight Web UI, and copy
 their source URLs into the example configuration. Each example README identifies
-the required transport and codec. RTSP examples decode H.264 or H.265, selected
-by the example's `codec` setting; the single-stream object detector and instance
-segmenter also accept MJPEG over RTSP or HTTP. Ensure each URL is reachable from
-the target.
+the required transport, including HTTP MJPEG where supported. Ensure each URL is
+reachable from the target.
 
 ## Development From Source
 

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -52,6 +52,7 @@ The 48-stream profile running in Insight:
 - An [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the DevKit.
 - 16, 24, or 48 H.264 or H.265 RTSP sources matching `input.codec` and the selected profile.
 - For H.265, the computer running the Insight viewer must support hardware HEVC decoding; Chromium does not provide a software decoder fallback for WebRTC H.265.
+- H.265 playback in Chrome on macOS renders, but is not stable. Chrome's WebRTC HEVC decoder can stop producing frames mid-stream and fall back to a null decoder that discards what follows, at which point the tile stalls until the viewer reconnects it.
 - Constant source frame rate, 1280×720 resolution, no B-frames in the selected codec, and a short, regular IDR interval. The validated sources use one IDR per second.
 - The `yolo26n-det-int8-b1.tar.gz` model pack.
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -14,7 +14,7 @@
 
 ## Concept
 
-This example runs a config-driven multi-stream RTSP H.264/H.265 detection pipeline and publishes video plus detection metadata for each stream to Insight.
+This example runs a config-driven multi-stream RTSP detection pipeline and publishes video plus detection metadata for each stream to Insight.
 
 ## Preview
 

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -14,7 +14,7 @@
 
 ## Concept
 
-This example runs a config-driven multi-stream RTSP detection pipeline and publishes video plus detection metadata for each stream to Insight.
+This example runs a config-driven multi-stream RTSP H.264/H.265 detection pipeline and publishes video plus detection metadata for each stream to Insight.
 
 ## Preview
 
@@ -23,7 +23,8 @@ This example runs a config-driven multi-stream RTSP detection pipeline and publi
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- RTSP sources and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
+- H.264 or H.265 RTSP sources matching `input.codec`, and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
+- For H.265, the computer running the Insight viewer must support hardware HEVC decoding; Chromium does not provide a software decoder fallback for WebRTC H.265.
 
 ## Install Apps
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -14,7 +14,7 @@
 
 ## Concept
 
-Track people across multiple RTSP inputs with mixed-resolution support. The pipeline filters detections to the configured person class, assigns stable IDs per stream, and publishes live video and metadata to Insight.
+Track people across multiple RTSP H.264/H.265 inputs with mixed-resolution support. The pipeline filters detections to the configured person class, assigns stable IDs per stream, and publishes live video and metadata to Insight.
 
 ## Preview
 
@@ -23,7 +23,8 @@ Track people across multiple RTSP inputs with mixed-resolution support. The pipe
 ## Prerequisites
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix or DevKit target.
-- RTSP sources and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
+- H.264 or H.265 RTSP sources matching `input.codec`, and an [Insight](https://developer.sima.ai/software/tools/insight/) URL reachable from the target.
+- For H.265, the computer running the Insight viewer must support hardware HEVC decoding; Chromium does not provide a software decoder fallback for WebRTC H.265.
 
 ## Install Apps
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -14,7 +14,7 @@
 
 ## Concept
 
-Track people across multiple RTSP H.264/H.265 inputs with mixed-resolution support. The pipeline filters detections to the configured person class, assigns stable IDs per stream, and publishes live video and metadata to Insight.
+Track people across multiple RTSP inputs with mixed-resolution support. The pipeline filters detections to the configured person class, assigns stable IDs per stream, and publishes live video and metadata to Insight.
 
 ## Preview
 


### PR DESCRIPTION
## Summary

H.265 RTSP input landed in #381, but `multi-stream-object-detector` and `multi-stream-people-tracker` still listed plain "RTSP sources" as their prerequisite, leaving the config comment `codec: h264  # h264/avc or h265/hevc` as the only place H.265 appeared. A user reading the prerequisites before configuring streams could not tell that H.265 is accepted, or what the viewer side needs.

Both READMEs now state the accepted codecs in Prerequisites and carry the hardware HEVC viewer requirement. That requirement is not boilerplate copied from `high-density-multi-stream-object-detector`: both examples call `VideoSenderOptions::Passthrough(cfg.codec)`, so H.265 input reaches the browser as H.265, and Chromium has no software decoder fallback for WebRTC H.265.

`high-density-multi-stream-object-detector` gains one prerequisite bullet for a limitation observed during H.265 validation: Chrome on macOS renders H.265 but does not play it back reliably. Its WebRTC HEVC decoder can stop producing frames mid-stream and fall back to a null decoder that discards what follows, leaving the tile stalled until the viewer reconnects it. A viewer that satisfies the hardware HEVC requirement can still hit this, and the stall is viewer-side rather than an application fault, so the two are documented together.

Unchanged on purpose. The root README describes transport at the level of the example catalog, and each example README is the place that names its codec. `single-stream-object-detector` and `single-stream-instance-segmenter` already document H.264/H.265/MJPEG and re-encode to H.264 for Insight, so neither viewer note applies to them. `detection-to-vlm-assistant` has no `codec` key and is H.264-only. No codec tag is added to the metadata tables, because no example tags a codec today and a lone `h265` tag would create a portal facet matching a few examples.

## Change Type

- [ ] Bug fix
- [ ] Refactor
- [ ] Feature
- [x] Docs
- [ ] Test-only
- [ ] Build/CI
- [ ] Breaking change

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Risk notes:

Documentation only: three prerequisite bullets across three example READMEs. No source, config, test, or generated-catalog content changes; the portal `summary` field reads the Concept line, which is untouched.

## Test Evidence

Commands run and outcomes:

```text
python3 scripts/validate_readmes.py
  RESULT: PASSED (14 READMEs), EXIT=0

git diff origin/develop --stat
  3 files changed, 5 insertions(+), 2 deletions(-)
```

Claims verified against source rather than assumed:

```text
multi-stream-object-detector/src/cpp/main.cpp:617
multi-stream-people-tracker/src/cpp/main.cpp:620
  VideoSenderOptions::Passthrough(cfg.codec) -> input codec reaches Insight,
  which is why the HEVC viewer requirement applies to these two examples

single-stream-object-detector/src/cpp/main.cpp:694
  video_options.encoder.bitrate_kbps -> H.264 re-encode, no viewer note needed

grep -rn "codec" --include="config*.yaml" examples/
  seven configs expose a codec key; the two edited examples accept h264/h265
```

The Chrome-on-macOS playback stall is reported from H.265 validation of the high-density profiles, not derived from repository source. No Modalix or SDK run was performed for this PR, and none applies: it changes no compiled or executed code path.

Refs #392
