### PR TITLE
feat(model-benchmark): measure YOLO26 through both postprocess routes

### DIFF
--- a/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
+++ b/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
@@ -10,45 +10,47 @@ These results measure the compiled model package only. They do not include camer
 | Field | Value |
 | --- | --- |
 | Target | Modalix (`aarch64`) |
-| SDK | 2.1.2 |
-| Date | 2026-06-12 |
+| SDK | 2.1.3_master_B4040 (neat core 0.4.0+develop.0d77e009b73b) |
+| Date | 2026-07-31 |
 | Frames | 1000 |
-| Command | `python3 examples/benchmarking/model-benchmark/src/python/main.py --model <model-package>` |
+| Command | `python3 examples/benchmarking/model-benchmark/src/python/main.py --model <model-package> [--decode-type <yolo26-det\|yolo26-seg>]` |
 | Refresh Script | `python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py --run` |
 | JSON Reports | `sandbox/model-benchmark/runs/<model-id>.json` |
 | Power Columns | Omitted |
 
 ## General Models
 
-| Model ID | Package | Used By | Latency / FPS |
-| --- | --- | --- | ---: |
-| `resnet_50` | `resnet_50_mpk.tar.gz` | image-classifier | 2.264 / 918.20 |
-| `depth_anything_v2_vits` | `depth_anything_v2_vits_mpk.tar.gz` | depth-estimator | 20.695 / 54.56 |
-| `retinaface_mobilenet25` | `retinaface_mobilenet25_mod_0_mpk.tar.gz` | face-detector | 4.383 / 608.04 |
-| `detr_resnet50_modified_class_embed_bbox_embed` | `detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` | detr-object-detector | 23.672 / 68.15 |
-| `yolo_v8n_seg` | `yolo_v8n_seg_mpk.tar.gz` | yolov8-instance-segmenter | 6.600 / 387.95 |
+| Model ID | Package | Used By | Postprocess | Outputs | Latency / FPS |
+| --- | --- | --- | --- | ---: | ---: |
+| `resnet_50` | `resnet_50_mpk.tar.gz` | image-classifier | `detessdequant` | 1 | 2.360 / 1102.25 |
+| `depth_anything_v2_vits` | `depth_anything_v2_vits_mpk.tar.gz` | depth-estimator | `detessdequant` | 1 | 20.841 / 55.01 |
+| `retinaface_mobilenet25` | `retinaface_mobilenet25_mod_0_mpk.tar.gz` | face-detector | `detessdequant` | 9 | 4.540 / 637.29 |
+| `detr_resnet50_modified_class_embed_bbox_embed` | `detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz` | detr-object-detector | `detessdequant` | 2 | 23.426 / 68.86 |
+| `yolo_v8n_seg` | `yolo_v8n_seg_mpk.tar.gz` | yolov8-instance-segmenter | `detessdequant` | 10 | 6.749 / 385.41 |
 
 ## YOLO26 Detection
 
-| Model ID | Package | Used By | Latency / FPS |
-| --- | --- | --- | ---: |
-| `yolo26n-det-bf16-mla_tess-b1` | `yolo26n-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | 6.427 / 348.86 |
-| `yolo26s-det-bf16-mla_tess-b1` | `yolo26s-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | 8.984 / 180.09 |
-| `yolo26m-det-bf16-mla_tess-b1` | `yolo26m-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, yolo26-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | 16.762 / 62.57 |
-| `yolo26l-det-bf16-mla_tess-b1` | `yolo26l-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | 20.107 / 50.71 |
-| `yolo26x-det-bf16-mla_tess-b1` | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | 49.978 / 27.83 |
-| `yolo26m-det-bf16-b1` | `yolo26m-det-bf16-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | 21.110 / 77.23 |
-| `yolo26m-det-int8-b1` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | 6.764 / 271.33 |
+| Model ID | Package | Used By | Postprocess | Outputs | Latency / FPS |
+| --- | --- | --- | --- | ---: | ---: |
+| `yolo26n-det-bf16-mla_tess-b1` | `yolo26n-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | `cast` | 6 | 6.757 / 377.67 |
+| `yolo26s-det-bf16-mla_tess-b1` | `yolo26s-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | `cast` | 6 | 9.321 / 188.20 |
+| `yolo26m-det-bf16-mla_tess-b1` | `yolo26m-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, yolo26-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `cast` | 6 | 17.024 / 77.33 |
+| `yolo26l-det-bf16-mla_tess-b1` | `yolo26l-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | `cast` | 6 | 20.331 / 61.34 |
+| `yolo26x-det-bf16-mla_tess-b1` | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | `cast` | 6 | 39.772 / 27.98 |
+| `yolo26m-det-bf16-b1` | `yolo26m-det-bf16-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `unknown` | 6 | 18.143 / 78.15 |
+| `yolo26m-det-int8-b1` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `detessdequant` | 6 | 7.076 / 300.09 |
+| `yolo26m-det-int8-b1-boxdecode` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `boxdecode` | 1 | 6.898 / 304.88 |
 
 ## YOLO26 Segmentation
 
-| Model ID | Package | Used By | Latency / FPS |
-| --- | --- | --- | ---: |
-| `yolo26n-seg-bf16-mla_tess` | `yolo26n-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | 9.290 / 238.74 |
-| `yolo26s-seg-bf16-mla_tess` | `yolo26s-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | 15.474 / 131.85 |
-| `yolo26m-seg-bf16-mla_tess` | `yolo26m-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | 32.663 / 50.02 |
-| `yolo26l-seg-bf16-mla_tess` | `yolo26l-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | 28.501 / 42.89 |
-| `yolo26x-seg-bf16-mla_tess` | `yolo26x-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | 55.701 / 19.84 |
-| `yolo26m-seg-bf16-b1` | `yolo26m-seg-bf16-b1.tar.gz` | single-stream-instance-segmenter | 26.983 / 50.43 |
-| `yolo26m-seg-bf16-mla_tess-b1` | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | single-stream-instance-segmenter | 25.012 / 50.53 |
-| `yolo26m-seg-int8-b1` | `yolo26m-seg-int8-b1.tar.gz` | single-stream-instance-segmenter | 9.991 / 195.12 |
+| Model ID | Package | Used By | Postprocess | Outputs | Latency / FPS |
+| --- | --- | --- | --- | ---: | ---: |
+| `yolo26n-seg-bf16-mla_tess` | `yolo26n-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 9.062 / 296.73 |
+| `yolo26s-seg-bf16-mla_tess` | `yolo26s-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 13.146 / 135.03 |
+| `yolo26m-seg-bf16-mla_tess` | `yolo26m-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 25.548 / 50.48 |
+| `yolo26l-seg-bf16-mla_tess` | `yolo26l-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 28.980 / 43.14 |
+| `yolo26x-seg-bf16-mla_tess` | `yolo26x-seg-bf16-mla_tess.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 56.054 / 19.91 |
+| `yolo26m-seg-bf16-b1` | `yolo26m-seg-bf16-b1.tar.gz` | single-stream-instance-segmenter | `unknown` | 10 | 27.146 / 50.90 |
+| `yolo26m-seg-bf16-mla_tess-b1` | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 25.248 / 51.09 |
+| `yolo26m-seg-int8-b1` | `yolo26m-seg-int8-b1.tar.gz` | single-stream-instance-segmenter | `detessdequant` | 10 | 10.403 / 201.88 |
+| `yolo26m-seg-int8-b1-boxdecode` | `yolo26m-seg-int8-b1.tar.gz` | single-stream-instance-segmenter | `boxdecode` | 1 | 11.736 / 205.43 |

--- a/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
+++ b/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
@@ -38,6 +38,7 @@ These results measure the compiled model package only. They do not include camer
 | `yolo26l-det-bf16-mla_tess-b1` | `yolo26l-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | `cast` | 6 | 20.331 / 61.34 |
 | `yolo26x-det-bf16-mla_tess-b1` | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, multi-stream-people-tracker | `cast` | 6 | 39.772 / 27.98 |
 | `yolo26m-det-bf16-b1` | `yolo26m-det-bf16-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `unknown` | 6 | 18.143 / 78.15 |
+| `yolo26n-det-int8-b1` | `yolo26n-det-int8-b1.tar.gz` | high-density-multi-stream-object-detector | `dequantize` | 6 | 4.392 / 869.39 |
 | `yolo26m-det-int8-b1` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `detessdequant` | 6 | 7.076 / 300.09 |
 | `yolo26m-det-int8-b1-boxdecode` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `boxdecode` | 1 | 6.898 / 304.88 |
 

--- a/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
+++ b/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md
@@ -17,6 +17,7 @@ These results measure the compiled model package only. They do not include camer
 | Refresh Script | `python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py --run` |
 | JSON Reports | `sandbox/model-benchmark/runs/<model-id>.json` |
 | Power Columns | Omitted |
+| BoxDecode Options | `top_k=100`, `score_threshold=0` (keeps all candidates), `nms_iou_threshold=0` (NMS disabled) |
 
 ## General Models
 
@@ -40,7 +41,7 @@ These results measure the compiled model package only. They do not include camer
 | `yolo26m-det-bf16-b1` | `yolo26m-det-bf16-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `unknown` | 6 | 18.143 / 78.15 |
 | `yolo26n-det-int8-b1` | `yolo26n-det-int8-b1.tar.gz` | high-density-multi-stream-object-detector | `dequantize` | 6 | 4.392 / 869.39 |
 | `yolo26m-det-int8-b1` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `detessdequant` | 6 | 7.076 / 300.09 |
-| `yolo26m-det-int8-b1-boxdecode` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `boxdecode` | 1 | 6.898 / 304.88 |
+| `yolo26m-det-int8-b1-boxdecode` | `yolo26m-det-int8-b1.tar.gz` | single-stream-object-detector, multi-stream-object-detector, detection-to-vlm-assistant, multi-stream-people-tracker | `boxdecode` | 1 | 6.841 / 305.82 |
 
 ## YOLO26 Segmentation
 
@@ -54,4 +55,4 @@ These results measure the compiled model package only. They do not include camer
 | `yolo26m-seg-bf16-b1` | `yolo26m-seg-bf16-b1.tar.gz` | single-stream-instance-segmenter | `unknown` | 10 | 27.146 / 50.90 |
 | `yolo26m-seg-bf16-mla_tess-b1` | `yolo26m-seg-bf16-mla_tess-b1.tar.gz` | single-stream-instance-segmenter | `cast` | 10 | 25.248 / 51.09 |
 | `yolo26m-seg-int8-b1` | `yolo26m-seg-int8-b1.tar.gz` | single-stream-instance-segmenter | `detessdequant` | 10 | 10.403 / 201.88 |
-| `yolo26m-seg-int8-b1-boxdecode` | `yolo26m-seg-int8-b1.tar.gz` | single-stream-instance-segmenter | `boxdecode` | 1 | 11.736 / 205.43 |
+| `yolo26m-seg-int8-b1-boxdecode` | `yolo26m-seg-int8-b1.tar.gz` | single-stream-instance-segmenter | `boxdecode` | 1 | 11.709 / 203.23 |

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -89,6 +89,8 @@ python3 examples/benchmarking/model-benchmark/src/python/main.py \
 
 The command prints headline metrics and writes the complete report to the selected JSON path.
 
+Without `--decode-type`, the model runs through the route its package declares. Add `--decode-type yolo26-det` or `--decode-type yolo26-seg` to benchmark a YOLO26 package through its BoxDecode route instead. Every report records the requested decode type and the postprocess Core resolved, so the two routes stay distinguishable.
+
 ## Benchmark Results
 
 See the maintained [benchmark results](https://github.com/sima-neat/apps/blob/main/examples/benchmarking/model-benchmark/BENCHMARK_RESULTS.md) for measurements from Apps-supported packages.

--- a/examples/benchmarking/model-benchmark/scripts/refresh_results.py
+++ b/examples/benchmarking/model-benchmark/scripts/refresh_results.py
@@ -26,6 +26,7 @@ class ModelRow:
     package: str
     used_by: str
     preferred_path: str
+    decode_type: str | None = None
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,11 @@ GROUPS: tuple[tuple[str, tuple[ModelRow, ...]], ...] = (
                      "single-stream-object-detector, multi-stream-object-detector, "
                      "detection-to-vlm-assistant, multi-stream-people-tracker",
                      "models/YOLO26-DETECTION/yolo26m-det-int8-b1.tar.gz"),
+            ModelRow("yolo26m-det-int8-b1-boxdecode", "yolo26m-det-int8-b1.tar.gz",
+                     "single-stream-object-detector, multi-stream-object-detector, "
+                     "detection-to-vlm-assistant, multi-stream-people-tracker",
+                     "models/YOLO26-DETECTION/yolo26m-det-int8-b1.tar.gz",
+                     decode_type="yolo26-det"),
         ),
     ),
     (
@@ -119,6 +125,10 @@ GROUPS: tuple[tuple[str, tuple[ModelRow, ...]], ...] = (
             ModelRow("yolo26m-seg-int8-b1", "yolo26m-seg-int8-b1.tar.gz",
                      "single-stream-instance-segmenter",
                      "models/YOLO26-SEGMENTATION/yolo26m-seg-int8-b1.tar.gz"),
+            ModelRow("yolo26m-seg-int8-b1-boxdecode", "yolo26m-seg-int8-b1.tar.gz",
+                     "single-stream-instance-segmenter",
+                     "models/YOLO26-SEGMENTATION/yolo26m-seg-int8-b1.tar.gz",
+                     decode_type="yolo26-seg"),
         ),
     ),
 )
@@ -166,6 +176,14 @@ def resolve_model_path(row: ModelRow) -> Path:
     return matches[0]
 
 
+def benchmark_command(row: ModelRow, model_path: Path, frames: int, out_path: Path) -> list[str]:
+    command = [sys.executable, str(MAIN_PY), "--model", str(model_path),
+               "--frames", str(frames), "--output-json", str(out_path)]
+    if row.decode_type:
+        command += ["--decode-type", row.decode_type]
+    return command
+
+
 def run_benchmarks(frames: int, reports_dir: Path, rows: tuple[ModelRow, ...]) -> list[BenchmarkFailure]:
     reports_dir.mkdir(parents=True, exist_ok=True)
     failures: list[BenchmarkFailure] = []
@@ -178,16 +196,8 @@ def run_benchmarks(frames: int, reports_dir: Path, rows: tuple[ModelRow, ...]) -
             continue
         out_path = reports_dir / f"{row.model_id}.json"
         print(f"[benchmark] {row.model_id}: {model_path}", flush=True)
-        result = subprocess.run([
-            sys.executable,
-            str(MAIN_PY),
-            "--model",
-            str(model_path),
-            "--frames",
-            str(frames),
-            "--output-json",
-            str(out_path),
-        ], cwd=APPS_ROOT, check=False)
+        result = subprocess.run(benchmark_command(row, model_path, frames, out_path),
+                                cwd=APPS_ROOT, check=False)
         if result.returncode != 0:
             failures.append(BenchmarkFailure(row.model_id, f"exit {result.returncode}"))
             print(f"[failed] {row.model_id}: exit {result.returncode}", file=sys.stderr,
@@ -195,13 +205,11 @@ def run_benchmarks(frames: int, reports_dir: Path, rows: tuple[ModelRow, ...]) -
     return failures
 
 
-def report_metrics(reports_dir: Path, row: ModelRow) -> tuple[float, float]:
+def read_report(reports_dir: Path, row: ModelRow) -> dict:
     report_path = reports_dir / f"{row.model_id}.json"
     if not report_path.exists():
         raise FileNotFoundError(f"missing benchmark report: {report_path}")
-    data = json.loads(report_path.read_text())
-    metrics = data["metrics"]
-    return float(metrics["latency_ms"]), float(metrics["fps"])
+    return json.loads(report_path.read_text())
 
 
 def report_date(reports_dir: Path) -> str:
@@ -233,7 +241,7 @@ def render_markdown(frames: int, sdk: str, run_date: str, reports_dir: Path) -> 
         f"| SDK | {sdk} |",
         f"| Date | {run_date} |",
         f"| Frames | {frames} |",
-        "| Command | `python3 examples/benchmarking/model-benchmark/src/python/main.py --model <model-package>` |",
+        "| Command | `python3 examples/benchmarking/model-benchmark/src/python/main.py --model <model-package> [--decode-type <yolo26-det\\|yolo26-seg>]` |",
         "| Refresh Script | `python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py --run` |",
         "| JSON Reports | `sandbox/model-benchmark/runs/<model-id>.json` |",
         "| Power Columns | Omitted |",
@@ -243,14 +251,16 @@ def render_markdown(frames: int, sdk: str, run_date: str, reports_dir: Path) -> 
         lines.extend([
             f"## {title}",
             "",
-            "| Model ID | Package | Used By | Latency / FPS |",
-            "| --- | --- | --- | ---: |",
+            "| Model ID | Package | Used By | Postprocess | Outputs | Latency / FPS |",
+            "| --- | --- | --- | --- | ---: | ---: |",
         ])
         for row in rows:
-            latency_ms, fps = report_metrics(reports_dir, row)
+            report = read_report(reports_dir, row)
+            model, metrics = report["model"], report["metrics"]
             lines.append(
                 f"| `{row.model_id}` | `{row.package}` | {row.used_by} | "
-                f"{latency_ms:.3f} / {fps:.2f} |"
+                f"`{model['resolved_postprocess']}` | {len(model['output_specs'])} | "
+                f"{float(metrics['latency_ms']):.3f} / {float(metrics['fps']):.2f} |"
             )
         lines.append("")
     return "\n".join(lines)

--- a/examples/benchmarking/model-benchmark/scripts/refresh_results.py
+++ b/examples/benchmarking/model-benchmark/scripts/refresh_results.py
@@ -86,6 +86,9 @@ GROUPS: tuple[tuple[str, tuple[ModelRow, ...]], ...] = (
                      "single-stream-object-detector, multi-stream-object-detector, "
                      "detection-to-vlm-assistant, multi-stream-people-tracker",
                      "models/YOLO26-DETECTION/yolo26m-det-bf16-b1.tar.gz"),
+            ModelRow("yolo26n-det-int8-b1", "yolo26n-det-int8-b1.tar.gz",
+                     "high-density-multi-stream-object-detector",
+                     "models/YOLO26-DETECTION/yolo26n-det-int8-b1.tar.gz"),
             ModelRow("yolo26m-det-int8-b1", "yolo26m-det-int8-b1.tar.gz",
                      "single-stream-object-detector, multi-stream-object-detector, "
                      "detection-to-vlm-assistant, multi-stream-people-tracker",

--- a/examples/benchmarking/model-benchmark/scripts/refresh_results.py
+++ b/examples/benchmarking/model-benchmark/scripts/refresh_results.py
@@ -248,6 +248,8 @@ def render_markdown(frames: int, sdk: str, run_date: str, reports_dir: Path) -> 
         "| Refresh Script | `python3 examples/benchmarking/model-benchmark/scripts/refresh_results.py --run` |",
         "| JSON Reports | `sandbox/model-benchmark/runs/<model-id>.json` |",
         "| Power Columns | Omitted |",
+        "| BoxDecode Options | `top_k=100`, `score_threshold=0` (keeps all candidates), "
+        "`nms_iou_threshold=0` (NMS disabled) |",
         "",
     ]
     for title, rows in GROUPS:
@@ -260,9 +262,11 @@ def render_markdown(frames: int, sdk: str, run_date: str, reports_dir: Path) -> 
         for row in rows:
             report = read_report(reports_dir, row)
             model, metrics = report["model"], report["metrics"]
+            specs = model["output_specs"]
+            outputs = "n/a" if specs[0].startswith("unavailable:") else len(specs)
             lines.append(
                 f"| `{row.model_id}` | `{row.package}` | {row.used_by} | "
-                f"`{model['resolved_postprocess']}` | {len(model['output_specs'])} | "
+                f"`{model['resolved_postprocess']}` | {outputs} | "
                 f"{float(metrics['latency_ms']):.3f} / {float(metrics['fps']):.2f} |"
             )
         lines.append("")

--- a/examples/benchmarking/model-benchmark/src/python/main.py
+++ b/examples/benchmarking/model-benchmark/src/python/main.py
@@ -12,6 +12,13 @@ from pathlib import Path
 import yaml
 
 
+DECODE_TYPES = {"yolo26-det": "YoloV26", "yolo26-seg": "YoloV26Seg"}
+
+# neatobjectdecode rejects a zero top-K, so the BoxDecode route needs an explicit cap.
+# The same value is used for every decode type to keep the measurements comparable.
+BOXDECODE_TOP_K = 100
+
+
 def load_config(path: Path) -> dict:
     with path.open("r", encoding="utf-8") as handle:
         payload = yaml.safe_load(handle) or {}
@@ -27,7 +34,8 @@ def spec_strings(model, method_name: str) -> list[str]:
         return [f"unavailable: {exc}"]
 
 
-def write_report(path: Path, model_path: Path, frames: int, model, report) -> None:
+def write_report(path: Path, model_path: Path, frames: int, decode_type, model, report) -> None:
+    info = model.info()
     data = {
         "benchmark": {
             "type": "model.synthetic",
@@ -37,6 +45,13 @@ def write_report(path: Path, model_path: Path, frames: int, model, report) -> No
         "model": {
             "path": str(model_path),
             "file": model_path.name,
+            "requested_decode_type": decode_type,
+            "resolved_postprocess": info.selection.selected_post_kind,
+            "output_topology": {
+                "physical": info.output_topology.physical_outputs,
+                "logical": info.output_topology.logical_outputs,
+                "packed": info.output_topology.packed_outputs,
+            },
             "input_specs": spec_strings(model, "input_specs"),
             "output_specs": spec_strings(model, "output_specs"),
         },
@@ -58,6 +73,11 @@ def main() -> int:
     parser.add_argument("--model", type=Path, help="compiled model package to benchmark")
     parser.add_argument("--frames", type=int, help="measured synthetic frames")
     parser.add_argument("--output-json", type=Path, help="benchmark report JSON path")
+    parser.add_argument(
+        "--decode-type",
+        choices=sorted(DECODE_TYPES),
+        help="select the BoxDecode postprocess route instead of the package default",
+    )
     args = parser.parse_args()
 
     try:
@@ -93,9 +113,15 @@ def main() -> int:
         return 3
 
     try:
-        model = pyneat.Model(str(model_path))
+        if args.decode_type is None:
+            model = pyneat.Model(str(model_path))
+        else:
+            options = pyneat.ModelOptions()
+            options.decode_type = getattr(pyneat.BoxDecodeType, DECODE_TYPES[args.decode_type])
+            options.top_k = BOXDECODE_TOP_K
+            model = pyneat.Model(str(model_path), options)
         report = model.benchmark(frames)
-        write_report(report_path, model_path, frames, model, report)
+        write_report(report_path, model_path, frames, args.decode_type, model, report)
     except Exception as exc:
         print(f"benchmark failed: {exc}", file=sys.stderr)
         return 4

--- a/examples/benchmarking/model-benchmark/src/python/main.py
+++ b/examples/benchmarking/model-benchmark/src/python/main.py
@@ -34,8 +34,23 @@ def spec_strings(model, method_name: str) -> list[str]:
         return [f"unavailable: {exc}"]
 
 
+def route_fields(model) -> dict:
+    """Describe the resolved route, without discarding a completed benchmark if info() fails."""
+    try:
+        info = model.info()
+    except Exception as exc:
+        return {"resolved_postprocess": f"unavailable: {exc}", "output_topology": None}
+    return {
+        "resolved_postprocess": info.selection.selected_post_kind,
+        "output_topology": {
+            "physical": info.output_topology.physical_outputs,
+            "logical": info.output_topology.logical_outputs,
+            "packed": info.output_topology.packed_outputs,
+        },
+    }
+
+
 def write_report(path: Path, model_path: Path, frames: int, decode_type, model, report) -> None:
-    info = model.info()
     data = {
         "benchmark": {
             "type": "model.synthetic",
@@ -46,12 +61,8 @@ def write_report(path: Path, model_path: Path, frames: int, decode_type, model, 
             "path": str(model_path),
             "file": model_path.name,
             "requested_decode_type": decode_type,
-            "resolved_postprocess": info.selection.selected_post_kind,
-            "output_topology": {
-                "physical": info.output_topology.physical_outputs,
-                "logical": info.output_topology.logical_outputs,
-                "packed": info.output_topology.packed_outputs,
-            },
+            "boxdecode_top_k": None if decode_type is None else BOXDECODE_TOP_K,
+            **route_fields(model),
             "input_specs": spec_strings(model, "input_specs"),
             "output_specs": spec_strings(model, "output_specs"),
         },

--- a/examples/benchmarking/model-benchmark/tests/python/test_unit.py
+++ b/examples/benchmarking/model-benchmark/tests/python/test_unit.py
@@ -13,8 +13,18 @@ import pytest
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
 
-sys.path.insert(0, str(EXAMPLE_DIR / "scripts"))
-import refresh_results  # noqa: E402
+SCRIPTS_DIR = EXAMPLE_DIR / "scripts"
+
+
+def load_refresh_results():
+    """Import the maintainer refresh script, which the installed Apps bundle omits."""
+    if not (SCRIPTS_DIR / "refresh_results.py").is_file():
+        pytest.skip("refresh_results.py is not part of the installed Apps bundle")
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    import refresh_results
+
+    return refresh_results
 
 # The fake traces the options reaching pyneat.Model so a test can assert the exact Core
 # enum and top-K, and resolves the postprocess the way Core does.
@@ -194,6 +204,7 @@ def test_decode_type_selects_core_enum(tmp_path: Path, flag: str, enum_name: str
 def test_boxdecode_row_shares_package_with_its_default(
     tmp_path: Path, default_id: str, boxdecode_id: str, flag: str
 ) -> None:
+    refresh_results = load_refresh_results()
     rows = {row.model_id: row for row in refresh_results.all_rows()}
     default_row, boxdecode_row = rows[default_id], rows[boxdecode_id]
     assert default_row.package == boxdecode_row.package
@@ -216,6 +227,7 @@ def test_boxdecode_row_shares_package_with_its_default(
 
 @pytest.mark.unit
 def test_render_markdown_reports_each_route(tmp_path: Path) -> None:
+    refresh_results = load_refresh_results()
     for row in refresh_results.all_rows():
         boxdecode = row.decode_type is not None
         (tmp_path / f"{row.model_id}.json").write_text(

--- a/examples/benchmarking/model-benchmark/tests/python/test_unit.py
+++ b/examples/benchmarking/model-benchmark/tests/python/test_unit.py
@@ -13,6 +13,80 @@ import pytest
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
 
+sys.path.insert(0, str(EXAMPLE_DIR / "scripts"))
+import refresh_results  # noqa: E402
+
+# The fake traces the options reaching pyneat.Model so a test can assert the exact Core
+# enum and top-K, and resolves the postprocess the way Core does.
+FAKE_PYNEAT = '''
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class BoxDecodeType:
+    YoloV26 = "YoloV26"
+    YoloV26Seg = "YoloV26Seg"
+
+
+class ModelOptions:
+    decode_type = None
+    top_k = 0
+
+
+class Report:
+    latency_ms = 1.25
+    fps = 800.0
+    avg_power_watts = 2.5
+    energy_joules = 0.75
+
+
+class Model:
+    def __init__(self, path, options=None):
+        trace = "none" if options is None else f"{options.decode_type}:{options.top_k}"
+        Path(os.environ["FAKE_PYNEAT_TRACE"]).write_text(trace, encoding="utf-8")
+        self.outputs = 1 if options else 6
+        self.post_kind = "boxdecode" if options else "detessdequant"
+
+    def info(self):
+        return SimpleNamespace(
+            selection=SimpleNamespace(selected_post_kind=self.post_kind),
+            output_topology=SimpleNamespace(
+                physical_outputs=1, logical_outputs=1, packed_outputs=False
+            ),
+        )
+
+    def input_specs(self):
+        return ["input:uint8[1,3,640,640]"]
+
+    def output_specs(self):
+        return [f"out{i}:float32[1,80,80]" for i in range(self.outputs)]
+
+    def benchmark(self, frames):
+        assert frames == 7
+        return Report()
+'''
+
+
+def run_main(tmp_path: Path, report: Path, *extra: str) -> tuple[subprocess.CompletedProcess, Path]:
+    (tmp_path / "pyneat.py").write_text(FAKE_PYNEAT, encoding="utf-8")
+    model = tmp_path / "model.tar.gz"
+    model.write_text("fake model", encoding="utf-8")
+    trace = tmp_path / "trace.txt"
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{tmp_path}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["FAKE_PYNEAT_TRACE"] = str(trace)
+    result = subprocess.run(
+        [sys.executable, str(MAIN_PY), "--model", str(model), "--frames", "7",
+         "--output-json", str(report), *extra],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env,
+    )
+    return result, trace
+
 
 @pytest.mark.unit
 def test_help_runs() -> None:
@@ -24,6 +98,8 @@ def test_help_runs() -> None:
     )
     assert result.returncode == 0
     assert "usage" in result.stdout.lower()
+    assert "yolo26-det" in result.stdout
+    assert "yolo26-seg" in result.stdout
 
 
 @pytest.mark.unit
@@ -68,63 +144,98 @@ def test_zero_frames_fails(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_writes_json_report_with_benchmark_metrics(tmp_path: Path) -> None:
-    fake_pyneat = tmp_path / "pyneat.py"
-    fake_pyneat.write_text(
-        """
-class Report:
-    latency_ms = 1.25
-    fps = 800.0
-    avg_power_watts = 2.5
-    energy_joules = 0.75
-
-
-class Model:
-    def __init__(self, path):
-        self.path = path
-
-    def input_specs(self):
-        return ["input:uint8[1,3,224,224]"]
-
-    def output_specs(self):
-        return ["output:float32[1,1000]"]
-
-    def benchmark(self, frames):
-        assert frames == 7
-        return Report()
-""",
-        encoding="utf-8",
-    )
-    model = tmp_path / "model.tar.gz"
-    model.write_text("fake model", encoding="utf-8")
     report = tmp_path / "report.json"
-
-    env = os.environ.copy()
-    env["PYTHONPATH"] = f"{tmp_path}{os.pathsep}{env.get('PYTHONPATH', '')}"
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(MAIN_PY),
-            "--model",
-            str(model),
-            "--frames",
-            "7",
-            "--output-json",
-            str(report),
-        ],
-        capture_output=True,
-        text=True,
-        timeout=20,
-        env=env,
-    )
+    result, trace = run_main(tmp_path, report)
 
     assert result.returncode == 0, result.stderr
+    assert trace.read_text(encoding="utf-8") == "none"
     data = json.loads(report.read_text(encoding="utf-8"))
     assert data["benchmark"]["type"] == "model.synthetic"
     assert data["benchmark"]["frames"] == 7
     assert data["model"]["file"] == "model.tar.gz"
+    assert data["model"]["requested_decode_type"] is None
+    assert data["model"]["resolved_postprocess"] == "detessdequant"
+    assert len(data["model"]["output_specs"]) == 6
     assert data["metrics"] == {
         "latency_ms": 1.25,
         "fps": 800.0,
         "avg_power_watts": 2.5,
         "energy_joules": 0.75,
     }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("flag", "enum_name"), [("yolo26-det", "YoloV26"), ("yolo26-seg", "YoloV26Seg")]
+)
+def test_decode_type_selects_core_enum(tmp_path: Path, flag: str, enum_name: str) -> None:
+    report = tmp_path / "report.json"
+    result, trace = run_main(tmp_path, report, "--decode-type", flag)
+
+    assert result.returncode == 0, result.stderr
+    traced_enum, traced_top_k = trace.read_text(encoding="utf-8").split(":")
+    assert traced_enum == enum_name
+    # neatobjectdecode rejects a zero top-K, so any BoxDecode run must carry a cap.
+    assert int(traced_top_k) > 0
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert data["model"]["requested_decode_type"] == flag
+    assert data["model"]["resolved_postprocess"] == "boxdecode"
+    assert len(data["model"]["output_specs"]) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("default_id", "boxdecode_id", "flag"),
+    [
+        ("yolo26m-det-int8-b1", "yolo26m-det-int8-b1-boxdecode", "yolo26-det"),
+        ("yolo26m-seg-int8-b1", "yolo26m-seg-int8-b1-boxdecode", "yolo26-seg"),
+    ],
+)
+def test_boxdecode_row_shares_package_with_its_default(
+    tmp_path: Path, default_id: str, boxdecode_id: str, flag: str
+) -> None:
+    rows = {row.model_id: row for row in refresh_results.all_rows()}
+    default_row, boxdecode_row = rows[default_id], rows[boxdecode_id]
+    assert default_row.package == boxdecode_row.package
+    assert default_row.decode_type is None
+
+    model = tmp_path / boxdecode_row.package
+    default_command = refresh_results.benchmark_command(
+        default_row, model, 5, tmp_path / f"{default_id}.json"
+    )
+    boxdecode_command = refresh_results.benchmark_command(
+        boxdecode_row, model, 5, tmp_path / f"{boxdecode_id}.json"
+    )
+    assert "--decode-type" not in default_command
+    assert boxdecode_command == default_command[:-1] + [
+        str(tmp_path / f"{boxdecode_id}.json"),
+        "--decode-type",
+        flag,
+    ]
+
+
+@pytest.mark.unit
+def test_render_markdown_reports_each_route(tmp_path: Path) -> None:
+    for row in refresh_results.all_rows():
+        boxdecode = row.decode_type is not None
+        (tmp_path / f"{row.model_id}.json").write_text(
+            json.dumps(
+                {
+                    "benchmark": {"timestamp_utc": "2026-07-31T00:00:00+00:00"},
+                    "model": {
+                        "resolved_postprocess": "boxdecode" if boxdecode else "detessdequant",
+                        "output_specs": ["o"] if boxdecode else ["o"] * 6,
+                    },
+                    "metrics": {"latency_ms": 1.0, "fps": 2.0},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    markdown = refresh_results.render_markdown(7, "2.1.3", "2026-07-31", tmp_path)
+
+    assert "| Model ID | Package | Used By | Postprocess | Outputs | Latency / FPS |" in markdown
+    for model_id in ("yolo26m-det-int8-b1-boxdecode", "yolo26m-seg-int8-b1-boxdecode"):
+        assert f"| `{model_id}` |" in markdown
+    assert markdown.count("`boxdecode`") == 2
+    assert markdown.count("`detessdequant`") == len(refresh_results.all_rows()) - 2


### PR DESCRIPTION
## Problem

Every published YOLO26 benchmark row measured whatever postprocess route the package declares, and recorded nothing about which route that was. `main.py` constructed `pyneat.Model` without options, so the BoxDecode route was unreachable and the results table could not tell the two apart.

## Change

Core selects the postprocess route at **model construction**, so an optional flag is enough — the existing `model.benchmark(frames)` call is untouched and Core attaches the BoxDecode input metadata itself.

- `--decode-type {yolo26-det,yolo26-seg}` maps to `BoxDecodeType.YoloV26` / `YoloV26Seg`. Omitting it preserves the current CLI, config, and behavior.
- Each JSON report records the requested decode type, the BoxDecode top-K, the postprocess Core resolved (`model.info().selection.selected_post_kind`), and the output topology.
- One BoxDecode row per task against the same package, keyed by `model_id` so report writing, lookup, and rendering stay consistent.
- `BENCHMARK_RESULTS.md` gains Postprocess and Outputs columns, sourced from each report rather than hard-coded package knowledge.
- Adds a maintained row for `yolo26n-det-int8-b1`, the default package of `high-density-multi-stream-object-detector`, which previously had no published cost.

## Results

Measured on one board, one Core build, one frame count:

| Model ID | Postprocess | Outputs | Latency / FPS |
| --- | --- | ---: | ---: |
| `yolo26n-det-int8-b1` | `dequantize` | 6 | 4.392 / 869.39 |
| `yolo26m-det-int8-b1` | `detessdequant` | 6 | 7.076 / 300.09 |
| `yolo26m-det-int8-b1-boxdecode` | `boxdecode` | 1 | 6.841 / 305.82 |
| `yolo26m-seg-int8-b1` | `detessdequant` | 10 | 10.403 / 201.88 |
| `yolo26m-seg-int8-b1-boxdecode` | `boxdecode` | 1 | 11.709 / 203.23 |

The whole table was regenerated so every row shares one build; earlier numbers came from a different Core, so every pre-existing row's value moved. The catalog spans four distinct routes — `detessdequant`, `dequantize`, `cast`, and `unknown` — none of which the table previously showed.

## Reviewer notes

**The BoxDecode rows do not measure an application's decode cost.** The flagged path sets `top_k=100` and leaves `score_threshold=0` (keeps all candidates) and `nms_iou_threshold=0` (NMS disabled) at Core defaults. `single-stream-object-detector` runs `0.30 / 0.60 / 50`. The configuration is now recorded in each report and in the `BoxDecode Options` row of the results table so the numbers are not read as an application figure.

**Why top-K is set at all.** `neatobjectdecode` rejects a zero top-K, and `Model::Options.top_k` defaults to `0`. Core documents this in `docs/reference/troubleshooting.md` §6 with the same fix value (`opt.top_k = 100`, "the tutorials use 100"), so this is a documented requirement rather than a new gap. The narrower inconsistency is `include/model/Model.h:265`, which still describes `top_k = 0` as "no cap".

**Packaging constraint.** `build.sh` stages only `src/python`, `src/common`, `README.md`, `run.sh`, and `setup.sh`, so a per-example `scripts/` directory does not exist in the installed bundle. The unit tests import `refresh_results` lazily and skip when it is absent; a module-scope import silently aborts collection for the whole module on the Modalix runner.

**Numbers come from a pre-release Core** (`0.4.0+develop.0d77e009b73b`, the sima-neat/core#663 merge) rather than a released SDK, because BoxDecode benchmark support is not in a release yet. The Run Context row records the exact build.

**Two rows publish `unknown` as their resolved postprocess** (`yolo26m-det-bf16-b1`, `yolo26m-seg-bf16-b1`). That is a real Core value — `post_route_stage_kind_name` maps `PostRouteStageKind::Unknown` to `"unknown"` — surfaced by the new column, not introduced by it.

## Test Evidence

```text
PASS  pytest examples/benchmarking/model-benchmark/tests/python/test_unit.py -m unit  (9 passed, host)
PASS  same suite in a tree without scripts/  (6 passed, 3 skipped — packaged-bundle shape)
PASS  python3 -m py_compile main.py refresh_results.py
PASS  python3 scripts/validate_readmes.py  (14 READMEs)
PASS  git diff --check
PASS  Modalix 2.1.3_master_B4040, neat core 0.4.0+develop.0d77e009b73b, 1000 frames, 23/23 rows
PASS  CI at a49a64c: all checks green, including Test Apps Runtime
```

Closes #407