### PR TITLE
ci(vulcan): skip the core platform check when building

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -72,6 +72,7 @@ jobs:
           -e GITHUB_SHA="${{ github.sha }}" \
           -e NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
           -e NEAT_CORE_INSTALL_MODE="vulcan" \
+          -e NEAT_INSTALLER_SKIP_PLATFORM_CHECK=ON \
           -e NEAT_VULCAN_ENV="${{ needs.resolve-vulcan-config.outputs.vulcan_env }}" \
           "${sdk_container}" \
           bash -lc '


### PR DESCRIPTION
## Why

Every Apps build currently fails on Vulcan, before compiling anything.

Apps does not pin Core. `deps/manifest.json` uses `policy: snap`, so the build resolves the newest Core from `develop`. Core 0.4.0 landed and declares it targets platform 2.1.3, while the Vulcan SDK build container is platform 2.1.2. Core's installer refuses to install:

```
Incompatible platform version for this Neat package.
  Package platform-version: 2.1.3 (./manifest.json)
  Detected SDK Version: 2.1.2 (/etc/sdk-release)
```

That `manifest.json` is Core's published artifact manifest, downloaded with the Core package. Apps' own `deps/manifest.json` is not read by that check.

This affects `develop` and every open pull request. `develop`'s last green run predates Core 0.4.0, so its status is stale.

## What changes

One environment variable on the Vulcan build job's `docker exec`:

```
-e NEAT_INSTALLER_SKIP_PLATFORM_CHECK=ON \
```

## Why this is safe

Apps installs Core in two places, and only one of them is a real platform test:

| Job | Environment | Purpose | Platform check |
| --- | --- | --- | --- |
| Build Apps on Vulcan | SDK container, 2.1.2 | Extracts Core into the cross-compile toolchain to compile against | skipped by this change |
| Test Apps Runtime | Modalix DevKit | Installs the built package on the target | unchanged |

The build container never runs the result. The DevKit install is where platform incompatibility actually surfaces, and it keeps its check.

The variable is set on the build step only, not in `build.sh`. Both CI install paths call `build.sh`, so setting it there would also disable the check on the DevKit. It appears exactly once in the workflow.

## Prior art

Core hits this same wall building itself in the same image and skips the check for its build-container self-install, with the same reasoning: the self-install checks packaging only, and the DevKit job performs the authoritative target-platform installation. `NEAT_INSTALLER_SKIP_PLATFORM_CHECK` is a documented escape hatch in Core's installer.

The SDK repo bootstraps the 2.1.3 prep image the same way (sima-neat/sdk@2a4c829).

## Validation

- YAML parses; `git diff --check` clean.
- Confirmed `sima-cli` forwards its environment to the installer, so the variable reaches `install_neat_framework.sh`.
- Verified the variable appears once, on the build job, and that the DevKit install step is unchanged.

The build job getting past the install step is what this PR proves, and only CI can show that. Whether Core 0.4.0's libraries then cross-compile cleanly against the 2.1.2 toolchain is the next thing this run will tell us.

## Not included

Local `./build.sh --all` inside a 2.1.2 SDK hits the same wall. That is deliberately left alone: the normal SDK flow uses the prepackaged Core and does not need `--all`, and making `build.sh` detect its own environment risks disabling the DevKit check through a detection bug.

Moving the Vulcan build container to a 2.1.3 SDK image is the eventual fix and needs a coordinated change across Internals, LLiMA, Core, and Apps.

Closes #399
