### PR TITLE
feat(deps): target platform 2.1.3 with Model Zoo 2.1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,10 @@ Each example README must identify:
 - the corresponding `sima-cli` command when that source supports it
 - the downloaded package selected by `model.path`
 
-Use `models/` for user-managed packages. Before downloading a model, read the
-installed platform version from `DISTRO_VERSION` in `/etc/buildinfo`.
+Use `models/` for user-managed packages. Model downloads use the Model Zoo
+version, which can differ from the installed platform version. Take it from
+`modelzoo-version` in `deps/manifest.json`, and keep the literal documented in
+example READMEs in sync with that field.
 
 Do not infer application support from every model declared in
 `tests/test-scope.yaml`. That file owns test acquisition. Confirm supported

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SiMa Neat Apps
 
 ![Vulcan CI](https://github.com/sima-neat/apps/actions/workflows/vulcan-ci.yml/badge.svg)
-![Neat Development Environment](https://img.shields.io/badge/Neat%20Development%20Environment-2.1.2-green)
+![Neat Development Environment](https://img.shields.io/badge/Neat%20Development%20Environment-2.1.3-green)
 ![Language](https://img.shields.io/badge/C%2B%2B-20-informational)
 
 SiMa Neat Apps provides runnable C++ and Python examples for detection,
@@ -56,13 +56,21 @@ under `models/`, or set `model.path` to another readable package. Each
 example README lists its default and additional supported models with the
 corresponding `sima-cli` or example-specific installation command.
 
-Check the installed platform version:
+Check the installed platform version to confirm the target is supported:
 
 ```bash
 cat /etc/buildinfo
 ```
 
-Before downloading a model, set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Runtime sample data is included under `assets/datasets/`.
+Model packages are versioned separately from the platform. They come from the
+Model Zoo release, which can differ from the installed platform version.
+Before downloading a model, set the Model Zoo version:
+
+```bash
+export MODELZOO_VERSION="2.1.2"
+```
+
+Runtime sample data is included under `assets/datasets/`.
 
 ## Installed Layout
 
@@ -124,7 +132,7 @@ curl -fsSL https://raw.githubusercontent.com/sima-neat/apps/main/scripts/get-exa
 
 ## Dependency Selection
 
-`deps/manifest.json` selects Core and records the SDK channel and platform version. Development uses the `snap` policy, while a release-preparation branch can select an exact Core artifact. Vulcan records the resolved Core target under package metadata and the Apps installer uses that same target. Insight is not pinned in the Apps manifest.
+`deps/manifest.json` selects Core and records the SDK channel, the platform version, and the Model Zoo version used for model downloads. Development uses the `snap` policy, while a release-preparation branch can select an exact Core artifact. Vulcan records the resolved Core target under package metadata and the Apps installer uses that same target. Insight is not pinned in the Apps manifest.
 
 ## Support
 

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -5,5 +5,6 @@
   "sdk": {
     "channel": "develop"
   },
-  "platform-version": "2.1.2"
+  "platform-version": "2.1.3",
+  "modelzoo-version": "2.1.2"
 }

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -49,16 +49,15 @@ The default model is `<default-model>`.
 | `<default-model>` | Default | <Model Zoo / direct artifact> |
 | `<supported-model>` | Supported | <Model Zoo / direct artifact> |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Use the command that matches the model source and delete the other command.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get <model-name>
+sima-cli modelzoo -v "${MODELZOO_VERSION}" get <model-name>
 cd ..
 ```
 

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -42,14 +42,13 @@ Run the remaining commands from `prebuilt-apps/`.
 
 This example accepts any compatible compiled MPK. Apps CI exercises the benchmark with `yolo26m-det-int8-b1.tar.gz`; it is not a required default.
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Download a Model Zoo package:
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Download a Model Zoo package:
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get <model-name>
+sima-cli modelzoo -v "${MODELZOO_VERSION}" get <model-name>
 cd ..
 ```
 

--- a/examples/benchmarking/model-benchmark/tests/test-scope.yaml
+++ b/examples/benchmarking/model-benchmark/tests/test-scope.yaml
@@ -9,11 +9,11 @@ models:
     file: depth_anything_v2_vits_mpk.tar.gz
   retinaface_mobilenet25:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
     file: retinaface_mobilenet25_mod_0_mpk.tar.gz
   detr_resnet50_modified_class_embed_bbox_embed:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
     file: detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
   yolo_v8n_seg:
     source: modelzoo
@@ -21,63 +21,63 @@ models:
     file: yolo_v8n_seg_mpk.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
   yolo26n-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
     file: yolo26n-seg-bf16-mla_tess.tar.gz
   yolo26s-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
     file: yolo26s-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
     file: yolo26m-seg-bf16-mla_tess.tar.gz
   yolo26l-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
     file: yolo26l-seg-bf16-mla_tess.tar.gz
   yolo26x-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
     file: yolo26x-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
     file: yolo26m-seg-bf16-b1.tar.gz
   yolo26m-seg-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
     file: yolo26m-seg-bf16-mla_tess-b1.tar.gz
   yolo26m-seg-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
     file: yolo26m-seg-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -43,14 +43,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `resnet_50_mpk.tar.gz` | Default | `resnet_50` |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get resnet_50
+sima-cli modelzoo -v "${MODELZOO_VERSION}" get resnet_50
 cd ..
 ```
 

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -41,14 +41,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `depth_anything_v2_vits_mpk.tar.gz` | Default | `depth_anything_v2_vits` |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get depth_anything_v2_vits
+sima-cli modelzoo -v "${MODELZOO_VERSION}" get depth_anything_v2_vits
 cd ..
 ```
 

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -43,14 +43,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `retinaface_mobilenet25_mod_0_mpk.tar.gz` | Default | Direct artifact |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz"
 cd ..
 ```
 

--- a/examples/face-detection/face-detector/tests/test-scope.yaml
+++ b/examples/face-detection/face-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   retinaface_mobilenet25:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz
     file: retinaface_mobilenet25_mod_0_mpk.tar.gz
 unit:
   python: true

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -51,14 +51,13 @@ Supported detector packages:
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/genai/detection-to-vlm-assistant/tests/test-scope.yaml
+++ b/examples/genai/detection-to-vlm-assistant/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   vlm-genai-server:
     source: huggingface

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -43,14 +43,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` | Default | Direct artifact |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz"
 cd ..
 ```
 

--- a/examples/object-detection/detr-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/detr-object-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   detr_resnet50_modified_class_embed_bbox_embed:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
     file: detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz
 unit:
   python: true

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -75,14 +75,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | --- | --- | --- |
 | `yolo26n-det-int8-b1.tar.gz` | Default | Direct artifact |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz"
 cd ..
 ```
 

--- a/examples/object-detection/high-density-multi-stream-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/high-density-multi-stream-object-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   yolo26n-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz
     file: yolo26n-det-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -49,14 +49,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/object-detection/multi-stream-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/multi-stream-object-detector/tests/test-scope.yaml
@@ -1,31 +1,31 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -48,14 +48,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/object-detection/single-stream-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/single-stream-object-detector/tests/test-scope.yaml
@@ -1,31 +1,31 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -47,14 +47,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 | `yolo26m-det-int8-b1.tar.gz` | Supported |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/object-detection/yolo26-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/yolo26-object-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
 unit:
   python: true

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -49,14 +49,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-seg-int8-b1.tar.gz` | Supported |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-segmentation/<model-file>"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-segmentation/<model-file>"
 cd ..
 ```
 

--- a/examples/segmentation/single-stream-instance-segmenter/tests/test-scope.yaml
+++ b/examples/segmentation/single-stream-instance-segmenter/tests/test-scope.yaml
@@ -1,35 +1,35 @@
 models:
   yolo26n-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26n-seg-bf16-mla_tess.tar.gz
     file: yolo26n-seg-bf16-mla_tess.tar.gz
   yolo26s-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26s-seg-bf16-mla_tess.tar.gz
     file: yolo26s-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess.tar.gz
     file: yolo26m-seg-bf16-mla_tess.tar.gz
   yolo26l-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26l-seg-bf16-mla_tess.tar.gz
     file: yolo26l-seg-bf16-mla_tess.tar.gz
   yolo26x-seg-bf16-mla_tess:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26x-seg-bf16-mla_tess.tar.gz
     file: yolo26x-seg-bf16-mla_tess.tar.gz
   yolo26m-seg-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-b1.tar.gz
     file: yolo26m-seg-bf16-b1.tar.gz
   yolo26m-seg-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-bf16-mla_tess-b1.tar.gz
     file: yolo26m-seg-bf16-mla_tess-b1.tar.gz
   yolo26m-seg-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-segmentation/yolo26m-seg-int8-b1.tar.gz
     file: yolo26m-seg-int8-b1.tar.gz
 unit:
   python: true

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -44,14 +44,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo_v8m_seg_mpk.tar.gz` | Supported | `yolo_v8m_seg` |
 | `yolo_v8l_seg_mpk.tar.gz` | Supported | `yolo_v8l_seg` |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-name>` with a model from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-name>` with a model from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "${PLATFORM_VERSION}" get <model-name>
+sima-cli modelzoo -v "${MODELZOO_VERSION}" get <model-name>
 cd ..
 ```
 

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -49,14 +49,13 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
 
-Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${PLATFORM_VERSION}/models/modalix/yolo26-detection/<model-file>"
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"
 cd ..
 ```
 

--- a/examples/tracking/multi-stream-people-tracker/tests/test-scope.yaml
+++ b/examples/tracking/multi-stream-people-tracker/tests/test-scope.yaml
@@ -1,31 +1,31 @@
 models:
   yolo26m-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-mla_tess-b1.tar.gz
     file: yolo26m-det-bf16-mla_tess-b1.tar.gz
   yolo26n-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26n-det-bf16-mla_tess-b1.tar.gz
     file: yolo26n-det-bf16-mla_tess-b1.tar.gz
   yolo26s-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26s-det-bf16-mla_tess-b1.tar.gz
     file: yolo26s-det-bf16-mla_tess-b1.tar.gz
   yolo26l-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26l-det-bf16-mla_tess-b1.tar.gz
     file: yolo26l-det-bf16-mla_tess-b1.tar.gz
   yolo26x-det-bf16-mla_tess-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26x-det-bf16-mla_tess-b1.tar.gz
     file: yolo26x-det-bf16-mla_tess-b1.tar.gz
   yolo26m-det-bf16-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-bf16-b1.tar.gz
     file: yolo26m-det-bf16-b1.tar.gz
   yolo26m-det-int8-b1:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b1.tar.gz
     file: yolo26m-det-int8-b1.tar.gz
 unit:
   python: true

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -242,16 +242,15 @@ The default model is \`<default-model>\`.
 | \`<default-model>\` | Default | <Model Zoo / direct artifact> |
 | \`<supported-model>\` | Supported | <Model Zoo / direct artifact> |
 
-Check the installed platform version, then set \`PLATFORM_VERSION\` to the displayed \`DISTRO_VERSION\` value. Use the command that matches the model source and delete the other command.
+Model packages come from the Model Zoo release below, which can differ from the installed platform version. Use the command that matches the model source and delete the other command.
 
 Model Zoo:
 
 \`\`\`bash
-cat /etc/buildinfo
-export PLATFORM_VERSION="<platform-version>"
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "\${PLATFORM_VERSION}" get <model-name>
+sima-cli modelzoo -v "\${MODELZOO_VERSION}" get <model-name>
 cd ..
 \`\`\`
 

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -25,7 +25,10 @@ SCOPE_PYTHON="${TEST_SCOPE_PYTHON_BIN:-${PYTHON_TEST_BIN:-python3}}"
 VERSION_PYTHON="${PYTHON_TEST_BIN:-python3}"
 export SIMA_CLI_CHECK_FOR_UPDATE="${SIMA_CLI_CHECK_FOR_UPDATE:-0}"
 
-detect_platform_version() {
+# Model assets follow the published Model Zoo release, which can lag the platform
+# release. modelzoo-version selects it; platform-version is the fallback for
+# manifests written before the two versions were separated.
+detect_modelzoo_version() {
     "$VERSION_PYTHON" - "$ROOT/deps/manifest.json" <<'PY'
 import json
 import sys
@@ -36,24 +39,27 @@ try:
     manifest = json.loads(path.read_text(encoding="utf-8"))
 except FileNotFoundError:
     print(
-        f"ERROR: Missing manifest: {path}. Set NEAT_APPS_PLATFORM_VERSION to override.",
+        f"ERROR: Missing manifest: {path}. Set NEAT_APPS_MODELZOO_VERSION to override.",
         file=sys.stderr,
     )
     raise SystemExit(1)
 
-platform_version = manifest.get("platform-version")
-if not isinstance(platform_version, str) or not platform_version.strip():
-    print(f"ERROR: {path} must define platform-version as a non-empty string.", file=sys.stderr)
+version = manifest.get("modelzoo-version") or manifest.get("platform-version")
+if not isinstance(version, str) or not version.strip():
+    print(
+        f"ERROR: {path} must define modelzoo-version or platform-version as a non-empty string.",
+        file=sys.stderr,
+    )
     raise SystemExit(1)
-print(platform_version.strip())
+print(version.strip())
 PY
 }
 
-PLATFORM_VERSION="${NEAT_APPS_PLATFORM_VERSION:-}"
+MODELZOO_VERSION="${NEAT_APPS_MODELZOO_VERSION:-}"
 
-ensure_platform_version() {
-    if [[ -z "$PLATFORM_VERSION" ]]; then
-        PLATFORM_VERSION="$(detect_platform_version)"
+ensure_modelzoo_version() {
+    if [[ -z "$MODELZOO_VERSION" ]]; then
+        MODELZOO_VERSION="$(detect_modelzoo_version)"
     fi
 }
 
@@ -67,7 +73,7 @@ Options:
   --scope-file <path>   Test scope source file or directory (default: examples)
   --kind <kind>         Scope kind to resolve (default: e2e)
   --language <lang>     Scope language to include; repeatable (python, cpp)
-  NEAT_APPS_PLATFORM_VERSION can override the platform version.
+  NEAT_APPS_MODELZOO_VERSION can override the Model Zoo version.
   -h, --help            Show help
 EOF
 }
@@ -196,12 +202,12 @@ download_modelzoo_model() {
         return 0
     fi
     ensure_sima_cli_bin
-    ensure_platform_version
+    ensure_modelzoo_version
 
     local before
     before=$(find "$MODELS_DIR" -maxdepth 1 -type f -name '*.tar.gz' | wc -l)
-    echo "[download] $model_id (modelzoo: $model_name, platform-version: $PLATFORM_VERSION)"
-    (cd "$MODELS_DIR" && "$SIMA_CLI_BIN" modelzoo -v "$PLATFORM_VERSION" get "$model_name")
+    echo "[download] $model_id (modelzoo: $model_name, modelzoo-version: $MODELZOO_VERSION)"
+    (cd "$MODELS_DIR" && "$SIMA_CLI_BIN" modelzoo -v "$MODELZOO_VERSION" get "$model_name")
 
     local after
     after=$(find "$MODELS_DIR" -maxdepth 1 -type f -name '*.tar.gz' | wc -l)
@@ -220,9 +226,16 @@ download_url_model() {
     local expected_file="$3"
     local tmpdir
     local downloaded_files=()
-    if [[ "$url" == *"{platform_version}"* ]]; then
-        ensure_platform_version
-        url="${url//\{platform_version\}/$PLATFORM_VERSION}"
+    if [[ "$url" == *"{modelzoo_version}"* ]]; then
+        ensure_modelzoo_version
+        url="${url//\{modelzoo_version\}/$MODELZOO_VERSION}"
+    fi
+
+    # An unsubstituted placeholder would otherwise reach sima-cli verbatim and
+    # fail as an opaque 404 rather than naming the scope file mistake.
+    if [[ "$url" == *"{"*"}"* ]]; then
+        echo "[error] $model_id has an unsupported URL placeholder: $url" >&2
+        return 1
     fi
 
     if model_exists "$model_id" "$expected_file"; then

--- a/tests/scripts/test_modelzoo_version_pin.py
+++ b/tests/scripts/test_modelzoo_version_pin.py
@@ -2,47 +2,95 @@
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 
 APPS_ROOT = Path(__file__).resolve().parents[2]
 
+# The runtime bundle ships neither deps/manifest.json nor download_models.sh, so
+# customer-facing commands carry a copy-pasteable literal instead of resolving the
+# version at run time. These tests are what keeps that literal honest.
+DOCUMENTED_VERSION_RE = re.compile(r'export MODELZOO_VERSION="([^"]+)"')
+PLATFORM_BADGE_RE = re.compile(r"Neat%20Development%20Environment-([^-]+)-")
+# Scope files interpolate the version at download time. A hardcoded SDK<version>
+# would still download successfully, so only a static check catches it.
+SCOPE_VERSION_LITERAL_RE = re.compile(r"SDK\d")
 
-def _files_requiring_pinned_modelzoo_calls() -> list[Path]:
+
+def _manifest() -> dict:
+    manifest = APPS_ROOT / "deps" / "manifest.json"
+    return json.loads(manifest.read_text(encoding="utf-8"))
+
+
+def _manifest_modelzoo_version() -> str:
+    manifest = _manifest()
+    return (manifest.get("modelzoo-version") or manifest["platform-version"]).strip()
+
+
+def _scope_files() -> list[Path]:
+    return sorted((APPS_ROOT / "examples").glob("*/*/tests/test-scope.yaml"))
+
+
+def _documented_surfaces() -> list[Path]:
     files = [
-        APPS_ROOT / "scripts" / "download_models.sh",
-        APPS_ROOT / "support" / "runtime" / "asset_utils.cpp",
+        APPS_ROOT / "README.md",
         APPS_ROOT / "examples" / "TEMPLATE_README.md",
+        APPS_ROOT / "scripts" / "create_example_scaffold.sh",
     ]
     files.extend(sorted((APPS_ROOT / "examples").glob("*/*/README.md")))
-    files.extend(sorted((APPS_ROOT / "examples").glob("*/*/tests/test-scope.yaml")))
-    files.append(
-        APPS_ROOT
-        / "examples"
-        / "object-detection"
-        / "single-stream-object-detector"
-        / "src"
-        / "python"
-        / "main.py"
-    )
     return files
 
 
-def test_apps_surfaces_do_not_hardcode_model_platform_version():
+def test_documented_modelzoo_version_matches_manifest():
+    expected = _manifest_modelzoo_version()
     offenders: list[str] = []
-    blocked = [
-        "modelzoo get",
-        "modelzoo -v 2.0.0",
-        "SDK2.0.0",
-        "{sdk_version}",
-        "NEAT_APPS_MODEL_SDK_VERSION",
-        "MODEL_SDK_VERSION",
+    documented = 0
+
+    for path in _documented_surfaces():
+        for version in DOCUMENTED_VERSION_RE.findall(path.read_text(encoding="utf-8")):
+            documented += 1
+            if version != expected:
+                name = path.relative_to(APPS_ROOT)
+                offenders.append(f"{name}: {version} != {expected}")
+
+    assert offenders == []
+    # Examples that install models from Hugging Face document no version, but the
+    # pinned surfaces must never all disappear without this test noticing.
+    assert documented > 0
+
+
+def test_scope_files_interpolate_the_version_instead_of_hardcoding_it():
+    """READMEs pin a literal; scope files must not. Documenting the asymmetry."""
+    offenders = [
+        str(path.relative_to(APPS_ROOT))
+        for path in _scope_files()
+        if SCOPE_VERSION_LITERAL_RE.search(path.read_text(encoding="utf-8"))
     ]
 
-    for path in _files_requiring_pinned_modelzoo_calls():
-        text = path.read_text(encoding="utf-8")
-        matches = [pattern for pattern in blocked if pattern in text]
-        if matches:
-            offenders.append(f"{path.relative_to(APPS_ROOT)}: {', '.join(matches)}")
+    assert offenders == []
+
+
+def test_readme_platform_badge_matches_manifest():
+    expected = _manifest()["platform-version"].strip()
+    readme = (APPS_ROOT / "README.md").read_text(encoding="utf-8")
+    badge = PLATFORM_BADGE_RE.search(readme)
+
+    assert badge is not None
+    assert badge.group(1) == expected
+
+
+def test_apps_surfaces_do_not_call_modelzoo_without_a_version():
+    scanned = [
+        *_documented_surfaces(),
+        APPS_ROOT / "scripts" / "download_models.sh",
+        APPS_ROOT / "support" / "runtime" / "asset_utils.cpp",
+    ]
+    offenders = [
+        str(path.relative_to(APPS_ROOT))
+        for path in scanned
+        if "modelzoo get" in path.read_text(encoding="utf-8")
+    ]
 
     assert offenders == []

--- a/tests/scripts/test_scope_contract.py
+++ b/tests/scripts/test_scope_contract.py
@@ -235,14 +235,14 @@ def test_download_models_preserves_empty_url_model_name(tmp_path):
     assert "[skip] url-demo already exists" in result.stdout
 
 
-def test_download_models_expands_platform_version_placeholder(tmp_path):
+def test_download_models_expands_modelzoo_version_placeholder(tmp_path):
     if subprocess.run(["bash", "-lc", "type mapfile"], capture_output=True).returncode != 0:
         pytest.skip("download_models.sh requires bash with mapfile support")
 
     fake_scope_python = tmp_path / "fake_scope_python"
     fake_scope_python.write_text(
         "#!/usr/bin/env bash\n"
-        "printf 'url-demo\\turl\\t\\thttps://example.test/SDK{platform_version}/demo-file.tar.gz\\tdemo-file.tar.gz\\t\\t\\n'\n",
+        "printf 'url-demo\\turl\\t\\thttps://example.test/SDK{modelzoo_version}/demo-file.tar.gz\\tdemo-file.tar.gz\\t\\t\\n'\n",
         encoding="utf-8",
     )
     fake_scope_python.chmod(0o755)
@@ -270,7 +270,7 @@ def test_download_models_expands_platform_version_placeholder(tmp_path):
             "MODELS_DIR": str(tmp_path / "models"),
             "TEST_SCOPE_PYTHON_BIN": str(fake_scope_python),
             "SIMA_CLI_BIN": str(fake_sima_cli),
-            "NEAT_APPS_PLATFORM_VERSION": "2.1.1",
+            "NEAT_APPS_MODELZOO_VERSION": "2.1.1",
             "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(sima_cli_args),
         },
         capture_output=True,
@@ -283,7 +283,56 @@ def test_download_models_expands_platform_version_placeholder(tmp_path):
     )
 
 
-def test_download_models_uses_manifest_platform_version_for_modelzoo(tmp_path):
+def test_download_models_rejects_unknown_url_placeholder(tmp_path):
+    if subprocess.run(["bash", "-lc", "type mapfile"], capture_output=True).returncode != 0:
+        pytest.skip("download_models.sh requires bash with mapfile support")
+
+    fake_scope_python = tmp_path / "fake_scope_python"
+    fake_scope_python.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf 'url-demo\\turl\\t\\thttps://example.test/SDK{platform_version}/demo-file.tar.gz\\tdemo-file.tar.gz\\t\\t\\n'\n",
+        encoding="utf-8",
+    )
+    fake_scope_python.chmod(0o755)
+
+    fake_sima_cli = tmp_path / "sima-cli"
+    fake_sima_cli.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_sima_cli.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(APPS_ROOT / "scripts" / "download_models.sh"),
+            "--language",
+            "python",
+        ],
+        cwd=APPS_ROOT,
+        env={
+            **os.environ,
+            "MODELS_DIR": str(tmp_path / "models"),
+            "TEST_SCOPE_PYTHON_BIN": str(fake_scope_python),
+            "SIMA_CLI_BIN": str(fake_sima_cli),
+            "NEAT_APPS_MODELZOO_VERSION": "2.1.1",
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "unsupported URL placeholder" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("manifest_json", "expected_version"),
+    [
+        ('{"platform-version": "2.1.3", "modelzoo-version": "2.1.2"}\n', "2.1.2"),
+        ('{"platform-version": "2.1.1"}\n', "2.1.1"),
+    ],
+    ids=["modelzoo-version-wins", "platform-version-fallback"],
+)
+def test_download_models_resolves_modelzoo_version_from_manifest(
+    tmp_path, manifest_json, expected_version
+):
     if subprocess.run(["bash", "-lc", "type mapfile"], capture_output=True).returncode != 0:
         pytest.skip("download_models.sh requires bash with mapfile support")
 
@@ -297,7 +346,7 @@ def test_download_models_uses_manifest_platform_version_for_modelzoo(tmp_path):
         encoding="utf-8",
     )
     script.chmod(0o755)
-    manifest.write_text('{"platform-version": "2.1.1"}\n', encoding="utf-8")
+    manifest.write_text(manifest_json, encoding="utf-8")
 
     sima_cli_args = tmp_path / "sima-cli-args.txt"
     fake_sima_cli = tmp_path / "sima-cli"
@@ -324,5 +373,5 @@ def test_download_models_uses_manifest_platform_version_for_modelzoo(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert sima_cli_args.read_text(encoding="utf-8").strip() == (
-        "modelzoo -v 2.1.1 get resnet_50"
+        f"modelzoo -v {expected_version} get resnet_50"
     )


### PR DESCRIPTION
## Why

Apps must target platform 2.1.3, but Model Zoo assets are still published under 2.1.2. Previously, one version controlled both platform compatibility and model downloads, so moving Apps to 2.1.3 would make examples request assets that do not exist.

## What Changed

- Set `platform-version` to `2.1.3` and added a separate `modelzoo-version` pinned to `2.1.2`.
- Updated the model downloader to resolve `modelzoo-version`, with `platform-version` retained as a fallback for older manifests.
- Renamed the scope URL placeholder to `{modelzoo_version}` and updated example READMEs, templates, and scaffolding to use `MODELZOO_VERSION`.
- Added checks that keep documented versions aligned with the manifest, reject hardcoded SDK versions in scope files, and fail early on unresolved URL placeholders.
- The platform bump routes Vulcan end-to-end tests to `modalix-devkit-2.1.3`; the build SDK channel remains unchanged.

## User Impact

Users can run Apps on platform 2.1.3 while continuing to download the published Model Zoo 2.1.2 assets. Model download instructions no longer derive the asset version from `/etc/buildinfo`.

## Validation

- Script tests: 98 passed; two pre-existing `test_manifest_contract.py` failures reproduce on unmodified `develop`.
- All 14 example READMEs passed validation, scope validation is clean, and catalog changes are content-only.
- Shell syntax and diff checks passed.
- CodeQL and PR sanitization pass. Vulcan is currently blocked because `sdk-develop` contains SDK 2.1.2 while the package requires 2.1.3.
- Board runtime, Nightly, and packaged runtime tests were not run.

Closes #396
