### PR TITLE
refactor(single-stream-object-detector): send video from the detection graph

### DIFF
--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -16,6 +16,8 @@
 
 This focused example ingests one RTSP H.264/H.265/MJPEG or HTTP MJPEG stream, decodes it, runs YOLO26 detection, and sends H.264 video plus detection metadata to Insight.
 
+The decoded frame branches inside a single graph to the detector and to the H.264 sender. Both outputs therefore carry timestamps from the same frame, which is what lets Insight draw each detection on the frame it came from. Setting `output.save_dir` adds a third branch that returns the decoded frame to the application so it can write annotated JPEGs.
+
 ## Preview
 
 ![Single-stream object detector preview](../../../portal/assets/examples/object-detection/single-stream-object-detector/image.png)

--- a/examples/object-detection/single-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/single-stream-object-detector/src/common/config.yaml
@@ -23,7 +23,7 @@ runtime:
   profile_interval: 100      # Rolling profile window in published frames.
 
 output:
-  save_dir: ""               # Optional directory for annotated frames.
+  save_dir: ""               # Optional directory for annotated frames. Adds a decoded-frame branch.
   save_every: 0              # Save every Nth output frame. 0 disables saving.
   insight:
     host: <insight-host-ip>  # Host running the Insight receiver/viewer.

--- a/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
+++ b/examples/object-detection/single-stream-object-detector/src/cpp/main.cpp
@@ -24,7 +24,6 @@
 #include <nodes/io/MetadataSender.h>
 
 #include <opencv2/imgcodecs.hpp>
-#include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
 
 #include <algorithm>
@@ -121,10 +120,10 @@ struct PipelineRuntime {
   std::unique_ptr<simaai::neat::Model> model;
   simaai::neat::Graph graph;
   simaai::neat::Run run;
-  simaai::neat::Graph video_graph;
-  simaai::neat::Run video_run;
   std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
   std::vector<std::string> labels;
+  /// Run output the loop pulls: the detections alone, or the frame-joined bundle when saving.
+  std::string output_name;
   int frame_w = 0;
   int frame_h = 0;
   int output_fps = 0;
@@ -645,11 +644,24 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   runtime.model = make_model(cfg, geometry);
   runtime.labels = load_labels(cfg.labels_path);
 
-  auto source = make_source_graph(cfg, geometry);
-  auto branch = simaai::neat::graphs::Branch("source", {"frame", "model"});
+  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
+      runtime.frame_w, runtime.frame_h, runtime.output_fps);
+  video_options.host = cfg.insight_host;
+  video_options.channel = 0;
+  video_options.video_port_base = cfg.video_port;
+  video_options.encoder.bitrate_kbps = 1000;
+  runtime.video_port = video_options.video_port();
 
-  simaai::neat::Graph frame_graph("frame");
-  frame_graph.add(simaai::neat::nodes::Output("frame", simaai::neat::OutputOptions::EveryFrame(4)));
+  // Insight correlates the RTP timestamp with the metadata timestamp, so the encoder and the
+  // detections must stay in one Run and therefore on one GStreamer timeline.
+  const bool save_frames = !cfg.save_dir.empty();
+  auto source = make_source_graph(cfg, geometry);
+  auto branch = save_frames ? simaai::neat::graphs::Branch("source", {"video", "model", "frame"})
+                            : simaai::neat::graphs::Branch("source", {"video", "model"});
+
+  simaai::neat::Graph video_graph("video");
+  video_graph.connect(simaai::neat::nodes::Input("video"),
+                      simaai::neat::nodes::groups::VideoSender(video_options));
 
   simaai::neat::Graph model_graph("model");
   model_graph.connect(simaai::neat::nodes::Input("model"), *runtime.model);
@@ -657,15 +669,21 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   detections_graph.add(
       simaai::neat::nodes::Output("detections", simaai::neat::OutputOptions::EveryFrame(4)));
 
-  auto joined = simaai::neat::graphs::Combine({"frame", "detections"}, "detector_output",
-                                              simaai::neat::CombinePolicy::ByFrame);
-
   runtime.graph.connect(source, branch);
-  runtime.graph.connect(branch, frame_graph);
+  runtime.graph.connect(branch, video_graph);
   runtime.graph.connect(branch, model_graph);
   runtime.graph.connect(model_graph, detections_graph);
-  runtime.graph.connect(frame_graph, joined);
-  runtime.graph.connect(detections_graph, joined);
+  if (save_frames) {
+    simaai::neat::Graph frame_graph("frame");
+    frame_graph.add(
+        simaai::neat::nodes::Output("frame", simaai::neat::OutputOptions::EveryFrame(4)));
+    auto joined = simaai::neat::graphs::Combine({"frame", "detections"}, "detector_output",
+                                                simaai::neat::CombinePolicy::ByFrame);
+    runtime.graph.connect(branch, frame_graph);
+    runtime.graph.connect(frame_graph, joined);
+    runtime.graph.connect(detections_graph, joined);
+  }
+  runtime.output_name = save_frames ? "detector_output" : "detections";
   if (cfg.profile) {
     std::cout << "Backend:\n" << runtime.graph.describe_backend() << "\n";
   }
@@ -677,29 +695,6 @@ PipelineRuntime build_pipeline(const AppConfig& cfg) {
   run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
   run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
   runtime.run = runtime.graph.build(run_options);
-
-  simaai::neat::InputOptions video_input;
-  video_input.payload_type = simaai::neat::PayloadType::Image;
-  video_input.format = "RGB";
-  video_input.width = runtime.frame_w;
-  video_input.height = runtime.frame_h;
-  video_input.depth = 3;
-  video_input.memory_policy = simaai::neat::InputMemoryPolicy::Ev74;
-
-  auto video_options = simaai::neat::nodes::groups::VideoSenderOptions::H264RtpUdpFromRaw(
-      runtime.frame_w, runtime.frame_h, runtime.output_fps);
-  video_options.host = cfg.insight_host;
-  video_options.channel = 0;
-  video_options.video_port_base = cfg.video_port;
-  video_options.encoder.bitrate_kbps = 1000;
-  runtime.video_port = video_options.video_port();
-
-  runtime.video_graph.add(simaai::neat::nodes::Input(video_input));
-  runtime.video_graph.add(simaai::neat::nodes::groups::VideoSender(video_options));
-  cv::Mat seed(runtime.frame_h, runtime.frame_w, CV_8UC3, cv::Scalar(0, 0, 0));
-  const auto seed_tensor = simaai::neat::Tensor::from_cv_mat(
-      seed, simaai::neat::ImageSpec::PixelFormat::RGB, simaai::neat::TensorMemory::EV74);
-  runtime.video_run = runtime.video_graph.build(simaai::neat::TensorList{seed_tensor});
 
   simaai::neat::MetadataSenderOptions metadata_options;
   metadata_options.host = cfg.insight_host;
@@ -732,30 +727,13 @@ void send_metadata(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
   }
 }
 
-void push_video(PipelineRuntime& runtime, const simaai::neat::Sample& sample,
-                const cv::Mat& frame_bgr) {
-  cv::Mat rgb;
-  cv::cvtColor(frame_bgr, rgb, cv::COLOR_BGR2RGB);
-  const auto tensor = simaai::neat::Tensor::from_cv_mat(
-      rgb, simaai::neat::ImageSpec::PixelFormat::RGB, simaai::neat::TensorMemory::EV74);
-  auto video_sample = simaai::neat::make_tensor_sample("", tensor);
-  video_sample.pts_ns = sample.pts_ns;
-  video_sample.dts_ns = sample.dts_ns;
-  video_sample.duration_ns = sample.duration_ns;
-  video_sample.frame_id = sample.frame_id;
-  video_sample.stream_id = sample.stream_id;
-  if (!runtime.video_run.push(video_sample)) {
-    throw std::runtime_error("Insight video push failed");
-  }
-}
-
-void maybe_save_debug_frame(const AppConfig& cfg, int processed, const cv::Mat& frame,
+void maybe_save_debug_frame(const AppConfig& cfg, int processed, const simaai::neat::Sample& sample,
                             const std::vector<objdet::Box>& boxes) {
   if (cfg.save_dir.empty() || cfg.save_every <= 0 || processed % cfg.save_every != 0) {
     return;
   }
 
-  cv::Mat bgr = frame.clone();
+  cv::Mat bgr = tensor_bgr_from_decoded(frame_tensor_from_sample(sample));
   objdet::draw_boxes(bgr, boxes, cfg.min_score, cv::Scalar(0, 255, 0), "");
   const auto out_path = cfg.save_dir / ("frame_" + std::to_string(processed) + ".jpg");
   if (!cv::imwrite(out_path.string(), bgr)) {
@@ -773,7 +751,7 @@ void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
     simaai::neat::Sample detection_sample;
     simaai::neat::PullError pull_error;
     const double pull_start = sima_examples::time_ms();
-    const auto status = runtime.run.pull("detector_output", 20000, detection_sample, &pull_error);
+    const auto status = runtime.run.pull(runtime.output_name, 20000, detection_sample, &pull_error);
     const double pull_end = sima_examples::time_ms();
     if (status == simaai::neat::PullStatus::Timeout) {
       std::cerr << "[warn] timed out waiting for detections\n";
@@ -794,15 +772,12 @@ void run_pipeline(PipelineRuntime& runtime, const AppConfig& cfg) {
     const auto boxes = objdet::parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h,
                                                   cfg.max_detections, false);
 
-    const cv::Mat frame = tensor_bgr_from_decoded(frame_tensor_from_sample(detection_sample));
-    push_video(runtime, detection_sample, frame);
-
     const double metadata_start = sima_examples::time_ms();
     send_metadata(runtime, detection_sample, boxes);
     const double metadata_end = sima_examples::time_ms();
 
     ++processed;
-    maybe_save_debug_frame(cfg, processed, frame, boxes);
+    maybe_save_debug_frame(cfg, processed, detection_sample, boxes);
     profile.add(pull_end - pull_start, metadata_end - metadata_start,
                 static_cast<int>(boxes.size()));
   }
@@ -833,7 +808,6 @@ int main(int argc, char** argv) {
     }
     PipelineRuntime runtime = build_pipeline(cfg);
     run_pipeline(runtime, cfg);
-    runtime.video_run.close();
     runtime.run.close();
     return 0;
   } catch (const std::exception& e) {

--- a/examples/object-detection/single-stream-object-detector/src/python/main.py
+++ b/examples/object-detection/single-stream-object-detector/src/python/main.py
@@ -52,10 +52,10 @@ class PipelineRuntime:
     model: object
     graph: object
     run: object
-    video_graph: object
-    video_run: object
     metadata_sender: object
     labels: list[str]
+    #: Run output the loop pulls: the detections alone, or the frame-joined bundle when saving.
+    output_name: str
     frame_w: int
     frame_h: int
     video_port: int
@@ -561,16 +561,6 @@ def make_model(cfg: AppConfig, frame_w: int, frame_h: int):
 
 
 def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
-    input_options = pyneat.InputOptions()
-    input_options.payload_type = pyneat.PayloadType.Image
-    input_options.format = pyneat.Format.RGB
-    input_options.width = width
-    input_options.height = height
-    input_options.depth = 3
-    input_options.fps_n = fps
-    input_options.fps_d = 1
-    input_options.memory_policy = pyneat.InputMemoryPolicy.Ev74
-
     sender_options = pyneat.VideoSenderOptions.h264_rtp_udp_from_raw(width, height, fps)
     sender_options.host = cfg.insight_host
     sender_options.channel = 0
@@ -578,16 +568,8 @@ def build_video_graph(cfg: AppConfig, width: int, height: int, fps: int):
     sender_options.encoder.bitrate_kbps = 1000
 
     graph = pyneat.Graph("video")
-    graph.add(pyneat.nodes.input(input_options))
-    graph.add(pyneat.groups.video_sender(sender_options))
-
-    seed = pyneat.Tensor.from_numpy(
-        np.zeros((height, width, 3), dtype=np.uint8),
-        copy=True,
-        image_format=pyneat.PixelFormat.RGB,
-        memory=pyneat.TensorMemory.EV74,
-    )
-    return graph, graph.build([seed]), sender_options.video_port
+    graph.connect(pyneat.nodes.input("video"), pyneat.groups.video_sender(sender_options))
+    return graph, sender_options.video_port
 
 
 def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
@@ -600,11 +582,15 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     model = make_model(cfg, frame_w, frame_h)
     labels = load_labels(cfg.labels_path)
 
-    source = make_source_graph(cfg, fps, frame_w, frame_h)
-    branch = pyneat.graphs.branch("source", ["frame", "model"])
+    video_graph, video_port = build_video_graph(cfg, frame_w, frame_h, fps)
 
-    frame_graph = pyneat.Graph("frame")
-    frame_graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(4)))
+    # Insight correlates the RTP timestamp with the metadata timestamp, so the encoder and the
+    # detections must stay in one Run and therefore on one GStreamer timeline.
+    save_frames = bool(cfg.save_dir)
+    source = make_source_graph(cfg, fps, frame_w, frame_h)
+    branch = pyneat.graphs.branch(
+        "source", ["video", "model", "frame"] if save_frames else ["video", "model"]
+    )
 
     model_graph = pyneat.Graph("model")
     model_graph.connect(pyneat.nodes.input("model"), model)
@@ -612,17 +598,21 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     detections_graph = pyneat.Graph("detections")
     detections_graph.add(pyneat.nodes.output("detections", pyneat.OutputOptions.every_frame(4)))
 
-    joined = pyneat.graphs.combine(
-        ["frame", "detections"], "detector_output", pyneat.CombinePolicy.ByFrame
-    )
-
     graph = pyneat.Graph()
     graph.connect(source, branch)
-    graph.connect(branch, frame_graph)
+    graph.connect(branch, video_graph)
     graph.connect(branch, model_graph)
     graph.connect(model_graph, detections_graph)
-    graph.connect(frame_graph, joined)
-    graph.connect(detections_graph, joined)
+    if save_frames:
+        frame_graph = pyneat.Graph("frame")
+        frame_graph.add(pyneat.nodes.output("frame", pyneat.OutputOptions.every_frame(4)))
+        joined = pyneat.graphs.combine(
+            ["frame", "detections"], "detector_output", pyneat.CombinePolicy.ByFrame
+        )
+        graph.connect(branch, frame_graph)
+        graph.connect(frame_graph, joined)
+        graph.connect(detections_graph, joined)
+    output_name = "detector_output" if save_frames else "detections"
     if cfg.profile:
         print(f"Backend:\n{graph.describe_backend()}")
 
@@ -632,8 +622,6 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
     run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
     run_options.output_memory = pyneat.OutputMemory.ZeroCopy
     run = graph.build(run_options)
-
-    video_graph, video_run, video_port = build_video_graph(cfg, frame_w, frame_h, fps)
 
     metadata_options = pyneat.MetadataSenderOptions()
     metadata_options.host = cfg.insight_host
@@ -651,10 +639,9 @@ def build_pipeline(cfg: AppConfig) -> PipelineRuntime:
         model=model,
         graph=graph,
         run=run,
-        video_graph=video_graph,
-        video_run=video_run,
         metadata_sender=metadata_sender,
         labels=labels,
+        output_name=output_name,
         frame_w=frame_w,
         frame_h=frame_h,
         video_port=video_port,
@@ -774,29 +761,11 @@ def draw_boxes(frame, boxes: list[dict], min_score: float) -> None:
         )
 
 
-def push_video(runtime: PipelineRuntime, sample, frame_bgr) -> None:
-    rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
-    tensor = pyneat.Tensor.from_numpy(
-        np.ascontiguousarray(rgb),
-        copy=True,
-        image_format=pyneat.PixelFormat.RGB,
-        memory=pyneat.TensorMemory.EV74,
-    )
-    video_sample = pyneat.make_tensor_sample("", tensor)
-    video_sample.pts_ns = sample.pts_ns
-    video_sample.dts_ns = sample.dts_ns
-    video_sample.duration_ns = sample.duration_ns
-    video_sample.frame_id = sample.frame_id
-    video_sample.stream_id = sample.stream_id
-    if not runtime.video_run.push([video_sample]):
-        raise RuntimeError("Insight video push failed")
-
-
-def maybe_save_debug_frame(cfg: AppConfig, processed: int, frame, boxes: list[dict]) -> None:
+def maybe_save_debug_frame(cfg: AppConfig, processed: int, sample, boxes: list[dict]) -> None:
     if not cfg.save_dir or cfg.save_every <= 0 or processed % cfg.save_every != 0:
         return
 
-    annotated = frame.copy()
+    annotated = tensor_bgr_from_decoded(frame_tensor_from_sample(sample))
     draw_boxes(annotated, boxes, cfg.min_score)
     out_path = Path(cfg.save_dir) / f"frame_{processed}.jpg"
     if not cv2.imwrite(str(out_path), annotated):
@@ -808,7 +777,7 @@ def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
     processed = 0
     while cfg.frames <= 0 or processed < cfg.frames:
         pull_start = time_ms()
-        detection_sample = runtime.run.pull("detector_output", 20000)
+        detection_sample = runtime.run.pull(runtime.output_name, 20000)
         pull_end = time_ms()
         if detection_sample is None:
             print("[warn] timed out waiting for detections", file=sys.stderr)
@@ -817,15 +786,12 @@ def run_pipeline(runtime: PipelineRuntime, cfg: AppConfig) -> int:
         payload = extract_bbox_payload(detection_sample)
         boxes = parse_boxes_strict(payload, runtime.frame_w, runtime.frame_h, cfg.max_detections)
 
-        frame = tensor_bgr_from_decoded(frame_tensor_from_sample(detection_sample))
-        push_video(runtime, detection_sample, frame)
-
         metadata_start = time_ms()
         send_metadata(runtime, detection_sample, boxes)
         metadata_end = time_ms()
 
         processed += 1
-        maybe_save_debug_frame(cfg, processed, frame, boxes)
+        maybe_save_debug_frame(cfg, processed, detection_sample, boxes)
         profile.add(pull_end - pull_start, metadata_end - metadata_start, len(boxes))
 
     profile.flush()
@@ -853,7 +819,6 @@ def main(argv: list[str] | None = None) -> int:
         try:
             run_pipeline(runtime, cfg)
         finally:
-            runtime.video_run.close()
             runtime.run.close()
         return 0
     except KeyboardInterrupt:


### PR DESCRIPTION
## Why

As an Apps user running `single-stream-object-detector`, bounding boxes almost never appear in the Insight viewer — sima-neat/apps#391.

The example built two graphs. Detections came from `runtime.run`; frames were copied out of it, converted BGR to RGB, and pushed into a second `Run` through an `appsrc` to be encoded. Two Runs meant two GStreamer timelines, so the RTP timestamp on the wire and the `timestamp` field in the metadata envelope stopped deriving from the same frame. Insight pairs them within ±90 RTP units, one millisecond, and the two values were landing at unrelated phase inside the frame interval.

## What Changed

- The source branches inside the existing graph. One edge feeds `VideoSender`, the other feeds the model. Both live in `runtime.run`.
- The `frame` output and the `Combine` are now conditional on `output.save_dir`. In the default path the pull key is `detections`; with `save_dir` set, `Combine` with `CombinePolicy::ByFrame` still pairs each saved JPEG with the detections from its own frame.
- Removes `video_graph`, `video_run`, `push_video`, its `cv::cvtColor`, the seed tensor, and the second `close()`.
- Same change in the Python implementation. Both produce the same graph shape.

Net effect is 65 insertions, 124 deletions.

`describe_backend()` confirms the shape — one plan, one FanOut, three segments, no Run-level input boundary:

```
ExecutionGraphPlan {
  mode: connected
  pipeline_segments: 3
    segment 0 nodes=[RTSPInput, Queue, H264Depacketize, Queue, H264CapsFixup, SimaDecode, CapsRaw]
    segment 1 nodes=[CapsRaw, VideoConvert, CapsRaw, H264EncodeSima, H264Parse, H264Packetize, UdpOutput]
    segment 2 nodes=[Preproc, ModelFragment, SimaBoxDecode, Output]
  stage_nodes: 1
    stage n3 kind=FanOut label=fanout0
  edges: e0: n0:out -> n3:in | e1: n3:branch0 -> n1:in | e2: n3:branch1 -> n2:in
  named_inputs: []
  named_outputs: [detections]
}
```

## Measurements

Modalix DevKit. Both UDP ports diverted to a local collector, 30 s captures, replayed through Insight's correlator with its production constants — tolerance ±90 RTP units, capacity 256, max age 5 s. The harness is kept out of tree as a local diagnostic; Insight reports neither matched nor expired counts, so correlation cannot be read from `/api/ingest/stats` today (sima-neat/insight#79).

Against a wall-clock-paced 1280x720@30 source:

| video path | video | metadata | matched | `\|delta\|` p50 |
| --- | --- | --- | --- | --- |
| two graphs, before this change | 751 frames (25.0 fps) | 751 | 34/751 — **4.5%** | 9.7 ms |
| one graph, this change | 754 frames (25.1 fps) | 754 | 753/754 — **99.9%** | 0.5 ms |
| one graph, `Passthrough` for reference (`multi-stream-object-detector`) | 763 frames (25.4 fps) | 763 | 757/763 — 99.2% | 0.5 ms |

The 4.5% row reproduces #391 as originally reported, which measured 45/870 — 5.2% — at a p50 of 9.1 ms. Both are the same signature: a sub-frame phase error, metadata landing at random phase inside a frame interval rather than on its own frame.

The third row is the reference. `Passthrough` is the video path used by every example that never exhibited #391, and one graph reaches the same result through either video path. So the fix is the single timeline, not the choice of sender.

Throughput is unchanged: on 1080p src2, 96 fps output, 10 ms average detection pull, 0.47 ms average metadata send.

### Sources that outrun wall clock fail regardless, and this does not address that

Measured against a bench source reporting `1920x1080@120` that delivers frames as fast as it can:

| video path | matched | `\|delta\|` p50 |
| --- | --- | --- |
| one graph, this change | 0/2290 | 4502.7 ms |
| one graph, `Passthrough` | 0/2977 | 3297.4 ms |

Both score zero, and the deltas are seconds and grow across the window — a clock rate divergence, not a phase error. When media time advances faster than wall clock, PTS-derived metadata timestamps race the RTP clock without bound. That is a property of the source, not of any example, and it masks the defect this pull request fixes. Worth knowing when reproducing #391: an over-rate source will show 0% before and after.

## Risk

The failure mode changes. Previously video and metadata were both emitted from the application loop, so a stalled loop froze both. Now video is produced by the graph independently, so a stalled or slow detector shows live video with no overlay rather than a frozen stream. Observed during testing as `[warn] timed out waiting for detections` with video continuing at full rate.

`InputOptions` set on the branch's `Input` node does not reach the compiler-synthesised segment-boundary appsrc — `named_inputs: []` above, and setting `do_timestamp = false` produced no measurable change. Not required by this change, but it means an application cannot currently control timestamping at that boundary.

## Testing & Verification

- [x] Built successfully on hardware — `./build.sh --clean` in the Neat SDK
- [x] Manual functional tests on a Modalix DevKit, C++ implementation
- [x] Correlation measured before and after against a paced source
- [x] Python implementation measured on hardware
- [x] e2e tests run for both implementations

Still open before merge: the Python implementation measured on the paced source — its graph shape matches on paper but has not been measured — and e2e for both implementations.

Closes #401. Refs #391.
