### PR TITLE
Add YOLO26 tiny-drone tracking profile

### DIFF
--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -1,4 +1,4 @@
-# Multi-Stream People Tracker
+# Multi-Stream Object Tracker
 
 ## Metadata
 
@@ -6,7 +6,7 @@
 | --- | --- |
 | Category | tracking |
 | Difficulty | Advanced |
-| Tags | object-detection, yolo26, rtsp, multistream, insight, people-tracking |
+| Tags | object-detection, yolo26, rtsp, multistream, insight, tracking, tiny-drone |
 | Languages | C++, Python |
 | Status | experimental |
 | Binary Name | multi-stream-people-tracker |
@@ -14,7 +14,12 @@
 
 ## Concept
 
-Track people across multiple RTSP inputs with mixed-resolution support. The pipeline filters detections to the configured person class, assigns stable IDs per stream, and publishes live video and metadata to Insight.
+Track a configured object class across multiple mixed-resolution RTSP inputs.
+The default profile tracks people. The optional tiny-drone profile uses a
+one-class YOLO26n-P2 INT8 QAT model, two-stage score association, and
+constant-velocity matching for boxes that may move far enough to have zero IoU
+between frames. Track IDs remain local to each stream, and live video plus
+metadata is published to Insight.
 
 ## Preview
 
@@ -47,6 +52,16 @@ Run the remaining commands from `prebuilt-apps/`.
 | `yolo26l-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26x-det-bf16-mla_tess-b1.tar.gz` | Supported |
 | `yolo26m-det-bf16-b1.tar.gz` | Supported |
+
+The tiny-drone profile expects
+`yolo26n-p2-tiny-drone-int8-qat-b1.tar.gz`. This is a custom, one-class model,
+not a current public Model Zoo download. Generate and qualify it with the
+`training/yolo26_tiny_drone` recipe in the Models repository before selecting
+`src/common/tiny-drone.yaml`. The package must expose four raw bbox heads
+followed by four class-logit heads for P2 through P5; Neat derives the four
+strides from the model output dimensions. As in the YOLO detector example,
+input width, height, normalization, and letterboxing come from model
+preprocessing; do not duplicate them in this app configuration.
 
 Check the installed platform version, then set `PLATFORM_VERSION` to the displayed `DISTRO_VERSION` value. Replace `<model-file>` with a file from the table.
 
@@ -83,9 +98,15 @@ inference:
   frames: 0
   max_inflight_per_stream: 4
   max_inflight_total: 16
+  target_class_id: 0
+  target_label: person
   min_score: 0.30
 
 tracking:
+  high_score_threshold: 0.30
+  new_track_threshold: 0.30
+  match_iou_threshold: 0.10
+  max_center_distance: 2.5
   max_missing_frames: 15
 
 output:
@@ -94,6 +115,11 @@ output:
     video_port_base: <videoUDP-start-port>
     metadata_port_base: <metadataUDP-start-port>
 ```
+
+For the qualified one-class drone model, copy
+`src/common/tiny-drone.yaml`, then set its model path, RTSP URL, and Insight
+host. Its low decoder floor is intentional: detections below the high-score
+threshold may recover an existing track but cannot create a new one.
 
 ## Run
 
@@ -119,6 +145,8 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
 - Verify `model.path`, every RTSP URL, and the Insight port ranges.
 - Set either inflight limit to `-1` to use the Core default.
 - Use `output.debug_dir` and `output.save_every` to save sampled overlays.
+- Do not use the tiny-drone thresholds with a generic COCO model; the extra
+  low-score candidates add unnecessary postprocessing work.
 
 ## Source Files
 
@@ -130,6 +158,31 @@ python3 examples/tracking/multi-stream-people-tracker/src/python/main.py \
 
 The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
 
+## Accuracy Qualification
+
+Evaluate one stream at a time. Ground truth JSONL uses frame dimensions and
+`objects`; predictions may be plain `tracks` JSONL or captured Insight
+metadata envelopes. Both use pixel-space `[x, y, width, height]` boxes and
+numeric frame IDs.
+
+```bash
+python3 examples/tracking/multi-stream-people-tracker/src/python/evaluate_tracking.py \
+  --ground-truth <ground-truth.jsonl> \
+  --predictions <insight-metadata.jsonl> \
+  --output <accuracy-report.json> \
+  --fps <source-fps> \
+  --minimum-frames <required-frames> \
+  --minimum-recall <required-recall> \
+  --minimum-tiny-recall <required-tiny-recall> \
+  --maximum-false-positives-per-minute <allowed-fp-per-minute> \
+  --maximum-id-switches <allowed-id-switches> \
+  --maximum-fragmentations <allowed-fragmentations>
+```
+
+Tiny/small/medium/large buckets are measured after the same 640-pixel model
+input scale, so the tiny-object recall gate reflects what the detector sees.
+
 ## Development From Source
 
 To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).
+Source validation includes the evaluator and its JSONL/Insight envelope tests.

--- a/examples/tracking/multi-stream-people-tracker/src/common/config.yaml
+++ b/examples/tracking/multi-stream-people-tracker/src/common/config.yaml
@@ -20,14 +20,20 @@ inference:                   # Detection controls.
   fps: 0                     # Max per-stream processing and output FPS. 0 means use source FPS.
   max_inflight_per_stream: 4 # Raw decoder-backed frames admitted per stream to the shared detector.
   max_inflight_total: 16     # Raw decoder-backed frames admitted across all detector streams.
-  person_class_id: 0         # Class id to track. COCO id 0 is person.
-  min_score: 0.30            # Detection score threshold.
+  target_class_id: 0         # Class id to track. COCO id 0 is person.
+  target_label: person       # Label emitted in Insight metadata.
+  min_score: 0.30            # Decoder floor; lower it only when recovery tracking is needed.
   nms_iou: 0.60              # NMS IoU threshold.
   max_detections: 50         # Max detections to keep per frame after NMS.
 
 tracking:                    # Per-stream tracker settings.
-  iou_threshold: 0.3         # Minimum IoU to match an existing track.
+  high_score_threshold: 0.30 # First association stage threshold.
+  new_track_threshold: 0.30  # Minimum score allowed to establish a track.
+  match_iou_threshold: 0.10  # Accept a match at or above this IoU.
+  max_center_distance: 2.5   # Or accept by center distance, normalized by box diagonal.
+  velocity_momentum: 0.80    # Constant-velocity estimate smoothing.
   max_missing_frames: 15     # Frames to keep a missing track alive.
+  min_confirmed_hits: 1      # Matches required before publishing a track.
 
 output:                      # Insight output plus optional local debug saves.
   insight:                   # Live video and metadata destination.

--- a/examples/tracking/multi-stream-people-tracker/src/common/tiny-drone.yaml
+++ b/examples/tracking/multi-stream-people-tracker/src/common/tiny-drone.yaml
@@ -1,0 +1,44 @@
+model:
+  # Custom one-class YOLO26n-P2 INT8 QAT pack. It must expose grouped raw
+  # bbox heads followed by class-logit heads for P2, P3, P4, and P5.
+  path: models/yolo26n-p2-tiny-drone-int8-qat-b1.tar.gz
+
+streams:
+  - <tiny-drone-rtsp-url>
+
+input:
+  tcp: true
+  latency_ms: 100
+
+runtime:
+  profile: true
+  warmup_frames: 30
+
+inference:
+  frames: 0
+  fps: 0
+  max_inflight_per_stream: 4
+  max_inflight_total: 4
+  target_class_id: 0
+  target_label: drone
+  min_score: 0.05
+  nms_iou: 0.60
+  max_detections: 100
+
+tracking:
+  high_score_threshold: 0.20
+  new_track_threshold: 0.30
+  match_iou_threshold: 0.05
+  max_center_distance: 3.0
+  velocity_momentum: 0.75
+  max_missing_frames: 30
+  min_confirmed_hits: 2
+
+output:
+  insight:
+    host: <insight-host-ip>
+    video_port_base: 9000
+    metadata_port_base: 9100
+  video_enabled: true
+  debug_dir: null
+  save_every: 0

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/main.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
@@ -42,8 +43,9 @@
 
 namespace fs = std::filesystem;
 using multi_stream_people_tracker::Detection;
-using multi_stream_people_tracker::PeopleTracker;
+using multi_stream_people_tracker::ObjectTracker;
 using multi_stream_people_tracker::TrackedDetection;
+using multi_stream_people_tracker::TrackerConfig;
 
 namespace {
 
@@ -62,14 +64,20 @@ struct AppConfig {
   int fps = 0;
   int max_inflight_per_stream = 4;
   int max_inflight_total = 16;
-  int person_class_id = 0;
-  double min_score = 0.55;
+  int target_class_id = 0;
+  std::string target_label = "person";
+  double min_score = 0.30;
   double nms_iou = 0.60;
   int max_detections = 50;
   bool profile = false;
   int warmup_frames = 30;
-  float tracker_iou_threshold = 0.3f;
+  float tracker_high_score = 0.30f;
+  float tracker_new_track_score = 0.30f;
+  float tracker_iou_threshold = 0.10f;
+  float tracker_max_center_distance = 2.5f;
+  float tracker_velocity_momentum = 0.80f;
   int tracker_max_missing = 15;
+  int tracker_min_confirmed_hits = 1;
   std::string insight_host = "127.0.0.1";
   int video_port_base = 9000;
   int metadata_port_base = 9100;
@@ -133,7 +141,7 @@ struct StreamRuntime {
   std::string url;
   simaai::neat::nodes::groups::RtspDecodedInputOptions source_options;
   std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
-  PeopleTracker tracker;
+  ObjectTracker tracker;
   ProfileWindow profile;
   std::optional<cv::Mat> latest_debug_frame;
   int frame_w = 0;
@@ -258,7 +266,10 @@ void validate_config(const AppConfig& cfg) {
                          "inference.max_inflight_per_stream must be -1 or > 0");
   sima_examples::require(cfg.max_inflight_total == -1 || cfg.max_inflight_total > 0,
                          "inference.max_inflight_total must be -1 or > 0");
-  sima_examples::require(cfg.person_class_id >= 0, "inference.person_class_id must be >= 0");
+  sima_examples::require(cfg.target_class_id >= 0, "inference.target_class_id must be >= 0");
+  sima_examples::require(std::any_of(cfg.target_label.begin(), cfg.target_label.end(),
+                                     [](unsigned char c) { return std::isspace(c) == 0; }),
+                         "inference.target_label must be set");
   sima_examples::require(cfg.min_score >= 0.0 && cfg.min_score <= 1.0,
                          "inference.min_score must be between 0 and 1");
   sima_examples::require(cfg.nms_iou >= 0.0 && cfg.nms_iou <= 1.0,
@@ -266,8 +277,21 @@ void validate_config(const AppConfig& cfg) {
   sima_examples::require(cfg.max_detections > 0, "inference.max_detections must be > 0");
   sima_examples::require(cfg.warmup_frames >= 0, "runtime.warmup_frames must be >= 0");
   sima_examples::require(cfg.tracker_iou_threshold >= 0.0f && cfg.tracker_iou_threshold <= 1.0f,
-                         "tracking.iou_threshold must be between 0 and 1");
+                         "tracking.match_iou_threshold must be between 0 and 1");
+  sima_examples::require(cfg.tracker_high_score >= cfg.min_score && cfg.tracker_high_score <= 1.0f,
+                         "tracking.high_score_threshold must be in [inference.min_score, 1]");
+  sima_examples::require(cfg.tracker_new_track_score >= cfg.tracker_high_score &&
+                             cfg.tracker_new_track_score <= 1.0f,
+                         "tracking.new_track_threshold must be in [high_score_threshold, 1]");
+  sima_examples::require(std::isfinite(cfg.tracker_max_center_distance) &&
+                             cfg.tracker_max_center_distance >= 0.0f,
+                         "tracking.max_center_distance must be >= 0");
+  sima_examples::require(cfg.tracker_velocity_momentum >= 0.0f &&
+                             cfg.tracker_velocity_momentum < 1.0f,
+                         "tracking.velocity_momentum must be in [0, 1)");
   sima_examples::require(cfg.tracker_max_missing >= 0, "tracking.max_missing_frames must be >= 0");
+  sima_examples::require(cfg.tracker_min_confirmed_hits >= 1,
+                         "tracking.min_confirmed_hits must be >= 1");
   sima_examples::require(cfg.video_port_base > 0, "output.insight.video_port_base must be > 0");
   sima_examples::require(cfg.metadata_port_base > 0,
                          "output.insight.metadata_port_base must be > 0");
@@ -286,14 +310,25 @@ AppConfig load_app_config(const fs::path& config_path) {
   cfg.fps = raw.int_or("inference.fps", 0);
   cfg.max_inflight_per_stream = raw.int_or("inference.max_inflight_per_stream", 4);
   cfg.max_inflight_total = raw.int_or("inference.max_inflight_total", 16);
-  cfg.person_class_id = raw.int_or("inference.person_class_id", 0);
-  cfg.min_score = raw.double_or("inference.min_score", 0.55);
+  cfg.target_class_id =
+      raw.int_or("inference.target_class_id", raw.int_or("inference.person_class_id", 0));
+  cfg.target_label = raw.string_or("inference.target_label", "person");
+  cfg.min_score = raw.double_or("inference.min_score", 0.30);
   cfg.nms_iou = raw.double_or("inference.nms_iou", 0.60);
   cfg.max_detections = raw.int_or("inference.max_detections", 50);
   cfg.profile = raw.bool_or("runtime.profile", false);
   cfg.warmup_frames = raw.int_or("runtime.warmup_frames", 30);
-  cfg.tracker_iou_threshold = static_cast<float>(raw.double_or("tracking.iou_threshold", 0.3));
+  cfg.tracker_high_score = static_cast<float>(raw.double_or("tracking.high_score_threshold", 0.30));
+  cfg.tracker_new_track_score =
+      static_cast<float>(raw.double_or("tracking.new_track_threshold", 0.30));
+  cfg.tracker_iou_threshold = static_cast<float>(
+      raw.double_or("tracking.match_iou_threshold", raw.double_or("tracking.iou_threshold", 0.10)));
+  cfg.tracker_max_center_distance =
+      static_cast<float>(raw.double_or("tracking.max_center_distance", 2.5));
+  cfg.tracker_velocity_momentum =
+      static_cast<float>(raw.double_or("tracking.velocity_momentum", 0.80));
   cfg.tracker_max_missing = raw.int_or("tracking.max_missing_frames", 15);
+  cfg.tracker_min_confirmed_hits = raw.int_or("tracking.min_confirmed_hits", 1);
   cfg.insight_host = raw.string_or("output.insight.host", "");
   cfg.video_port_base = raw.int_or("output.insight.video_port_base", 9000);
   cfg.metadata_port_base = raw.int_or("output.insight.metadata_port_base", 9100);
@@ -325,20 +360,22 @@ bool extract_bbox_payload(const simaai::neat::Sample& sample, std::vector<std::u
   return objdet::extract_bbox_payload(sample, payload, err);
 }
 
-std::vector<Detection> filter_people(const std::vector<objdet::Box>& boxes, int person_class_id) {
-  std::vector<Detection> people;
-  people.reserve(boxes.size());
+std::vector<Detection> filter_target_class(const std::vector<objdet::Box>& boxes,
+                                           int target_class_id) {
+  std::vector<Detection> detections;
+  detections.reserve(boxes.size());
   for (const auto& box : boxes) {
-    if (box.class_id != person_class_id) {
+    if (box.class_id != target_class_id) {
       continue;
     }
-    people.push_back(Detection{box.x1, box.y1, box.x2, box.y2, box.score, box.class_id});
+    detections.push_back(Detection{box.x1, box.y1, box.x2, box.y2, box.score, box.class_id});
   }
-  return people;
+  return detections;
 }
 
 std::vector<sima_examples::MetadataBox>
-build_metadata_tracks(const std::vector<TrackedDetection>& tracks, int frame_w, int frame_h) {
+build_metadata_tracks(const std::vector<TrackedDetection>& tracks, int frame_w, int frame_h,
+                      const std::string& target_label) {
   std::vector<sima_examples::MetadataBox> metadata_boxes;
   metadata_boxes.reserve(tracks.size());
   for (const auto& track : tracks) {
@@ -353,7 +390,7 @@ build_metadata_tracks(const std::vector<TrackedDetection>& tracks, int frame_w, 
 
     sima_examples::MetadataBox obj;
     obj.id = std::to_string(track.track_id);
-    obj.label = "person";
+    obj.label = target_label;
     obj.confidence = track.score;
     obj.x = static_cast<float>(x1);
     obj.y = static_cast<float>(y1);
@@ -585,7 +622,15 @@ StreamRuntime build_stream_runtime(const AppConfig& cfg, int stream_index, const
   StreamRuntime runtime;
   runtime.index = stream_index;
   runtime.url = url;
-  runtime.tracker = PeopleTracker(cfg.tracker_iou_threshold, cfg.tracker_max_missing);
+  runtime.tracker = ObjectTracker(TrackerConfig{
+      cfg.tracker_high_score,
+      cfg.tracker_new_track_score,
+      cfg.tracker_iou_threshold,
+      cfg.tracker_max_center_distance,
+      cfg.tracker_velocity_momentum,
+      cfg.tracker_max_missing,
+      cfg.tracker_min_confirmed_hits,
+  });
   const auto source_options =
       build_source_options(cfg, url, runtime.output_fps, runtime.frame_w, runtime.frame_h);
   sima_examples::require(runtime.frame_w > 0 && runtime.frame_h > 0,
@@ -662,9 +707,10 @@ void connect_stream_graph(AppRuntime& app, const AppConfig& cfg, const StreamRun
   }
 }
 
-void send_metadata(StreamRuntime& stream, const simaai::neat::Sample& sample,
+void send_metadata(StreamRuntime& stream, const AppConfig& cfg, const simaai::neat::Sample& sample,
                    const std::vector<TrackedDetection>& tracks) {
-  const auto metadata_tracks = build_metadata_tracks(tracks, stream.frame_w, stream.frame_h);
+  const auto metadata_tracks =
+      build_metadata_tracks(tracks, stream.frame_w, stream.frame_h, cfg.target_label);
   const std::string data_json = sima_examples::metadata_boxes_data_json("tracks", metadata_tracks);
   const int64_t timestamp_ms = sample.pts_ns >= 0 ? sample.pts_ns / 1'000'000 : -1;
   const std::string frame_id = sample.frame_id >= 0 ? std::to_string(sample.frame_id) : "";
@@ -721,16 +767,16 @@ void process_output_sample(StreamRuntime& stream, const AppConfig& cfg,
   }
   const auto boxes = objdet::parse_boxes_strict(payload, stream.frame_w, stream.frame_h,
                                                 cfg.max_detections, false);
-  const auto people = filter_people(boxes, cfg.person_class_id);
+  const auto target_detections = filter_target_class(boxes, cfg.target_class_id);
   const double tracker_start = sima_examples::time_ms();
-  const auto tracks = stream.tracker.update(people, stream.processed);
+  const auto tracks = stream.tracker.update(target_detections, stream.processed);
   const double tracker_end = sima_examples::time_ms();
 
   ++stream.processed;
   const bool warming_up = stream.processed <= cfg.warmup_frames;
   if (!warming_up) {
     const double metadata_start = sima_examples::time_ms();
-    send_metadata(stream, sample, tracks);
+    send_metadata(stream, cfg, sample, tracks);
     const double metadata_end = sima_examples::time_ms();
     if (save_frames_enabled(cfg)) {
       maybe_save_debug_frame(

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/utils/tracker.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/utils/tracker.cpp
@@ -1,6 +1,9 @@
 #include "examples/tracking/multi-stream-people-tracker/src/cpp/utils/tracker_api.cpp"
 
 #include <algorithm>
+#include <cmath>
+#include <functional>
+#include <stdexcept>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -10,139 +13,253 @@
 namespace multi_stream_people_tracker {
 namespace {
 
+struct TrackState {
+  int track_id = 0;
+  Detection detection;
+  float velocity_x = 0.0f;
+  float velocity_y = 0.0f;
+  float velocity_w = 0.0f;
+  float velocity_h = 0.0f;
+  int last_frame_index = 0;
+  int missing_frames = 0;
+  int hits = 1;
+};
+
+float width(const Detection& detection) {
+  return std::max(0.0f, detection.x2 - detection.x1);
+}
+
+float height(const Detection& detection) {
+  return std::max(0.0f, detection.y2 - detection.y1);
+}
+
+float center_x(const Detection& detection) {
+  return 0.5f * (detection.x1 + detection.x2);
+}
+
+float center_y(const Detection& detection) {
+  return 0.5f * (detection.y1 + detection.y2);
+}
+
 float iou_xyxy(const Detection& a, const Detection& b) {
   const float xx1 = std::max(a.x1, b.x1);
   const float yy1 = std::max(a.y1, b.y1);
   const float xx2 = std::min(a.x2, b.x2);
   const float yy2 = std::min(a.y2, b.y2);
-  const float width = std::max(0.0f, xx2 - xx1);
-  const float height = std::max(0.0f, yy2 - yy1);
-  const float inter = width * height;
-  const float area_a = std::max(0.0f, a.x2 - a.x1) * std::max(0.0f, a.y2 - a.y1);
-  const float area_b = std::max(0.0f, b.x2 - b.x1) * std::max(0.0f, b.y2 - b.y1);
-  const float denom = area_a + area_b - inter;
-  return denom > 0.0f ? (inter / denom) : 0.0f;
+  const float intersection = std::max(0.0f, xx2 - xx1) * std::max(0.0f, yy2 - yy1);
+  const float union_area = width(a) * height(a) + width(b) * height(b) - intersection;
+  return union_area > 0.0f ? intersection / union_area : 0.0f;
 }
 
-struct TrackState {
-  int track_id = 0;
-  Detection detection;
-  int last_frame_index = 0;
-  int missing_frames = 0;
-};
+float normalized_center_distance(const Detection& a, const Detection& b) {
+  const float dx = center_x(a) - center_x(b);
+  const float dy = center_y(a) - center_y(b);
+  const float diagonal_a = std::hypot(width(a), height(a));
+  const float diagonal_b = std::hypot(width(b), height(b));
+  const float scale = std::max(1.0f, 0.5f * (diagonal_a + diagonal_b));
+  return std::hypot(dx, dy) / scale;
+}
+
+Detection predict(const TrackState& track, int frame_index) {
+  const int elapsed = std::max(0, frame_index - track.last_frame_index);
+  const float predicted_x = center_x(track.detection) + track.velocity_x * elapsed;
+  const float predicted_y = center_y(track.detection) + track.velocity_y * elapsed;
+  const float predicted_w = std::max(1.0f, width(track.detection) + track.velocity_w * elapsed);
+  const float predicted_h = std::max(1.0f, height(track.detection) + track.velocity_h * elapsed);
+  return Detection{
+      predicted_x - predicted_w * 0.5f,
+      predicted_y - predicted_h * 0.5f,
+      predicted_x + predicted_w * 0.5f,
+      predicted_y + predicted_h * 0.5f,
+      track.detection.score,
+      track.detection.class_id,
+  };
+}
+
+void validate_config(const TrackerConfig& config) {
+  if (config.high_score_threshold < 0.0f || config.high_score_threshold > 1.0f) {
+    throw std::invalid_argument("high_score_threshold must be in [0, 1]");
+  }
+  if (config.new_track_threshold < config.high_score_threshold ||
+      config.new_track_threshold > 1.0f) {
+    throw std::invalid_argument("new_track_threshold must be in [high_score_threshold, 1]");
+  }
+  if (config.match_iou_threshold < 0.0f || config.match_iou_threshold > 1.0f) {
+    throw std::invalid_argument("match_iou_threshold must be in [0, 1]");
+  }
+  if (!std::isfinite(config.max_center_distance) || config.max_center_distance < 0.0f) {
+    throw std::invalid_argument("max_center_distance must be >= 0");
+  }
+  if (config.velocity_momentum < 0.0f || config.velocity_momentum >= 1.0f) {
+    throw std::invalid_argument("velocity_momentum must be in [0, 1)");
+  }
+  if (config.max_missing_frames < 0) {
+    throw std::invalid_argument("max_missing_frames must be >= 0");
+  }
+  if (config.min_confirmed_hits < 1) {
+    throw std::invalid_argument("min_confirmed_hits must be >= 1");
+  }
+}
 
 } // namespace
 
-struct PeopleTracker::Impl {
+struct ObjectTracker::Impl {
   std::unordered_map<int, TrackState> tracks;
+  int last_frame_index = -1;
 };
 
-PeopleTracker::PeopleTracker(float iou_threshold, int max_missing_frames)
-    : iou_threshold_(iou_threshold), max_missing_frames_(max_missing_frames),
-      impl_(std::make_unique<Impl>()) {}
+ObjectTracker::ObjectTracker(TrackerConfig config)
+    : config_(config), impl_(std::make_unique<Impl>()) {
+  validate_config(config_);
+}
 
-PeopleTracker::~PeopleTracker() = default;
+ObjectTracker::~ObjectTracker() = default;
+ObjectTracker::ObjectTracker(ObjectTracker&&) noexcept = default;
+ObjectTracker& ObjectTracker::operator=(ObjectTracker&&) noexcept = default;
 
-PeopleTracker::PeopleTracker(PeopleTracker&&) noexcept = default;
-
-PeopleTracker& PeopleTracker::operator=(PeopleTracker&&) noexcept = default;
-
-int PeopleTracker::active_track_count() const {
+int ObjectTracker::active_track_count() const {
   return static_cast<int>(impl_->tracks.size());
 }
 
-std::vector<TrackedDetection> PeopleTracker::update(const std::vector<Detection>& detections,
+std::vector<TrackedDetection> ObjectTracker::update(const std::vector<Detection>& detections,
                                                     int frame_index) {
-  std::vector<std::tuple<float, int, int>> candidates;
+  if (frame_index < 0) {
+    throw std::invalid_argument("frame_index must be >= 0");
+  }
+  if (frame_index < impl_->last_frame_index) {
+    throw std::invalid_argument("frame_index must be monotonic");
+  }
+  impl_->last_frame_index = frame_index;
+
+  std::vector<int> stale_tracks;
   for (const auto& [track_id, track] : impl_->tracks) {
-    for (std::size_t det_index = 0; det_index < detections.size(); ++det_index) {
-      if (detections[det_index].class_id != track.detection.class_id) {
-        continue;
-      }
-      const float iou = iou_xyxy(track.detection, detections[det_index]);
-      if (iou >= iou_threshold_) {
-        candidates.emplace_back(iou, track_id, static_cast<int>(det_index));
-      }
+    if (frame_index - track.last_frame_index > config_.max_missing_frames) {
+      stale_tracks.push_back(track_id);
     }
   }
-  std::sort(candidates.begin(), candidates.end(), std::greater<>());
+  for (const int track_id : stale_tracks) {
+    impl_->tracks.erase(track_id);
+  }
+
+  std::vector<int> high_detections;
+  std::vector<int> low_detections;
+  for (std::size_t index = 0; index < detections.size(); ++index) {
+    if (detections[index].score >= config_.high_score_threshold) {
+      high_detections.push_back(static_cast<int>(index));
+    } else {
+      low_detections.push_back(static_cast<int>(index));
+    }
+  }
 
   std::unordered_set<int> matched_tracks;
-  std::unordered_set<int> matched_dets;
+  std::unordered_set<int> matched_detections;
   std::unordered_map<int, int> assignments;
 
-  for (const auto& [iou, track_id, det_index] : candidates) {
-    static_cast<void>(iou);
-    if (matched_tracks.count(track_id) > 0 || matched_dets.count(det_index) > 0) {
+  const auto associate = [&](const std::vector<int>& detection_indices) {
+    std::vector<std::tuple<float, int, int>> candidates;
+    for (const auto& [track_id, track] : impl_->tracks) {
+      if (matched_tracks.count(track_id) != 0) {
+        continue;
+      }
+      const Detection predicted = predict(track, frame_index);
+      for (const int detection_index : detection_indices) {
+        if (matched_detections.count(detection_index) != 0) {
+          continue;
+        }
+        const Detection& detection = detections[static_cast<std::size_t>(detection_index)];
+        if (detection.class_id != track.detection.class_id) {
+          continue;
+        }
+        const float iou = iou_xyxy(predicted, detection);
+        const float center_distance = normalized_center_distance(predicted, detection);
+        if (iou < config_.match_iou_threshold && center_distance > config_.max_center_distance) {
+          continue;
+        }
+        const float affinity = iou + 1.0f / (1.0f + center_distance);
+        candidates.emplace_back(affinity, track_id, detection_index);
+      }
+    }
+    std::sort(candidates.begin(), candidates.end(), std::greater<>());
+    for (const auto& [affinity, track_id, detection_index] : candidates) {
+      static_cast<void>(affinity);
+      if (matched_tracks.count(track_id) != 0 || matched_detections.count(detection_index) != 0) {
+        continue;
+      }
+      matched_tracks.insert(track_id);
+      matched_detections.insert(detection_index);
+      assignments[detection_index] = track_id;
+    }
+  };
+
+  // ByteTrack-style score staging: recover existing tracks with low scores,
+  // but only high-score detections participate in track creation.
+  associate(high_detections);
+  associate(low_detections);
+
+  for (const auto& [detection_index, track_id] : assignments) {
+    TrackState& track = impl_->tracks.at(track_id);
+    const Detection& detection = detections[static_cast<std::size_t>(detection_index)];
+    const int elapsed = std::max(1, frame_index - track.last_frame_index);
+    const float measured_vx = (center_x(detection) - center_x(track.detection)) / elapsed;
+    const float measured_vy = (center_y(detection) - center_y(track.detection)) / elapsed;
+    const float measured_vw = (width(detection) - width(track.detection)) / elapsed;
+    const float measured_vh = (height(detection) - height(track.detection)) / elapsed;
+    const float previous = config_.velocity_momentum;
+    const float measured = 1.0f - previous;
+    track.velocity_x = previous * track.velocity_x + measured * measured_vx;
+    track.velocity_y = previous * track.velocity_y + measured * measured_vy;
+    track.velocity_w = previous * track.velocity_w + measured * measured_vw;
+    track.velocity_h = previous * track.velocity_h + measured * measured_vh;
+    track.detection = detection;
+    track.last_frame_index = frame_index;
+    track.missing_frames = 0;
+    ++track.hits;
+  }
+
+  for (const int detection_index : high_detections) {
+    if (matched_detections.count(detection_index) != 0) {
       continue;
     }
-    matched_tracks.insert(track_id);
-    matched_dets.insert(det_index);
-    assignments[det_index] = track_id;
-  }
-
-  for (const auto& [det_index, track_id] : assignments) {
-    TrackState state;
-    state.track_id = track_id;
-    state.detection = detections[static_cast<std::size_t>(det_index)];
-    state.last_frame_index = frame_index;
-    state.missing_frames = 0;
-    impl_->tracks[track_id] = state;
-  }
-
-  for (std::size_t det_index = 0; det_index < detections.size(); ++det_index) {
-    if (matched_dets.count(static_cast<int>(det_index)) > 0) {
+    const Detection& detection = detections[static_cast<std::size_t>(detection_index)];
+    if (detection.score < config_.new_track_threshold) {
       continue;
     }
     const int track_id = next_track_id_++;
-    impl_->tracks[track_id] = TrackState{
-        track_id,
-        detections[det_index],
-        frame_index,
-        0,
-    };
-    assignments[static_cast<int>(det_index)] = track_id;
+    impl_->tracks.emplace(
+        track_id, TrackState{track_id, detection, 0.0f, 0.0f, 0.0f, 0.0f, frame_index, 0, 1});
+    matched_tracks.insert(track_id);
+    matched_detections.insert(detection_index);
+    assignments[detection_index] = track_id;
   }
 
-  std::vector<int> expired;
+  std::vector<int> expired_tracks;
   for (auto& [track_id, track] : impl_->tracks) {
-    if (matched_tracks.count(track_id) > 0) {
+    if (matched_tracks.count(track_id) != 0) {
       continue;
     }
-    bool assigned_now = false;
-    for (const auto& [det_index, assigned_track_id] : assignments) {
-      static_cast<void>(det_index);
-      if (assigned_track_id == track_id) {
-        assigned_now = true;
-        break;
-      }
-    }
-    if (assigned_now) {
-      continue;
-    }
-    track.missing_frames += 1;
-    if (track.missing_frames > max_missing_frames_) {
-      expired.push_back(track_id);
+    track.missing_frames = frame_index - track.last_frame_index;
+    if (track.missing_frames > config_.max_missing_frames) {
+      expired_tracks.push_back(track_id);
     }
   }
-  for (const int track_id : expired) {
+  for (const int track_id : expired_tracks) {
     impl_->tracks.erase(track_id);
   }
 
   std::vector<TrackedDetection> tracked;
-  tracked.reserve(detections.size());
-  for (std::size_t det_index = 0; det_index < detections.size(); ++det_index) {
-    const int track_id = assignments[static_cast<int>(det_index)];
-    const Detection& det = detections[det_index];
-    tracked.push_back(TrackedDetection{
-        track_id,
-        det.x1,
-        det.y1,
-        det.x2,
-        det.y2,
-        det.score,
-        det.class_id,
-    });
+  tracked.reserve(assignments.size());
+  for (std::size_t detection_index = 0; detection_index < detections.size(); ++detection_index) {
+    const auto assignment = assignments.find(static_cast<int>(detection_index));
+    if (assignment == assignments.end()) {
+      continue;
+    }
+    const TrackState& track = impl_->tracks.at(assignment->second);
+    if (track.hits < config_.min_confirmed_hits) {
+      continue;
+    }
+    const Detection& detection = detections[detection_index];
+    tracked.push_back(TrackedDetection{track.track_id, detection.x1, detection.y1, detection.x2,
+                                       detection.y2, detection.score, detection.class_id});
   }
   return tracked;
 }

--- a/examples/tracking/multi-stream-people-tracker/src/cpp/utils/tracker_api.cpp
+++ b/examples/tracking/multi-stream-people-tracker/src/cpp/utils/tracker_api.cpp
@@ -24,22 +24,34 @@ struct TrackedDetection {
   int class_id = -1;
 };
 
-class PeopleTracker {
-public:
-  explicit PeopleTracker(float iou_threshold = 0.3f, int max_missing_frames = 2);
-  ~PeopleTracker();
+struct TrackerConfig {
+  float high_score_threshold = 0.30f;
+  float new_track_threshold = 0.30f;
+  float match_iou_threshold = 0.10f;
+  float max_center_distance = 2.5f;
+  float velocity_momentum = 0.80f;
+  int max_missing_frames = 15;
+  int min_confirmed_hits = 1;
+};
 
-  PeopleTracker(PeopleTracker&&) noexcept;
-  PeopleTracker& operator=(PeopleTracker&&) noexcept;
-  PeopleTracker(const PeopleTracker&) = delete;
-  PeopleTracker& operator=(const PeopleTracker&) = delete;
+// A compact two-stage tracker for detections whose boxes may be only a few
+// pixels wide. High-confidence detections establish tracks. Lower-confidence
+// detections may recover an established track, but can never create one.
+class ObjectTracker {
+public:
+  explicit ObjectTracker(TrackerConfig config = {});
+  ~ObjectTracker();
+
+  ObjectTracker(ObjectTracker&&) noexcept;
+  ObjectTracker& operator=(ObjectTracker&&) noexcept;
+  ObjectTracker(const ObjectTracker&) = delete;
+  ObjectTracker& operator=(const ObjectTracker&) = delete;
 
   int active_track_count() const;
   std::vector<TrackedDetection> update(const std::vector<Detection>& detections, int frame_index);
 
 private:
-  float iou_threshold_ = 0.3f;
-  int max_missing_frames_ = 2;
+  TrackerConfig config_;
   int next_track_id_ = 1;
 
   struct Impl;

--- a/examples/tracking/multi-stream-people-tracker/src/python/evaluate_tracking.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/evaluate_tracking.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Evaluate detector and tracker JSONL output against frame-level ground truth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def xywh_to_xyxy(box: list[float]) -> tuple[float, float, float, float]:
+    if len(box) != 4:
+        raise ValueError(f"bbox must contain four values, got {box!r}")
+    x, y, width, height = (float(value) for value in box)
+    if not all(math.isfinite(value) for value in (x, y, width, height)):
+        raise ValueError(f"bbox values must be finite, got {box!r}")
+    if width < 0 or height < 0:
+        raise ValueError(f"bbox width and height must be non-negative, got {box!r}")
+    return x, y, x + width, y + height
+
+
+def iou(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> float:
+    x1 = max(a[0], b[0])
+    y1 = max(a[1], b[1])
+    x2 = min(a[2], b[2])
+    y2 = min(a[3], b[3])
+    intersection = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union_area = area_a + area_b - intersection
+    return intersection / union_area if union_area > 0 else 0.0
+
+
+def read_jsonl(path: Path, array_key: str) -> dict[int, dict[str, Any]]:
+    frames: dict[int, dict[str, Any]] = {}
+    with path.open(encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            if not line.strip():
+                continue
+            document = json.loads(line)
+            if not isinstance(document, dict):
+                raise ValueError(f"{path}:{line_number}: frame must be an object")
+            frame_index = document.get("frame_index")
+            if frame_index is None:
+                frame_id = document.get("frame_id")
+                if isinstance(frame_id, str) and frame_id.isdigit():
+                    frame_index = int(frame_id)
+                elif isinstance(frame_id, int):
+                    frame_index = frame_id
+            data = document.get("data")
+            if isinstance(data, str):
+                try:
+                    data = json.loads(data)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"{path}:{line_number}: data is not valid JSON") from exc
+            if array_key not in document and isinstance(data, dict) and array_key in data:
+                document = {**document, array_key: data[array_key]}
+            if not isinstance(frame_index, int) or frame_index < 0:
+                raise ValueError(f"{path}:{line_number}: frame_index must be a non-negative integer")
+            if frame_index in frames:
+                raise ValueError(f"{path}:{line_number}: duplicate frame_index {frame_index}")
+            if not isinstance(document.get(array_key), list):
+                raise ValueError(f"{path}:{line_number}: {array_key} must be a list")
+            document["frame_index"] = frame_index
+            frames[frame_index] = document
+    if not frames:
+        raise ValueError(f"{path}: no frames found")
+    return frames
+
+
+def greedy_matches(
+    truth: list[dict[str, Any]], predictions: list[dict[str, Any]], threshold: float
+) -> list[tuple[int, int, float]]:
+    candidates = []
+    for truth_index, truth_object in enumerate(truth):
+        truth_box = xywh_to_xyxy(truth_object["bbox"])
+        for prediction_index, prediction in enumerate(predictions):
+            overlap = iou(truth_box, xywh_to_xyxy(prediction["bbox"]))
+            if overlap >= threshold:
+                candidates.append((overlap, truth_index, prediction_index))
+    candidates.sort(reverse=True)
+    matched_truth: set[int] = set()
+    matched_predictions: set[int] = set()
+    matches = []
+    for overlap, truth_index, prediction_index in candidates:
+        if truth_index in matched_truth or prediction_index in matched_predictions:
+            continue
+        matched_truth.add(truth_index)
+        matched_predictions.add(prediction_index)
+        matches.append((truth_index, prediction_index, overlap))
+    return matches
+
+
+def model_box_area(box: list[float], source_width: int, source_height: int, model_size: int) -> float:
+    if source_width <= 0 or source_height <= 0:
+        raise ValueError("ground-truth frame width and height must be positive")
+    scale = min(model_size / source_width, model_size / source_height)
+    return max(0.0, float(box[2])) * max(0.0, float(box[3])) * scale * scale
+
+
+def size_bucket(area: float) -> str:
+    if area < 16.0**2:
+        return "tiny"
+    if area < 32.0**2:
+        return "small"
+    if area < 96.0**2:
+        return "medium"
+    return "large"
+
+
+def safe_ratio(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def evaluate(
+    truth_frames: dict[int, dict[str, Any]],
+    prediction_frames: dict[int, dict[str, Any]],
+    *,
+    iou_threshold: float,
+    fps: float,
+    model_size: int,
+) -> dict[str, Any]:
+    if not 0.0 < iou_threshold <= 1.0:
+        raise ValueError("iou_threshold must be in (0, 1]")
+    if fps <= 0.0 or model_size <= 0:
+        raise ValueError("fps and model_size must be positive")
+
+    true_positives = 0
+    false_positives = 0
+    false_negatives = 0
+    overlap_sum = 0.0
+    size_counts = {name: {"ground_truth": 0, "matched": 0} for name in ("tiny", "small", "medium", "large")}
+    last_prediction_by_truth: dict[str, str] = {}
+    truth_was_matched: dict[str, bool] = {}
+    truth_seen_match: set[str] = set()
+    id_switches = 0
+    fragmentations = 0
+
+    frame_indices = sorted(set(truth_frames) | set(prediction_frames))
+    for frame_index in frame_indices:
+        truth_frame = truth_frames.get(frame_index, {"objects": []})
+        prediction_frame = prediction_frames.get(frame_index, {"tracks": []})
+        truth = truth_frame.get("objects", [])
+        predictions = prediction_frame.get("tracks", [])
+        width = int(truth_frame.get("width", 0))
+        height = int(truth_frame.get("height", 0))
+        matches = greedy_matches(truth, predictions, iou_threshold)
+        matched_truth_indices = {match[0] for match in matches}
+        true_positives += len(matches)
+        false_positives += len(predictions) - len(matches)
+        false_negatives += len(truth) - len(matches)
+        overlap_sum += sum(match[2] for match in matches)
+
+        for truth_index, truth_object in enumerate(truth):
+            bucket = size_bucket(model_box_area(truth_object["bbox"], width, height, model_size))
+            size_counts[bucket]["ground_truth"] += 1
+            if truth_index in matched_truth_indices:
+                size_counts[bucket]["matched"] += 1
+
+        matches_by_truth = {truth_index: prediction_index for truth_index, prediction_index, _ in matches}
+        for truth_index, truth_object in enumerate(truth):
+            truth_id = str(truth_object.get("track_id", f"frame-{frame_index}-object-{truth_index}"))
+            prediction_index = matches_by_truth.get(truth_index)
+            if prediction_index is None:
+                if truth_id in truth_seen_match:
+                    truth_was_matched[truth_id] = False
+                continue
+            raw_prediction_id = predictions[prediction_index].get("id")
+            if not isinstance(raw_prediction_id, (str, int)) or str(raw_prediction_id) == "":
+                raise ValueError(f"frame {frame_index}: matched prediction has no track id")
+            prediction_id = str(raw_prediction_id)
+            if truth_id in truth_seen_match and not truth_was_matched.get(truth_id, False):
+                fragmentations += 1
+            previous_prediction = last_prediction_by_truth.get(truth_id)
+            if previous_prediction is not None and prediction_id != previous_prediction:
+                id_switches += 1
+            last_prediction_by_truth[truth_id] = prediction_id
+            truth_was_matched[truth_id] = True
+            truth_seen_match.add(truth_id)
+
+    precision = safe_ratio(true_positives, true_positives + false_positives)
+    recall = safe_ratio(true_positives, true_positives + false_negatives)
+    f1 = 2.0 * precision * recall / (precision + recall) if precision + recall else 0.0
+    duration_minutes = len(frame_indices) / fps / 60.0
+    return {
+        "schema_version": 1,
+        "configuration": {"fps": fps, "iou_threshold": iou_threshold, "model_size": model_size},
+        "frames": len(frame_indices),
+        "detection": {
+            "true_positives": true_positives,
+            "false_positives": false_positives,
+            "false_negatives": false_negatives,
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "mean_matched_iou": safe_ratio(overlap_sum, true_positives),
+            "false_positives_per_minute": false_positives / duration_minutes if duration_minutes else 0.0,
+            "recall_by_model_input_size": {
+                name: {
+                    **counts,
+                    "recall": safe_ratio(counts["matched"], counts["ground_truth"]),
+                }
+                for name, counts in size_counts.items()
+            },
+        },
+        "tracking": {
+            "ground_truth_track_count": len({
+                str(obj.get("track_id"))
+                for frame in truth_frames.values()
+                for obj in frame.get("objects", [])
+                if obj.get("track_id") is not None
+            }),
+            "id_switches": id_switches,
+            "fragmentations": fragmentations,
+        },
+    }
+
+
+def enforce_gates(report: dict[str, Any], args: argparse.Namespace) -> list[str]:
+    failures = []
+    detection = report["detection"]
+    tracking = report["tracking"]
+    if report["frames"] < args.minimum_frames:
+        failures.append(f"frames {report['frames']} < required {args.minimum_frames}")
+    if detection["recall"] < args.minimum_recall:
+        failures.append(f"recall {detection['recall']:.6f} < required {args.minimum_recall:.6f}")
+    tiny_recall = detection["recall_by_model_input_size"]["tiny"]["recall"]
+    if tiny_recall < args.minimum_tiny_recall:
+        failures.append(f"tiny recall {tiny_recall:.6f} < required {args.minimum_tiny_recall:.6f}")
+    if detection["false_positives_per_minute"] > args.maximum_false_positives_per_minute:
+        failures.append(
+            "false positives/minute "
+            f"{detection['false_positives_per_minute']:.6f} > allowed "
+            f"{args.maximum_false_positives_per_minute:.6f}"
+        )
+    if tracking["id_switches"] > args.maximum_id_switches:
+        failures.append(
+            f"id switches {tracking['id_switches']} > allowed {args.maximum_id_switches}"
+        )
+    if tracking["fragmentations"] > args.maximum_fragmentations:
+        failures.append(
+            f"fragmentations {tracking['fragmentations']} > allowed {args.maximum_fragmentations}"
+        )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ground-truth", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--iou-threshold", type=float, default=0.30)
+    parser.add_argument("--fps", type=float, required=True)
+    parser.add_argument("--model-size", type=int, default=640)
+    parser.add_argument("--minimum-frames", type=int, default=1)
+    parser.add_argument("--minimum-recall", type=float, default=0.0)
+    parser.add_argument("--minimum-tiny-recall", type=float, default=0.0)
+    parser.add_argument("--maximum-false-positives-per-minute", type=float, default=math.inf)
+    parser.add_argument("--maximum-id-switches", type=int, default=2**31 - 1)
+    parser.add_argument("--maximum-fragmentations", type=int, default=2**31 - 1)
+    args = parser.parse_args()
+    if args.minimum_frames < 1:
+        parser.error("minimum-frames must be positive")
+    if not 0.0 <= args.minimum_recall <= 1.0 or not 0.0 <= args.minimum_tiny_recall <= 1.0:
+        parser.error("minimum recall gates must be in [0, 1]")
+    if args.maximum_false_positives_per_minute < 0.0:
+        parser.error("maximum-false-positives-per-minute must be >= 0")
+    if args.maximum_id_switches < 0 or args.maximum_fragmentations < 0:
+        parser.error("tracking count gates must be >= 0")
+
+    report = evaluate(
+        read_jsonl(args.ground_truth, "objects"),
+        read_jsonl(args.predictions, "tracks"),
+        iou_threshold=args.iou_threshold,
+        fps=args.fps,
+        model_size=args.model_size,
+    )
+    failures = enforce_gates(report, args)
+    report["gates"] = {"passed": not failures, "failures": failures}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/tracking/multi-stream-people-tracker/src/python/main.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/main.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
-from pathlib import Path
 import glob
 import json
+import math
 import os
 import struct
 import sys
 import time
+from dataclasses import dataclass
+from pathlib import Path
 
 import yaml
-
-from utils.tracker import PeopleTracker, TrackedDetection
+from utils.tracker import ObjectTracker, TrackedDetection, TrackerConfig
 
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
 
@@ -33,14 +33,20 @@ class AppConfig:
     fps: int = 0
     max_inflight_per_stream: int = 4
     max_inflight_total: int = 16
-    person_class_id: int = 0
-    min_score: float = 0.55
+    target_class_id: int = 0
+    target_label: str = "person"
+    min_score: float = 0.30
     nms_iou: float = 0.60
     max_detections: int = 50
     profile: bool = False
     warmup_frames: int = 30
-    tracker_iou_threshold: float = 0.3
+    tracker_high_score: float = 0.30
+    tracker_new_track_score: float = 0.30
+    tracker_iou_threshold: float = 0.10
+    tracker_max_center_distance: float = 2.5
+    tracker_velocity_momentum: float = 0.80
     tracker_max_missing: int = 15
+    tracker_min_confirmed_hits: int = 1
     insight_host: str = "127.0.0.1"
     video_port_base: int = 9000
     metadata_port_base: int = 9100
@@ -55,7 +61,7 @@ class StreamRuntime:
     url: str
     source_options: object
     metadata_sender: object
-    tracker: PeopleTracker
+    tracker: ObjectTracker
     profile: "ProfileWindow"
     latest_debug_frame: object | None
     frame_w: int
@@ -214,8 +220,10 @@ def validate_config(cfg: AppConfig) -> None:
         raise ValueError("inference.max_inflight_per_stream must be -1 or > 0")
     if cfg.max_inflight_total != -1 and cfg.max_inflight_total <= 0:
         raise ValueError("inference.max_inflight_total must be -1 or > 0")
-    if cfg.person_class_id < 0:
-        raise ValueError("inference.person_class_id must be >= 0")
+    if cfg.target_class_id < 0:
+        raise ValueError("inference.target_class_id must be >= 0")
+    if not cfg.target_label.strip():
+        raise ValueError("inference.target_label must be set")
     if not 0.0 <= cfg.min_score <= 1.0:
         raise ValueError("inference.min_score must be between 0 and 1")
     if not 0.0 <= cfg.nms_iou <= 1.0:
@@ -225,9 +233,19 @@ def validate_config(cfg: AppConfig) -> None:
     if cfg.warmup_frames < 0:
         raise ValueError("runtime.warmup_frames must be >= 0")
     if not 0.0 <= cfg.tracker_iou_threshold <= 1.0:
-        raise ValueError("tracking.iou_threshold must be between 0 and 1")
+        raise ValueError("tracking.match_iou_threshold must be between 0 and 1")
+    if not cfg.min_score <= cfg.tracker_high_score <= 1.0:
+        raise ValueError("tracking.high_score_threshold must be in [inference.min_score, 1]")
+    if not cfg.tracker_high_score <= cfg.tracker_new_track_score <= 1.0:
+        raise ValueError("tracking.new_track_threshold must be in [high_score_threshold, 1]")
+    if not math.isfinite(cfg.tracker_max_center_distance) or cfg.tracker_max_center_distance < 0.0:
+        raise ValueError("tracking.max_center_distance must be >= 0")
+    if not 0.0 <= cfg.tracker_velocity_momentum < 1.0:
+        raise ValueError("tracking.velocity_momentum must be in [0, 1)")
     if cfg.tracker_max_missing < 0:
         raise ValueError("tracking.max_missing_frames must be >= 0")
+    if cfg.tracker_min_confirmed_hits < 1:
+        raise ValueError("tracking.min_confirmed_hits must be >= 1")
     if cfg.video_port_base <= 0:
         raise ValueError("output.insight.video_port_base must be > 0")
     if cfg.metadata_port_base <= 0:
@@ -267,14 +285,24 @@ def load_app_config(config_path: Path) -> AppConfig:
         fps=int_or(inference, "fps", 0),
         max_inflight_per_stream=int_or(inference, "max_inflight_per_stream", 4),
         max_inflight_total=int_or(inference, "max_inflight_total", 16),
-        person_class_id=int_or(inference, "person_class_id", 0),
-        min_score=float_or(inference, "min_score", 0.55),
+        target_class_id=int_or(
+            inference, "target_class_id", int_or(inference, "person_class_id", 0)
+        ),
+        target_label=string_or(inference, "target_label", "person"),
+        min_score=float_or(inference, "min_score", 0.30),
         nms_iou=float_or(inference, "nms_iou", 0.60),
         max_detections=int_or(inference, "max_detections", 50),
         profile=bool_or(runtime, "profile", False),
         warmup_frames=int_or(runtime, "warmup_frames", 30),
-        tracker_iou_threshold=float_or(tracking, "iou_threshold", 0.3),
+        tracker_high_score=float_or(tracking, "high_score_threshold", 0.30),
+        tracker_new_track_score=float_or(tracking, "new_track_threshold", 0.30),
+        tracker_iou_threshold=float_or(
+            tracking, "match_iou_threshold", float_or(tracking, "iou_threshold", 0.10)
+        ),
+        tracker_max_center_distance=float_or(tracking, "max_center_distance", 2.5),
+        tracker_velocity_momentum=float_or(tracking, "velocity_momentum", 0.80),
         tracker_max_missing=int_or(tracking, "max_missing_frames", 15),
+        tracker_min_confirmed_hits=int_or(tracking, "min_confirmed_hits", 1),
         insight_host=string_or(insight, "host"),
         video_port_base=int_or(insight, "video_port_base", 9000),
         metadata_port_base=int_or(insight, "metadata_port_base", 9100),
@@ -348,12 +376,12 @@ def parse_boxes_strict(payload: bytes, img_w: int, img_h: int, expected_topk: in
     return boxes
 
 
-def filter_people(boxes: list[dict], person_class_id: int) -> list[dict]:
-    return [box for box in boxes if int(box["class_id"]) == person_class_id]
+def filter_target_class(boxes: list[dict], target_class_id: int) -> list[dict]:
+    return [box for box in boxes if int(box["class_id"]) == target_class_id]
 
 
 def build_metadata_tracks(
-    tracks: list[TrackedDetection], frame_w: int, frame_h: int
+    tracks: list[TrackedDetection], frame_w: int, frame_h: int, target_label: str
 ) -> list[dict]:
     metadata_tracks = []
     for track in tracks:
@@ -368,7 +396,7 @@ def build_metadata_tracks(
         metadata_tracks.append(
             {
                 "id": str(track.track_id),
-                "label": "person",
+                "label": target_label,
                 "confidence": float(track.score),
                 "bbox": [float(x), float(y), float(max(0, w)), float(max(0, h))],
             }
@@ -616,7 +644,17 @@ def build_stream_runtime(cfg: AppConfig, stream_index: int, url: str) -> StreamR
         url=url,
         source_options=source_options,
         metadata_sender=metadata_sender,
-        tracker=PeopleTracker(cfg.tracker_iou_threshold, cfg.tracker_max_missing),
+        tracker=ObjectTracker(
+            TrackerConfig(
+                high_score_threshold=cfg.tracker_high_score,
+                new_track_threshold=cfg.tracker_new_track_score,
+                match_iou_threshold=cfg.tracker_iou_threshold,
+                max_center_distance=cfg.tracker_max_center_distance,
+                velocity_momentum=cfg.tracker_velocity_momentum,
+                max_missing_frames=cfg.tracker_max_missing,
+                min_confirmed_hits=cfg.tracker_min_confirmed_hits,
+            )
+        ),
         profile=ProfileWindow(cfg.profile, stream_index),
         latest_debug_frame=None,
         frame_w=frame_w,
@@ -670,8 +708,12 @@ def connect_stream_graph(
         )
 
 
-def send_metadata(stream: StreamRuntime, sample, tracks: list[TrackedDetection]) -> None:
-    metadata_tracks = build_metadata_tracks(tracks, stream.frame_w, stream.frame_h)
+def send_metadata(
+    stream: StreamRuntime, cfg: AppConfig, sample, tracks: list[TrackedDetection]
+) -> None:
+    metadata_tracks = build_metadata_tracks(
+        tracks, stream.frame_w, stream.frame_h, cfg.target_label
+    )
     timestamp_ms = int(sample.pts_ns // 1_000_000) if sample.pts_ns >= 0 else -1
     frame_id = str(sample.frame_id) if sample.frame_id >= 0 else ""
     stream.metadata_sender.send_metadata(
@@ -773,16 +815,16 @@ def process_output_sample(stream: StreamRuntime, cfg: AppConfig, sample, detecti
 
     payload = extract_bbox_payload(sample)
     boxes = parse_boxes_strict(payload, stream.frame_w, stream.frame_h, cfg.max_detections)
-    people = filter_people(boxes, cfg.person_class_id)
+    target_detections = filter_target_class(boxes, cfg.target_class_id)
     tracker_start = time_ms()
-    tracks = stream.tracker.update(people, stream.processed)
+    tracks = stream.tracker.update(target_detections, stream.processed)
     tracker_end = time_ms()
 
     stream.processed += 1
     warming_up = stream.processed <= cfg.warmup_frames
     if not warming_up:
         metadata_start = time_ms()
-        send_metadata(stream, sample, tracks)
+        send_metadata(stream, cfg, sample, tracks)
         metadata_end = time_ms()
         if save_frames_enabled(cfg):
             maybe_save_debug_frame(cfg, stream, stream.latest_debug_frame, tracks)

--- a/examples/tracking/multi-stream-people-tracker/src/python/utils/tracker.py
+++ b/examples/tracking/multi-stream-people-tracker/src/python/utils/tracker.py
@@ -1,22 +1,47 @@
-"""Lightweight per-stream people tracker for the Python multi-camera example."""
+"""Two-stage, motion-aware tracking for small object detections."""
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
+BBox = tuple[float, float, float, float]
 
-def _iou_xyxy(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> float:
+
+def _width(box: BBox) -> float:
+    return max(0.0, box[2] - box[0])
+
+
+def _height(box: BBox) -> float:
+    return max(0.0, box[3] - box[1])
+
+
+def _center(box: BBox) -> tuple[float, float]:
+    return 0.5 * (box[0] + box[2]), 0.5 * (box[1] + box[3])
+
+
+def _iou_xyxy(a: BBox, b: BBox) -> float:
     xx1 = max(a[0], b[0])
     yy1 = max(a[1], b[1])
     xx2 = min(a[2], b[2])
     yy2 = min(a[3], b[3])
-    width = max(0.0, xx2 - xx1)
-    height = max(0.0, yy2 - yy1)
-    inter = width * height
-    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
-    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
-    denom = area_a + area_b - inter
-    return inter / denom if denom > 0 else 0.0
+    intersection = max(0.0, xx2 - xx1) * max(0.0, yy2 - yy1)
+    union_area = _width(a) * _height(a) + _width(b) * _height(b) - intersection
+    return intersection / union_area if union_area > 0 else 0.0
+
+
+def _normalized_center_distance(a: BBox, b: BBox) -> float:
+    ax, ay = _center(a)
+    bx, by = _center(b)
+    scale = max(
+        1.0,
+        0.5
+        * (
+            math.hypot(_width(a), _height(a))
+            + math.hypot(_width(b), _height(b))
+        ),
+    )
+    return math.hypot(ax - bx, ay - by) / scale
 
 
 @dataclass(frozen=True)
@@ -30,109 +55,229 @@ class TrackedDetection:
     class_id: int
 
 
+@dataclass(frozen=True)
+class TrackerConfig:
+    high_score_threshold: float = 0.30
+    new_track_threshold: float = 0.30
+    match_iou_threshold: float = 0.10
+    max_center_distance: float = 2.5
+    velocity_momentum: float = 0.80
+    max_missing_frames: int = 15
+    min_confirmed_hits: int = 1
+
+    def validate(self) -> None:
+        if not 0.0 <= self.high_score_threshold <= 1.0:
+            raise ValueError("high_score_threshold must be in [0, 1]")
+        if not self.high_score_threshold <= self.new_track_threshold <= 1.0:
+            raise ValueError("new_track_threshold must be in [high_score_threshold, 1]")
+        if not 0.0 <= self.match_iou_threshold <= 1.0:
+            raise ValueError("match_iou_threshold must be in [0, 1]")
+        if not math.isfinite(self.max_center_distance) or self.max_center_distance < 0.0:
+            raise ValueError("max_center_distance must be >= 0")
+        if not 0.0 <= self.velocity_momentum < 1.0:
+            raise ValueError("velocity_momentum must be in [0, 1)")
+        if self.max_missing_frames < 0:
+            raise ValueError("max_missing_frames must be >= 0")
+        if self.min_confirmed_hits < 1:
+            raise ValueError("min_confirmed_hits must be >= 1")
+
+
 @dataclass
 class TrackState:
     track_id: int
-    bbox: tuple[float, float, float, float]
+    bbox: BBox
     score: float
     class_id: int
     last_frame_index: int
+    velocity: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
     missing_frames: int = 0
+    hits: int = 1
+
+    def predict(self, frame_index: int) -> BBox:
+        elapsed = max(0, frame_index - self.last_frame_index)
+        center_x, center_y = _center(self.bbox)
+        vx, vy, vw, vh = self.velocity
+        center_x += vx * elapsed
+        center_y += vy * elapsed
+        width = max(1.0, _width(self.bbox) + vw * elapsed)
+        height = max(1.0, _height(self.bbox) + vh * elapsed)
+        return (
+            center_x - width * 0.5,
+            center_y - height * 0.5,
+            center_x + width * 0.5,
+            center_y + height * 0.5,
+        )
 
 
-class PeopleTracker:
-    """Greedy IoU tracker intended for the example's person-only detections."""
+class ObjectTracker:
+    """Track tiny boxes with two-score association and constant-velocity prediction."""
 
-    def __init__(self, iou_threshold: float = 0.3, max_missing_frames: int = 2) -> None:
-        self.iou_threshold = float(iou_threshold)
-        self.max_missing_frames = int(max_missing_frames)
+    def __init__(self, config: TrackerConfig | None = None) -> None:
+        self.config = config or TrackerConfig()
+        self.config.validate()
         self._next_track_id = 1
         self._tracks: dict[int, TrackState] = {}
+        self._last_frame_index = -1
 
     def active_track_count(self) -> int:
         return len(self._tracks)
 
-    def update(self, detections: list[dict], frame_index: int) -> list[TrackedDetection]:
-        det_boxes = [
-            (
-                float(det["x1"]),
-                float(det["y1"]),
-                float(det["x2"]),
-                float(det["y2"]),
-            )
-            for det in detections
-        ]
-
+    def _associate(
+        self,
+        detections: list[dict],
+        detection_indices: list[int],
+        frame_index: int,
+        matched_tracks: set[int],
+        matched_detections: set[int],
+        assignments: dict[int, int],
+    ) -> None:
         candidates: list[tuple[float, int, int]] = []
-        track_ids = list(self._tracks.keys())
-        for track_id in track_ids:
-            track = self._tracks[track_id]
-            for det_index, bbox in enumerate(det_boxes):
-                if int(detections[det_index]["class_id"]) != track.class_id:
+        for track_id, track in self._tracks.items():
+            if track_id in matched_tracks:
+                continue
+            predicted = track.predict(frame_index)
+            for detection_index in detection_indices:
+                if detection_index in matched_detections:
                     continue
-                iou = _iou_xyxy(track.bbox, bbox)
-                if iou >= self.iou_threshold:
-                    candidates.append((iou, track_id, det_index))
-        candidates.sort(reverse=True)
+                detection = detections[detection_index]
+                if int(detection["class_id"]) != track.class_id:
+                    continue
+                bbox = _bbox(detection)
+                iou = _iou_xyxy(predicted, bbox)
+                center_distance = _normalized_center_distance(predicted, bbox)
+                if (
+                    iou < self.config.match_iou_threshold
+                    and center_distance > self.config.max_center_distance
+                ):
+                    continue
+                affinity = iou + 1.0 / (1.0 + center_distance)
+                candidates.append((affinity, track_id, detection_index))
 
-        matched_tracks: set[int] = set()
-        matched_dets: set[int] = set()
-        assignments: dict[int, int] = {}
-        for _, track_id, det_index in candidates:
-            if track_id in matched_tracks or det_index in matched_dets:
+        candidates.sort(reverse=True)
+        for _affinity, track_id, detection_index in candidates:
+            if track_id in matched_tracks or detection_index in matched_detections:
                 continue
             matched_tracks.add(track_id)
-            matched_dets.add(det_index)
-            assignments[det_index] = track_id
+            matched_detections.add(detection_index)
+            assignments[detection_index] = track_id
 
-        for det_index, track_id in assignments.items():
-            det = detections[det_index]
-            self._tracks[track_id] = TrackState(
-                track_id=track_id,
-                bbox=det_boxes[det_index],
-                score=float(det["score"]),
-                class_id=int(det["class_id"]),
-                last_frame_index=frame_index,
-                missing_frames=0,
+    def update(self, detections: list[dict], frame_index: int) -> list[TrackedDetection]:
+        if frame_index < 0:
+            raise ValueError("frame_index must be >= 0")
+        if frame_index < self._last_frame_index:
+            raise ValueError("frame_index must be monotonic")
+        self._last_frame_index = frame_index
+
+        self._tracks = {
+            track_id: track
+            for track_id, track in self._tracks.items()
+            if frame_index - track.last_frame_index <= self.config.max_missing_frames
+        }
+
+        high = [
+            index
+            for index, detection in enumerate(detections)
+            if float(detection["score"]) >= self.config.high_score_threshold
+        ]
+        low = [index for index in range(len(detections)) if index not in high]
+        matched_tracks: set[int] = set()
+        matched_detections: set[int] = set()
+        assignments: dict[int, int] = {}
+
+        self._associate(
+            detections,
+            high,
+            frame_index,
+            matched_tracks,
+            matched_detections,
+            assignments,
+        )
+        self._associate(
+            detections,
+            low,
+            frame_index,
+            matched_tracks,
+            matched_detections,
+            assignments,
+        )
+
+        for detection_index, track_id in assignments.items():
+            detection = detections[detection_index]
+            bbox = _bbox(detection)
+            track = self._tracks[track_id]
+            elapsed = max(1, frame_index - track.last_frame_index)
+            old_x, old_y = _center(track.bbox)
+            new_x, new_y = _center(bbox)
+            measured = (
+                (new_x - old_x) / elapsed,
+                (new_y - old_y) / elapsed,
+                (_width(bbox) - _width(track.bbox)) / elapsed,
+                (_height(bbox) - _height(track.bbox)) / elapsed,
             )
+            momentum = self.config.velocity_momentum
+            track.velocity = tuple(
+                momentum * previous + (1.0 - momentum) * current
+                for previous, current in zip(track.velocity, measured)
+            )
+            track.bbox = bbox
+            track.score = float(detection["score"])
+            track.last_frame_index = frame_index
+            track.missing_frames = 0
+            track.hits += 1
 
-        for det_index, det in enumerate(detections):
-            if det_index in matched_dets:
+        for detection_index in high:
+            if detection_index in matched_detections:
+                continue
+            detection = detections[detection_index]
+            if float(detection["score"]) < self.config.new_track_threshold:
                 continue
             track_id = self._next_track_id
             self._next_track_id += 1
             self._tracks[track_id] = TrackState(
                 track_id=track_id,
-                bbox=det_boxes[det_index],
-                score=float(det["score"]),
-                class_id=int(det["class_id"]),
+                bbox=_bbox(detection),
+                score=float(detection["score"]),
+                class_id=int(detection["class_id"]),
                 last_frame_index=frame_index,
-                missing_frames=0,
             )
-            assignments[det_index] = track_id
+            matched_tracks.add(track_id)
+            matched_detections.add(detection_index)
+            assignments[detection_index] = track_id
 
-        expired: list[int] = []
-        for track_id, track in self._tracks.items():
-            if track_id in matched_tracks or track_id in assignments.values():
+        for track_id, track in list(self._tracks.items()):
+            if track_id in matched_tracks:
                 continue
-            track.missing_frames += 1
-            if track.missing_frames > self.max_missing_frames:
-                expired.append(track_id)
-        for track_id in expired:
-            self._tracks.pop(track_id, None)
+            track.missing_frames = frame_index - track.last_frame_index
+            if track.missing_frames > self.config.max_missing_frames:
+                del self._tracks[track_id]
 
         tracked: list[TrackedDetection] = []
-        for det_index, det in enumerate(detections):
-            track_id = assignments[det_index]
+        for detection_index, detection in enumerate(detections):
+            track_id = assignments.get(detection_index)
+            if track_id is None:
+                continue
+            track = self._tracks[track_id]
+            if track.hits < self.config.min_confirmed_hits:
+                continue
+            bbox = _bbox(detection)
             tracked.append(
                 TrackedDetection(
                     track_id=track_id,
-                    x1=det_boxes[det_index][0],
-                    y1=det_boxes[det_index][1],
-                    x2=det_boxes[det_index][2],
-                    y2=det_boxes[det_index][3],
-                    score=float(det["score"]),
-                    class_id=int(det["class_id"]),
+                    x1=bbox[0],
+                    y1=bbox[1],
+                    x2=bbox[2],
+                    y2=bbox[3],
+                    score=float(detection["score"]),
+                    class_id=int(detection["class_id"]),
                 )
             )
         return tracked
+
+
+def _bbox(detection: dict) -> BBox:
+    return (
+        float(detection["x1"]),
+        float(detection["y1"]),
+        float(detection["x2"]),
+        float(detection["y2"]),
+    )

--- a/examples/tracking/multi-stream-people-tracker/tests/cpp/test_unit.cpp
+++ b/examples/tracking/multi-stream-people-tracker/tests/cpp/test_unit.cpp
@@ -4,12 +4,15 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
 #include <string>
 
 namespace fs = std::filesystem;
 
 using multi_stream_people_tracker::Detection;
-using multi_stream_people_tracker::PeopleTracker;
+using multi_stream_people_tracker::ObjectTracker;
+using multi_stream_people_tracker::TrackerConfig;
 using sima_examples::testing::create_test_scratch_dir;
 using sima_examples::testing::remove_dir;
 using sima_examples::testing::spawn_and_wait;
@@ -131,7 +134,7 @@ bool test_validate_config_only_rejects_invalid_inflight_limit(const std::string&
 }
 
 bool test_tracker_reuses_track_id_for_nearby_detection() {
-  PeopleTracker tracker(0.3f, 2);
+  ObjectTracker tracker;
   const auto first = tracker.update({Detection{10.0f, 10.0f, 50.0f, 80.0f, 0.9f, 0}}, 0);
   const auto second = tracker.update({Detection{12.0f, 11.0f, 52.0f, 81.0f, 0.8f, 0}}, 1);
   return expect_true(first.size() == 1, "tracker returns one detection on first frame") &&
@@ -141,12 +144,89 @@ bool test_tracker_reuses_track_id_for_nearby_detection() {
 }
 
 bool test_tracker_drops_track_after_missing_budget() {
-  PeopleTracker tracker(0.3f, 1);
+  TrackerConfig config;
+  config.max_missing_frames = 1;
+  ObjectTracker tracker(config);
   tracker.update({Detection{10.0f, 10.0f, 50.0f, 80.0f, 0.9f, 0}}, 0);
   tracker.update({}, 1);
   tracker.update({}, 2);
   return expect_true(tracker.active_track_count() == 0,
                      "tracker expires track after missing frame budget");
+}
+
+bool test_tracker_matches_tiny_non_overlapping_boxes_by_motion() {
+  TrackerConfig config;
+  config.match_iou_threshold = 0.5f;
+  config.max_center_distance = 2.0f;
+  ObjectTracker tracker(config);
+  const auto first = tracker.update({Detection{10.0f, 10.0f, 12.0f, 12.0f, 0.9f, 0}}, 0);
+  const auto second = tracker.update({Detection{13.0f, 10.0f, 15.0f, 12.0f, 0.8f, 0}}, 1);
+  return expect_true(first.size() == 1 && second.size() == 1,
+                     "tiny non-overlapping detections are tracked") &&
+         expect_true(first.front().track_id == second.front().track_id,
+                     "motion gate preserves the tiny-object track id");
+}
+
+bool test_low_score_detection_recovers_but_does_not_create_track() {
+  TrackerConfig config;
+  config.high_score_threshold = 0.5f;
+  config.new_track_threshold = 0.7f;
+  ObjectTracker established(config);
+  const auto first = established.update({Detection{10.0f, 10.0f, 14.0f, 14.0f, 0.9f, 0}}, 0);
+  const auto recovered = established.update({Detection{11.0f, 10.0f, 15.0f, 14.0f, 0.2f, 0}}, 1);
+
+  ObjectTracker fresh(config);
+  const auto low_only = fresh.update({Detection{10.0f, 10.0f, 14.0f, 14.0f, 0.2f, 0}}, 0);
+  return expect_true(first.size() == 1 && recovered.size() == 1,
+                     "low-score detection recovers an established track") &&
+         expect_true(first.front().track_id == recovered.front().track_id,
+                     "recovered detection retains the track id") &&
+         expect_true(low_only.empty() && fresh.active_track_count() == 0,
+                     "low-score detection cannot create a track");
+}
+
+bool test_tracker_confirmation_suppresses_single_frame_noise() {
+  TrackerConfig config;
+  config.min_confirmed_hits = 2;
+  ObjectTracker tracker(config);
+  const auto first = tracker.update({Detection{10.0f, 10.0f, 14.0f, 14.0f, 0.9f, 0}}, 0);
+  const auto second = tracker.update({Detection{10.5f, 10.0f, 14.5f, 14.0f, 0.8f, 0}}, 1);
+  return expect_true(first.empty(), "unconfirmed one-frame track is not published") &&
+         expect_true(second.size() == 1, "track is published after the configured hit count");
+}
+
+bool test_tracker_does_not_revive_after_missing_budget() {
+  TrackerConfig config;
+  config.max_missing_frames = 1;
+  ObjectTracker tracker(config);
+  const auto first = tracker.update({Detection{10.0f, 10.0f, 14.0f, 14.0f, 0.9f, 0}}, 0);
+  const auto replacement = tracker.update({Detection{11.0f, 10.0f, 15.0f, 14.0f, 0.9f, 0}}, 2);
+  return expect_true(first.size() == 1 && replacement.size() == 1,
+                     "detection after missing budget creates a replacement track") &&
+         expect_true(first.front().track_id != replacement.front().track_id,
+                     "expired track id is not revived");
+}
+
+bool test_tracker_enforces_monotonic_frames_without_active_tracks() {
+  ObjectTracker tracker;
+  tracker.update({}, 5);
+  try {
+    tracker.update({}, 4);
+  } catch (const std::invalid_argument&) {
+    return expect_true(true, "tracker rejects a non-monotonic empty frame");
+  }
+  return expect_true(false, "tracker rejects a non-monotonic empty frame");
+}
+
+bool test_tracker_rejects_non_finite_motion_gate() {
+  TrackerConfig config;
+  config.max_center_distance = std::numeric_limits<float>::quiet_NaN();
+  try {
+    ObjectTracker tracker(config);
+  } catch (const std::invalid_argument&) {
+    return expect_true(true, "tracker rejects a non-finite motion gate");
+  }
+  return expect_true(false, "tracker rejects a non-finite motion gate");
 }
 
 } // namespace
@@ -166,5 +246,11 @@ int main(int argc, char** argv) {
   ok &= test_validate_config_only_rejects_invalid_inflight_limit(binary);
   ok &= test_tracker_reuses_track_id_for_nearby_detection();
   ok &= test_tracker_drops_track_after_missing_budget();
+  ok &= test_tracker_matches_tiny_non_overlapping_boxes_by_motion();
+  ok &= test_low_score_detection_recovers_but_does_not_create_track();
+  ok &= test_tracker_confirmation_suppresses_single_frame_noise();
+  ok &= test_tracker_does_not_revive_after_missing_budget();
+  ok &= test_tracker_enforces_monotonic_frames_without_active_tracks();
+  ok &= test_tracker_rejects_non_finite_motion_gate();
   return ok ? 0 : 1;
 }

--- a/examples/tracking/multi-stream-people-tracker/tests/python/test_unit.py
+++ b/examples/tracking/multi-stream-people-tracker/tests/python/test_unit.py
@@ -2,24 +2,30 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
-from pathlib import Path
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-
 EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
 PYTHON_DIR = EXAMPLE_DIR / "src" / "python"
 MAIN_PY = PYTHON_DIR / "main.py"
+ACCURACY_PATH = PYTHON_DIR / "evaluate_tracking.py"
 
 if str(PYTHON_DIR) not in sys.path:
     sys.path.insert(0, str(PYTHON_DIR))
 
 pytestmark = pytest.mark.unit
+
+ACCURACY_SPEC = importlib.util.spec_from_file_location("evaluate_tracking", ACCURACY_PATH)
+assert ACCURACY_SPEC and ACCURACY_SPEC.loader
+evaluate_tracking = importlib.util.module_from_spec(ACCURACY_SPEC)
+ACCURACY_SPEC.loader.exec_module(evaluate_tracking)
 
 
 def write_config(
@@ -139,6 +145,8 @@ class TestConfigLoading:
         cfg = load_app_config(EXAMPLE_DIR / "src" / "common" / "config.yaml")
 
         assert cfg.min_score == 0.30
+        assert cfg.target_class_id == 0
+        assert cfg.target_label == "person"
 
     def test_load_app_config_rejects_too_many_streams(self, tmp_path: Path):
         from main import load_app_config
@@ -236,8 +244,8 @@ class FakeSample:
 
 class TestMetadata:
     def test_send_metadata_uses_tracking_contract(self):
-        from main import ProfileWindow, StreamRuntime, send_metadata
-        from utils.tracker import PeopleTracker, TrackedDetection
+        from main import AppConfig, ProfileWindow, StreamRuntime, send_metadata
+        from utils.tracker import ObjectTracker, TrackedDetection
 
         sender = FakeMetadataSender()
         runtime = StreamRuntime(
@@ -245,7 +253,7 @@ class TestMetadata:
             url="rtsp://127.0.0.1:8554/src1",
             source_options=None,
             metadata_sender=sender,
-            tracker=PeopleTracker(),
+            tracker=ObjectTracker(),
             profile=ProfileWindow(False, 0),
             latest_debug_frame=None,
             frame_w=100,
@@ -255,7 +263,12 @@ class TestMetadata:
         )
         tracks = [TrackedDetection(7, 10.0, 20.0, 40.0, 60.0, 0.75, 0)]
 
-        send_metadata(runtime, FakeSample(), tracks)
+        cfg = AppConfig(
+            model_path="models/yolo26n-p2-tiny-drone-int8-qat-b1.tar.gz",
+            rtsp_urls=[runtime.url],
+            target_label="drone",
+        )
+        send_metadata(runtime, cfg, FakeSample(), tracks)
 
         assert len(sender.calls) == 1
         metadata_type, data_json, timestamp_ms, frame_id = sender.calls[0]
@@ -266,7 +279,7 @@ class TestMetadata:
             "tracks": [
                 {
                     "id": "7",
-                    "label": "person",
+                    "label": "drone",
                     "confidence": 0.75,
                     "bbox": [10.0, 20.0, 30.0, 40.0],
                 }
@@ -276,9 +289,9 @@ class TestMetadata:
 
 class TestTracker:
     def test_tracker_reuses_track_id_for_nearby_detection(self):
-        from utils.tracker import PeopleTracker
+        from utils.tracker import ObjectTracker
 
-        tracker = PeopleTracker(iou_threshold=0.3, max_missing_frames=2)
+        tracker = ObjectTracker()
         first = tracker.update(
             [{"x1": 10.0, "y1": 10.0, "x2": 50.0, "y2": 80.0, "score": 0.9, "class_id": 0}],
             frame_index=0,
@@ -293,9 +306,9 @@ class TestTracker:
         assert first[0].track_id == second[0].track_id
 
     def test_tracker_drops_track_after_missing_budget(self):
-        from utils.tracker import PeopleTracker
+        from utils.tracker import ObjectTracker, TrackerConfig
 
-        tracker = PeopleTracker(iou_threshold=0.3, max_missing_frames=1)
+        tracker = ObjectTracker(TrackerConfig(max_missing_frames=1))
         tracker.update(
             [{"x1": 10.0, "y1": 10.0, "x2": 50.0, "y2": 80.0, "score": 0.9, "class_id": 0}],
             frame_index=0,
@@ -304,3 +317,183 @@ class TestTracker:
         tracker.update([], frame_index=2)
 
         assert tracker.active_track_count() == 0
+
+    def test_tracker_matches_tiny_boxes_after_zero_iou_shift(self):
+        from utils.tracker import ObjectTracker, TrackerConfig
+
+        tracker = ObjectTracker(
+            TrackerConfig(match_iou_threshold=0.5, max_center_distance=2.0)
+        )
+        first = tracker.update(
+            [{"x1": 10, "y1": 10, "x2": 12, "y2": 12, "score": 0.9, "class_id": 0}],
+            frame_index=0,
+        )
+        second = tracker.update(
+            [{"x1": 13, "y1": 10, "x2": 15, "y2": 12, "score": 0.8, "class_id": 0}],
+            frame_index=1,
+        )
+
+        assert len(first) == len(second) == 1
+        assert first[0].track_id == second[0].track_id
+
+    def test_low_score_detection_recovers_but_cannot_create_track(self):
+        from utils.tracker import ObjectTracker, TrackerConfig
+
+        config = TrackerConfig(high_score_threshold=0.5, new_track_threshold=0.7)
+        established = ObjectTracker(config)
+        first = established.update(
+            [{"x1": 10, "y1": 10, "x2": 14, "y2": 14, "score": 0.9, "class_id": 0}],
+            frame_index=0,
+        )
+        recovered = established.update(
+            [{"x1": 11, "y1": 10, "x2": 15, "y2": 14, "score": 0.2, "class_id": 0}],
+            frame_index=1,
+        )
+
+        fresh = ObjectTracker(config)
+        low_only = fresh.update(
+            [{"x1": 10, "y1": 10, "x2": 14, "y2": 14, "score": 0.2, "class_id": 0}],
+            frame_index=0,
+        )
+
+        assert len(first) == len(recovered) == 1
+        assert first[0].track_id == recovered[0].track_id
+        assert low_only == []
+        assert fresh.active_track_count() == 0
+
+    def test_confirmation_suppresses_single_frame_noise(self):
+        from utils.tracker import ObjectTracker, TrackerConfig
+
+        tracker = ObjectTracker(TrackerConfig(min_confirmed_hits=2))
+        first = tracker.update(
+            [{"x1": 10, "y1": 10, "x2": 14, "y2": 14, "score": 0.9, "class_id": 0}],
+            frame_index=0,
+        )
+        second = tracker.update(
+            [{"x1": 10.5, "y1": 10, "x2": 14.5, "y2": 14, "score": 0.8, "class_id": 0}],
+            frame_index=1,
+        )
+
+        assert first == []
+        assert len(second) == 1
+
+    def test_tracker_does_not_revive_after_missing_budget(self):
+        from utils.tracker import ObjectTracker, TrackerConfig
+
+        tracker = ObjectTracker(TrackerConfig(max_missing_frames=1))
+        first = tracker.update(
+            [{"x1": 10, "y1": 10, "x2": 14, "y2": 14, "score": 0.9, "class_id": 0}],
+            frame_index=0,
+        )
+        replacement = tracker.update(
+            [{"x1": 11, "y1": 10, "x2": 15, "y2": 14, "score": 0.9, "class_id": 0}],
+            frame_index=2,
+        )
+
+        assert first[0].track_id != replacement[0].track_id
+
+    def test_tracker_enforces_monotonic_frames_without_active_tracks(self):
+        from utils.tracker import ObjectTracker
+
+        tracker = ObjectTracker()
+        tracker.update([], frame_index=5)
+        with pytest.raises(ValueError, match="monotonic"):
+            tracker.update([], frame_index=4)
+
+    def test_tracker_rejects_non_finite_motion_gate(self):
+        from utils.tracker import ObjectTracker, TrackerConfig
+
+        with pytest.raises(ValueError, match="max_center_distance"):
+            ObjectTracker(TrackerConfig(max_center_distance=float("nan")))
+
+
+class TestAccuracyEvaluation:
+    def test_metrics_count_recall_false_positives_and_id_switches(self):
+        truth = {
+            0: {
+                "frame_index": 0,
+                "width": 1920,
+                "height": 1080,
+                "objects": [{"track_id": "d1", "bbox": [10, 10, 12, 8]}],
+            },
+            1: {
+                "frame_index": 1,
+                "width": 1920,
+                "height": 1080,
+                "objects": [{"track_id": "d1", "bbox": [12, 10, 12, 8]}],
+            },
+            2: {
+                "frame_index": 2,
+                "width": 1920,
+                "height": 1080,
+                "objects": [{"track_id": "d1", "bbox": [14, 10, 12, 8]}],
+            },
+        }
+        predictions = {
+            0: {"frame_index": 0, "tracks": [{"id": "1", "bbox": [10, 10, 12, 8]}]},
+            1: {
+                "frame_index": 1,
+                "tracks": [{"id": "noise", "bbox": [100, 100, 10, 10]}],
+            },
+            2: {"frame_index": 2, "tracks": [{"id": "2", "bbox": [14, 10, 12, 8]}]},
+        }
+
+        report = evaluate_tracking.evaluate(
+            truth, predictions, iou_threshold=0.3, fps=30.0, model_size=640
+        )
+
+        assert report["detection"]["true_positives"] == 2
+        assert report["detection"]["false_positives"] == 1
+        assert report["detection"]["false_negatives"] == 1
+        assert report["detection"]["recall"] == pytest.approx(2 / 3)
+        assert report["tracking"]["id_switches"] == 1
+        assert report["tracking"]["fragmentations"] == 1
+        assert (
+            report["detection"]["recall_by_model_input_size"]["tiny"]["ground_truth"]
+            == 3
+        )
+
+    def test_greedy_matching_is_one_to_one(self):
+        truth = [{"bbox": [0, 0, 10, 10]}, {"bbox": [1, 1, 10, 10]}]
+        predictions = [{"bbox": [0, 0, 10, 10]}]
+
+        matches = evaluate_tracking.greedy_matches(truth, predictions, 0.3)
+
+        assert len(matches) == 1
+
+    def test_reader_accepts_insight_metadata_envelope(self, tmp_path: Path):
+        path = tmp_path / "predictions.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "tracking",
+                    "frame_id": "42",
+                    "timestamp": 1000,
+                    "data": {"tracks": [{"id": "7", "bbox": [1, 2, 3, 4]}]},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        frames = evaluate_tracking.read_jsonl(path, "tracks")
+
+        assert frames[42]["tracks"][0]["id"] == "7"
+
+    def test_reader_accepts_json_encoded_insight_data(self, tmp_path: Path):
+        path = tmp_path / "predictions.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "tracking",
+                    "frame_id": 7,
+                    "data": json.dumps({"tracks": [{"id": "2", "bbox": [1, 2, 3, 4]}]}),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        frames = evaluate_tracking.read_jsonl(path, "tracks")
+
+        assert frames[7]["tracks"][0]["id"] == "2"


### PR DESCRIPTION
Refs sima-neat/models#28

## Summary

- generalize the existing multi-stream people tracker to a configurable target class while preserving the current people defaults and legacy config aliases
- add a YOLO26n-P2 one-class tiny-drone profile with a low decoder floor, two-stage score association, confirmation, track expiry, and constant-velocity/normalized-center matching for tiny zero-IoU frame-to-frame motion
- keep input width, height, normalization, letterboxing, and output-derived strides in Neat model preprocessing/`YoloV26`, consistent with the existing YOLO app
- add per-stream Insight metadata labels and a JSONL/Insight-envelope evaluator for recall, tiny recall, false positives/minute, ID switches, and fragmentation gates

The profile expects the qualified asset produced by sima-neat/models#27. It does not publish or claim a trained drone model in this PR.

## Validation

- Python unit suite: 23 passed
- C++ aarch64 cross-build: passed
- changed C++ files: clang-format passed
- README, CMake style, include hygiene, conflict, artifact, and catalog generation checks: passed
- Modalix 1.246 board unit suite: passed
- ModelSDK structural smoke MPK loaded successfully on the 1.246 board through Neat; the run then stopped at the deliberately absent RTSP source

The only aggregate local `check_all.sh` failure is environmental: the host has no `clang-format` executable. The same four changed C++ files pass with the SDK container's clang-format 18. The repository also has an unchanged YOLO26 detector file that is not clang-format-18-clean, so this PR does not rewrite it.
