### PR TITLE
perf(detection): select throughput decoding

### DIFF
--- a/examples/object-detection/high-density-multi-stream-object-detector/src/common/config-24x720p20fps.yaml
+++ b/examples/object-detection/high-density-multi-stream-object-detector/src/common/config-24x720p20fps.yaml
@@ -41,7 +41,7 @@ input:                       # RTSP input transport settings.
   fps: 20
   decoder_buffers: 16        # Per-stream decoder output pool used by the validated profile.
   decoder_input_buffers: 2   # Per-stream compressed-input pool.
-  decoder_tuning: auto
+  decoder_tuning: throughput-low-latency
 
 runtime:                     # Runtime and profiling settings.
   profile: false             # Leave hot-path profiling off for the live visualizer run.

--- a/examples/object-detection/high-density-multi-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/high-density-multi-stream-object-detector/src/common/config.yaml
@@ -34,7 +34,7 @@ input:
   fps: 25
   decoder_buffers: 8
   decoder_input_buffers: 2
-  decoder_tuning: auto
+  decoder_tuning: throughput-low-latency
 
 runtime:
   profile: false

--- a/examples/object-detection/high-density-multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/high-density-multi-stream-object-detector/tests/python/test_unit.py
@@ -116,14 +116,14 @@ class TestConfigLoading:
             "max_inflight_total",
         ),
         [
-            ("config.yaml", 16, 25, 8, 2, "auto", 16, 1, 1, 8),
+            ("config.yaml", 16, 25, 8, 2, "throughput-low-latency", 16, 1, 1, 8),
             (
                 "config-24x720p20fps.yaml",
                 24,
                 20,
                 16,
                 2,
-                "auto",
+                "throughput-low-latency",
                 4,
                 2,
                 4,


### PR DESCRIPTION
## Why

The 16×720p25 and 24×720p20 high-density profiles allowed automatic decoder admission to choose low-memory tuning, leaving unnecessary frame-reordering overhead for their validated no-B/ref1 H.264 streams.

## What Changed

- Select `throughput-low-latency` decoder tuning in both dense profiles.

## Validation

- Both edited configs parsed successfully as YAML.
- `git diff --check` and staged validation passed.
- A controlled Modalix A/B test improved 16-stream aggregate throughput from approximately 360–377 FPS to 402–409 FPS when only this setting changed.
- The focused Python unit test was not run because the host Python environment does not have `pytest`.

## Risk

This tuning disables frame reordering and is appropriate for the validated no-B/ref1 media contract used by these profiles.

Closes #415
