### PR TITLE
feat(high-density): raise default profile to 30 FPS

### DIFF
--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -34,7 +34,7 @@ The three checked-in profiles use the same application and model:
 
 | Config | Streams | Source resolution and FPS | Expected FPS per channel |
 | --- | ---: | --- | ---: |
-| `config.yaml` | 16 | 1280×720 at 25 FPS | 25 FPS |
+| `config.yaml` | 16 | 1280×720 at 30 FPS | 30 FPS |
 | `config-24x720p20fps.yaml` | 24 | 1280×720 at 20 FPS | 20 FPS |
 | `config-48x720p10fps.yaml` | 48 | 1280×720 at 10 FPS | 10 FPS |
 
@@ -172,7 +172,7 @@ Use one active Insight viewer while validating metadata. Insight currently has a
 
 - Every configured Insight channel receives live video.
 - Detection boxes appear on the matching channel.
-- Video and metadata advance at 25 FPS for 16 streams, 20 FPS for 24 streams, or 10 FPS for 48 streams.
+- Video and metadata advance at 30 FPS for 16 streams, 20 FPS for 24 streams, or 10 FPS for 48 streams.
 - Final per-stream counters show every stream advancing; the application fails with the missing channel IDs if a stream never starts or later stops.
 - No detection timeout or stalled channel is reported. Metadata sender counters expose any nonblocking UDP drops without stalling inference.
 

--- a/examples/object-detection/high-density-multi-stream-object-detector/src/common/config.yaml
+++ b/examples/object-detection/high-density-multi-stream-object-detector/src/common/config.yaml
@@ -1,4 +1,4 @@
-# Default profile: 16 x 720p @ 25 FPS.
+# Default profile: 16 x 720p @ 30 FPS.
 # Relative model paths use this file; label paths use the Apps root.
 model:
   path: <model-path>
@@ -31,7 +31,7 @@ input:
   skip_rtsp_probe: true
   width: 1280
   height: 720
-  fps: 25
+  fps: 30
   decoder_buffers: 8
   decoder_input_buffers: 2
   decoder_tuning: throughput-low-latency

--- a/examples/object-detection/high-density-multi-stream-object-detector/tests/cpp/test_unit.cpp
+++ b/examples/object-detection/high-density-multi-stream-object-detector/tests/cpp/test_unit.cpp
@@ -238,7 +238,7 @@ bool test_validate_config_only_accepts_named_profiles(const std::string& binary)
   };
 
   constexpr std::array<ProfileExpectation, 3> profiles{{
-      {"config.yaml", 16, 25, 16, 1, 1, 8},
+      {"config.yaml", 16, 30, 16, 1, 1, 8},
       {"config-24x720p20fps.yaml", 24, 20, 4, 2, 4, 24},
       {"config-48x720p10fps.yaml", 48, 10, 1, 2, 1, 8},
   }};

--- a/examples/object-detection/high-density-multi-stream-object-detector/tests/python/test_unit.py
+++ b/examples/object-detection/high-density-multi-stream-object-detector/tests/python/test_unit.py
@@ -116,7 +116,7 @@ class TestConfigLoading:
             "max_inflight_total",
         ),
         [
-            ("config.yaml", 16, 25, 8, 2, "throughput-low-latency", 16, 1, 1, 8),
+            ("config.yaml", 16, 30, 8, 2, "throughput-low-latency", 16, 1, 1, 8),
             (
                 "config-24x720p20fps.yaml",
                 24,
@@ -184,10 +184,10 @@ class TestConfigLoading:
         assert not Path(raw["model"]["path"]).is_absolute()
         assert not Path(raw["model"]["labels"]).is_absolute()
 
-    def test_default_config_is_the_16x25_profile(self):
+    def test_default_config_is_the_16x30_profile(self):
         default = yaml.safe_load((COMMON_DIR / "config.yaml").read_text(encoding="utf-8"))
         assert len(default["streams"]) == 16
-        assert default["input"]["fps"] == 25
+        assert default["input"]["fps"] == 30
 
     def test_config_rejects_overlapping_insight_port_ranges(self, tmp_path: Path):
         from main import load_app_config


### PR DESCRIPTION
## What Changed

The high-density multi-stream object detector's default 16-stream profile now runs at 30 FPS instead of 25 FPS. 16 × 720p at 30 FPS is validated on Modalix with Insight, so the checked-in default now matches what the tuned pipeline actually delivers.

This was more than a documentation gap. `input.skip_rtsp_probe: true` makes the config the source contract, so pointing 30 FPS publishers at the checked-in `config.yaml` was a caps mismatch rather than a supported setup — users had to know to edit `input.fps` themselves.

## Profiles

| Config | Streams | Source resolution and FPS | Expected FPS per channel |
| --- | ---: | --- | ---: |
| `config.yaml` | 16 | 1280×720 at 30 FPS | 30 FPS (was 25) |
| `config-24x720p20fps.yaml` | 24 | 1280×720 at 20 FPS | 20 FPS (unchanged) |
| `config-48x720p10fps.yaml` | 48 | 1280×720 at 10 FPS | 10 FPS (unchanged) |

## Scope

`input.fps` is the only setting that changes. The decoder pools (`decoder_buffers: 8`, `decoder_input_buffers: 2`, `decoder_tuning: throughput-low-latency`) and detector credits (`queue_depth: 16`, `internal_queue_depth: 1`, `max_inflight_per_stream: 1`, `max_inflight_total: 8`) carry over unchanged from the validated run.

The diff is 8 lines across four files: the config header comment and `input.fps`, the README profile table and Expected Result line, the C++ named-profile expectation table, and the Python parametrized case plus the `16x25` → `16x30` default-profile test rename.

## Validation

- The in-process C++ unit tests (metadata single-pass, watchdog cadence) pass in the Neat SDK.
- `clang-format` is clean on `tests/cpp/test_unit.cpp`.
- Config values were checked directly against both test tables: `config.yaml` is 16 streams at `fps: 30` with `queue_depth: 16`, `internal_queue_depth: 1`, `max_inflight_per_stream: 1`, `max_inflight_total: 8`, matching the updated C++ and Python expectations.

Not run locally: the spawn-based C++ tests and the Python suite. The Neat SDK container has `libsima_neat.so.4` while `develop` needs `.so.5`, and `./build.sh --only-install-neat-core` fails because the `develop-latest` Core artifact returns 404. This blocks every test that spawns the application binary, independent of this change. CI covers them.

Closes #420
