### PR TITLE
perf(multimodal-assistant): Stream Piper TTS for faster first audio

### DIFF
--- a/examples/genai/multimodal-assistant/README.md
+++ b/examples/genai/multimodal-assistant/README.md
@@ -258,6 +258,20 @@ What is the canonical RAG validation phrase?
 
 The RAG status area should report whether RAG was used and how many hits were retrieved.
 
+## Text to Speech
+`./setup.sh` downloads the Piper voices listed in `src/python/voice_install.sh` and splits
+each into an encoder/decoder pair, which lets playback start before a sentence finishes
+synthesizing. To turn that off, edit `config.local.yaml`:
+
+```yaml
+app:
+  tts:
+    streaming: true
+```
+
+Voices without a pair, including multi-speaker ones that cannot be split, are spoken a
+whole sentence at a time. `SPLIT_VOICES=0 ./setup.sh` skips splitting.
+
 ## Verify
 Use these checks after the model server and Flask UI are running.
 

--- a/examples/genai/multimodal-assistant/setup.sh
+++ b/examples/genai/multimodal-assistant/setup.sh
@@ -12,6 +12,7 @@ ASR_MODEL_REPO="simaai/whisper-small-a16w8"
 RAG_EMBEDDING_REPO="thenlper/gte-small"
 CHAT_MODEL_NAME="${CHAT_MODEL_NAME:-$(basename "${CHAT_MODEL_REPO}")}"
 INSTALL_TTS_VOICES="${INSTALL_TTS_VOICES:-1}"
+SPLIT_VOICES="${SPLIT_VOICES:-1}"
 SKIP_MODEL_DOWNLOAD="${SKIP_MODEL_DOWNLOAD:-0}"
 CPU_TORCH_VERSION="${CPU_TORCH_VERSION:-2.8.0+cpu}"
 
@@ -31,7 +32,9 @@ Environment:
                                 default: /media/nvme/llima/models
   CHAT_MODEL_REPO               Hugging Face repo for the default chat/VLM model
                                 default: simaai/Qwen3-VL-4B-Instruct-GPTQ-a16w4
-  INSTALL_TTS_VOICES            Download and split Piper TTS voices, 1 or 0
+  INSTALL_TTS_VOICES            Download Piper TTS voices, 1 or 0
+                                default: 1
+  SPLIT_VOICES                  Split voices for streaming synthesis, 1 or 0
                                 default: 1
   CPU_TORCH_VERSION             CPU-only PyTorch version for RAG installs
                                 default: 2.8.0+cpu
@@ -128,6 +131,9 @@ else
   echo "Skipping model downloads because SKIP_MODEL_DOWNLOAD=1."
 fi
 
+# Streaming needs the split voices.
+TTS_STREAMING_SETTING=$([[ "${SPLIT_VOICES}" == "1" ]] && echo true || echo false)
+
 mkdir -p "$(dirname "${CONFIG_PATH}")"
 cat > "${CONFIG_PATH}" <<YAML
 server:
@@ -161,6 +167,9 @@ app:
   rag:
     enabled: true
     embedding_model_dir: ${RAG_EMBEDDING_DIR}
+
+  tts:
+    streaming: ${TTS_STREAMING_SETTING}
 YAML
 
 if [[ "${SKIP_MODEL_DOWNLOAD}" != "1" ]]; then
@@ -180,7 +189,7 @@ if [[ "${INSTALL_TTS_VOICES}" == "1" ]]; then
   echo "Installing Piper TTS voices..."
   (
     cd "${EXAMPLE_DIR}/src/python"
-    PYTHON="${APP_VENV}/bin/python" bash voice_install.sh
+    PYTHON="${APP_VENV}/bin/python" SPLIT_VOICES="${SPLIT_VOICES}" bash voice_install.sh
   )
 fi
 

--- a/examples/genai/multimodal-assistant/setup.sh
+++ b/examples/genai/multimodal-assistant/setup.sh
@@ -31,7 +31,7 @@ Environment:
                                 default: /media/nvme/llima/models
   CHAT_MODEL_REPO               Hugging Face repo for the default chat/VLM model
                                 default: simaai/Qwen3-VL-4B-Instruct-GPTQ-a16w4
-  INSTALL_TTS_VOICES            Download Piper TTS voices, 1 or 0
+  INSTALL_TTS_VOICES            Download and split Piper TTS voices, 1 or 0
                                 default: 1
   CPU_TORCH_VERSION             CPU-only PyTorch version for RAG installs
                                 default: 2.8.0+cpu
@@ -180,7 +180,7 @@ if [[ "${INSTALL_TTS_VOICES}" == "1" ]]; then
   echo "Installing Piper TTS voices..."
   (
     cd "${EXAMPLE_DIR}/src/python"
-    bash voice_install.sh
+    PYTHON="${APP_VENV}/bin/python" bash voice_install.sh
   )
 fi
 

--- a/examples/genai/multimodal-assistant/src/common/config.yaml
+++ b/examples/genai/multimodal-assistant/src/common/config.yaml
@@ -32,3 +32,7 @@ app:                         # Assistant web app settings.
   rag:                       # Retrieval-augmented generation settings.
     enabled: false                             # Enable document retrieval.
     embedding_model_dir: <path-to-embedding-model-dir> # Embedding model directory.
+
+  tts:                       # Text-to-speech settings.
+    streaming: false          # Start playback before a sentence finishes synthesizing.
+

--- a/examples/genai/multimodal-assistant/src/common/config.yaml
+++ b/examples/genai/multimodal-assistant/src/common/config.yaml
@@ -34,5 +34,5 @@ app:                         # Assistant web app settings.
     embedding_model_dir: <path-to-embedding-model-dir> # Embedding model directory.
 
   tts:                       # Text-to-speech settings.
-    streaming: false          # Start playback before a sentence finishes synthesizing.
+    streaming: true          # Start playback before a sentence finishes synthesizing.
 

--- a/examples/genai/multimodal-assistant/src/python/requirements.txt
+++ b/examples/genai/multimodal-assistant/src/python/requirements.txt
@@ -5,3 +5,4 @@ Flask-Cors>=6,<7
 requests>=2,<3
 huggingface_hub[cli]>=0.34.0,<1.0
 piper-tts==1.3.0
+onnx>=1.17,<2

--- a/examples/genai/multimodal-assistant/src/python/shared/config.py
+++ b/examples/genai/multimodal-assistant/src/python/shared/config.py
@@ -74,6 +74,7 @@ class AppConfig:
     request: RequestConfig
     web: WebConfig
     rag: RagConfig
+    tts_streaming: bool = True
 
 
 def load_config(path: Path = DEFAULT_CONFIG, apps_root: Path = PATH_ROOT) -> AppConfig:
@@ -123,6 +124,7 @@ def load_ui_config(path: Path = DEFAULT_UI_CONFIG, apps_root: Path = PATH_ROOT) 
     request = raw.get("request", {})
     web = raw.get("web", {})
     rag = raw.get("rag", {})
+    tts = raw.get("tts", {})
     chat_models = _load_chat_model_names(server_models, apps_root)
 
     return AppConfig(
@@ -144,6 +146,7 @@ def load_ui_config(path: Path = DEFAULT_UI_CONFIG, apps_root: Path = PATH_ROOT) 
             https=_load_bool(web.get("https", True)),
         ),
         rag=_load_rag_config(rag, apps_root),
+        tts_streaming=_load_bool(tts.get("streaming", True)),
     )
 
 

--- a/examples/genai/multimodal-assistant/src/python/split_voices.py
+++ b/examples/genai/multimodal-assistant/src/python/split_voices.py
@@ -8,11 +8,12 @@ in slices and start playing audio while the rest of the sentence is still being
 generated, instead of waiting for the whole sentence to finish.
 
 Each `<voice>.onnx` produces `<voice>.enc.onnx` and `<voice>.dec.onnx` beside it.
-PiperTTS loads that pair, so every voice under `ui/assets/` needs one: a voice
-missing its halves fails to load and that language ends up with no speech.
+PiperTTS streams from the pair where it exists and synthesizes a whole sentence
+at a time where it does not, so a voice that cannot be split still speaks.
 
-`voice_install.sh` runs this after downloading, so `setup.sh` already covers it.
-Run it by hand only after dropping a voice into the assets directory yourself:
+`voice_install.sh` runs this after downloading, so `setup.sh` covers it unless it
+ran with `SPLIT_VOICES=0`. Run it by hand after dropping a voice into the assets
+directory yourself, or to add streaming to an install without it:
 
     python split_voices.py ui/assets
 
@@ -108,12 +109,10 @@ def main():
             print(f"❌ Split failed for {model_path.name}: {e}", file=sys.stderr)
             failed.append(model_path.name)
 
-    # A voice without both halves cannot be loaded at all, so say so plainly
-    # rather than letting the traceback scroll past in the middle of setup.
     if failed:
         sys.stdout.flush()
-        print(f"\n⚠️  {len(failed)} of {len(voices)} voices could not be split "
-              f"and will not be available: {', '.join(failed)}", file=sys.stderr)
+        print(f"\n⚠️  {len(failed)} of {len(voices)} voices could not be split and will be "
+              f"spoken a whole sentence at a time: {', '.join(failed)}", file=sys.stderr)
 
     return 0
 

--- a/examples/genai/multimodal-assistant/src/python/split_voices.py
+++ b/examples/genai/multimodal-assistant/src/python/split_voices.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Split Piper voice models into streaming encoder/decoder pairs.
+
+The HiFi-GAN decoder is about three quarters of the runtime of a Piper voice.
+Splitting the exported graph at the decoder input lets the app decode the latent
+in slices and start playing audio while the rest of the sentence is still being
+generated, instead of waiting for the whole sentence to finish.
+
+Each `<voice>.onnx` produces `<voice>.enc.onnx` and `<voice>.dec.onnx` beside it.
+PiperTTS loads that pair, so every voice under `ui/assets/` needs one: a voice
+missing its halves fails to load and that language ends up with no speech.
+
+`voice_install.sh` runs this after downloading, so `setup.sh` already covers it.
+Run it by hand only after dropping a voice into the assets directory yourself:
+
+    python split_voices.py ui/assets
+
+Voices that already have both halves are left alone, so re-running is cheap.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import onnx
+
+
+def find_decoder_input(graph):
+    """
+    Return the name of the tensor that feeds the decoder.
+
+    This is the single non-initializer input of the decoder's first convolution.
+    Looking the node up by name keeps this working across voice qualities, which
+    have different numbers of upsampling layers.
+    """
+    initializers = {entry.name for entry in graph.initializer}
+    for node in graph.node:
+        if node.name.startswith("/dec/conv_pre"):
+            inputs = [name for name in node.input if name not in initializers]
+            if len(inputs) != 1:
+                raise ValueError(f"Ambiguous decoder input in {node.name}: {inputs}")
+            return inputs[0]
+    raise ValueError("No /dec/conv_pre node found; this is not a Piper voice model")
+
+
+def split_voice(model_path):
+    """Write the encoder and decoder halves of a voice model next to it."""
+    encoder_path = model_path.with_suffix(".enc.onnx")
+    decoder_path = model_path.with_suffix(".dec.onnx")
+
+    if encoder_path.exists() and decoder_path.exists():
+        print(f"✅ Already split: {model_path.name}")
+        return
+
+    model = onnx.load(str(model_path), load_external_data=False)
+
+    # Multi-speaker voices condition the decoder on a speaker embedding, so the
+    # decoder half needs `sid` as well as the latent and PiperTTS has no value to
+    # feed it. Say that outright instead of failing on a dangling /emb_g node.
+    if any(entry.name == "sid" for entry in model.graph.input):
+        raise ValueError("multi-speaker voice (has a 'sid' input); "
+                         "streaming synthesis supports single-speaker voices only")
+
+    boundary = find_decoder_input(model.graph)
+
+    # Take the graph inputs as they are: multi-speaker voices have an extra `sid`
+    # input that a hardcoded list would silently drop.
+    graph_inputs = [entry.name for entry in model.graph.input]
+    graph_outputs = [entry.name for entry in model.graph.output]
+
+    try:
+        onnx.utils.extract_model(str(model_path), str(encoder_path), graph_inputs, [boundary])
+        onnx.utils.extract_model(str(model_path), str(decoder_path), [boundary], graph_outputs)
+    except Exception:
+        # extract_model saves before it validates, so a failure can leave a file
+        # that looks complete. Clear both halves or the next run skips this voice.
+        encoder_path.unlink(missing_ok=True)
+        decoder_path.unlink(missing_ok=True)
+        raise
+
+    print(f"🔪 Split {model_path.name} at {boundary}")
+    print(f"  {encoder_path.name} ({encoder_path.stat().st_size / 1e6:.1f} MB)")
+    print(f"  {decoder_path.name} ({decoder_path.stat().st_size / 1e6:.1f} MB)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("assets_dir", type=Path, help="Directory holding the voice .onnx files")
+    args = parser.parse_args()
+
+    if not args.assets_dir.is_dir():
+        print(f"not a directory: {args.assets_dir}", file=sys.stderr)
+        return 2
+
+    voices = [path for path in sorted(args.assets_dir.glob("*.onnx"))
+              if not path.name.endswith((".enc.onnx", ".dec.onnx"))]
+    if not voices:
+        print(f"no voice models found in {args.assets_dir}", file=sys.stderr)
+        return 2
+
+    failed = []
+    for model_path in voices:
+        try:
+            split_voice(model_path)
+        except Exception as e:
+            print(f"❌ Split failed for {model_path.name}: {e}", file=sys.stderr)
+            failed.append(model_path.name)
+
+    # A voice without both halves cannot be loaded at all, so say so plainly
+    # rather than letting the traceback scroll past in the middle of setup.
+    if failed:
+        sys.stdout.flush()
+        print(f"\n⚠️  {len(failed)} of {len(voices)} voices could not be split "
+              f"and will not be available: {', '.join(failed)}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/genai/multimodal-assistant/src/python/ui/flask_app.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/flask_app.py
@@ -343,21 +343,26 @@ class TalkController:
                     if piper is None:
                         self._warn_missing_voice_once(self.current_language)
                     else:
-                        buffer = piper.synthesize(sanitized_sentence)
-                        if generation_id is not None and not genai_app.is_generation_current(generation_id):
-                            return
                         self.full_response.append(sanitized_sentence)
+                        audio_duration = 0.0
+                        elapsed_time = 0.0
 
-                        elapsed_time = time.time() - start_time
-                        audio_duration = self._get_wav_duration(buffer)
-                        rtf = elapsed_time / audio_duration if audio_duration > 0 else 0
+                        # Emit each piece as it is synthesized so playback can start early.
+                        for buffer in piper.synthesize_stream(sanitized_sentence):
+                            if generation_id is not None and not genai_app.is_generation_current(generation_id):
+                                return
+
+                            elapsed_time = time.time() - start_time
+                            audio_duration += self._get_wav_duration(buffer)
+                            rtf = elapsed_time / audio_duration if audio_duration > 0 else 0
+                            genai_app.emit('audio_chunk', {
+                                'text': sanitized_sentence.strip(),
+                                'audio': buffer.getvalue(),
+                                'tps': round(self.tps, 2),
+                                'rtf': round(rtf, 2)
+                            })
+
                         logging.info(f"[Timing] self.piper.synthesize took {elapsed_time:.3f} seconds for [{sanitized_sentence}]")
-                        genai_app.emit('audio_chunk', {
-                            'text': sanitized_sentence.strip(),
-                            'audio': buffer.getvalue(),
-                            'tps': round(self.tps, 2),
-                            'rtf': round(rtf, 2)
-                        })
                         self.chunk_count += 1
 
                 self.talk = []

--- a/examples/genai/multimodal-assistant/src/python/ui/flask_app.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/flask_app.py
@@ -117,7 +117,7 @@ class AppConstants:
     DEFAULT_UPLOADS_DIR = 'uploads'
 
 class TalkController:
-    def __init__(self, supported_langs=None):
+    def __init__(self, supported_langs=None, streaming=True):
         self._next = None
         self.prefix = ''
         self.totalk = ''
@@ -125,6 +125,7 @@ class TalkController:
         self.pipers = {}
         self.utterance_speed = 1.0
         self.missing_voice_warnings = set()
+        self.streaming = streaming
         self._init_pipers_threaded(supported_langs or ['en'])
         
         self.lock = threading.Lock()
@@ -165,11 +166,13 @@ class TalkController:
             from pipertts import PiperTTS # import here if needed locally
             try:
                 piper = PiperTTS(
-                    model_path=str(onnx_file)
+                    model_path=str(onnx_file),
+                    streaming=self.streaming
                 )
                 piper.set_utterance_speed(self.utterance_speed)
                 self.pipers[lang_code] = piper
-                logging.info(f"Loaded Piper model for {lang_code}")
+                logging.info(f"Loaded Piper model for {lang_code}"
+                             f"{' (streaming)' if piper.streaming else ''}")
             except Exception as e:
                 logging.warning(f"Failed to load Piper model for {lang_code}: {e}")
 
@@ -468,6 +471,7 @@ class AppContext:
         self.web_port = 5000
         self.rag_enabled = True
         self.rag_embedding_model_dir = ""
+        self.tts_streaming = True
         self.vision_image_size = None
 
         # Conversation history for OpenAI-style chat
@@ -647,7 +651,8 @@ class AppContext:
             self.set_system_prompt(self.system_prompt)
 
         if not self.apionly:
-            self.talk_ctrl = TalkController(['en', 'fr', 'es', 'de', 'it', 'zh', 'vi'])
+            self.talk_ctrl = TalkController(['en', 'fr', 'es', 'de', 'it', 'zh', 'vi'],
+                                            streaming=self.tts_streaming)
 
     def update_from_config(self, app_cfg):
         model_server = f"{app_cfg.openai.client_host}:{app_cfg.openai.port}"
@@ -667,6 +672,7 @@ class AppContext:
         self.web_port = app_cfg.web.port
         self.rag_enabled = app_cfg.rag.enabled
         self.rag_embedding_model_dir = app_cfg.rag.embedding_model_dir
+        self.tts_streaming = app_cfg.tts_streaming
         if self.rag_embedding_model_dir:
             os.environ["VDB_EMBED_MODEL_DIR"] = self.rag_embedding_model_dir
         self.update_settings(
@@ -829,7 +835,8 @@ class AppContext:
                 from pipertts import PiperTTS
                 with self.talk_ctrl.lock:
                     old = self.talk_ctrl.pipers.get(lang)
-                    new_voice = PiperTTS(model_path=str(candidate))
+                    new_voice = PiperTTS(model_path=str(candidate),
+                                         streaming=self.talk_ctrl.streaming)
                     new_voice.set_utterance_speed(self.talk_ctrl.utterance_speed)
                     self.talk_ctrl.pipers[lang] = new_voice
                     self.current_voice_by_lang[lang] = candidate.name

--- a/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
@@ -3,12 +3,15 @@ PiperTTS - A wrapper class for Piper TTS model to synthesize speech from text.
 
 This module provides an interface to load a Piper ONNX model and generate speech audio:
 - Supports WAV audio generation as a memory buffer
+- Streams audio in chunks so playback can start before synthesis finishes
 - Encodes audio as Base64 for WebSocket or network transmission
 - Saves generated audio to disk as a standard WAV file
 
 Dependencies:
 -------------
 - piper-tts >= 1.3.0
+- onnxruntime
+- numpy
 - Python standard libraries: io, wave, base64, os, tempfile
 """
 
@@ -17,7 +20,10 @@ import io
 import os
 import tempfile
 import wave
+import numpy as np
+import onnxruntime
 from piper import PiperVoice, SynthesisConfig
+from piper.voice import AudioChunk
 
 class PiperTTS:
     """
@@ -27,20 +33,22 @@ class PiperTTS:
 
     DEFAULT_MODEL_PATH = "assets/en_US-amy-low.onnx"
     DEFAULT_SAMPLE_RATE = 22050
+    DEFAULT_NUM_THREADS = 8   # ONNX Runtime's own default oversubscribes this CPU
+    CHUNK_FRAMES = 45         # latent frames per streaming step, about 0.5 s of audio
+    CHUNK_PADDING = 10        # context frames decoded either side, then trimmed off
 
-    def __init__(self, model_path=None, sample_rate=DEFAULT_SAMPLE_RATE, use_cuda=False, config=None):
+    def __init__(self, model_path=None, sample_rate=DEFAULT_SAMPLE_RATE, config=None):
         """
         Initialize the Piper TTS engine.
 
         Args:
             model_path (str, optional): Path to the Piper ONNX model file.
             sample_rate (int): Desired sample rate in Hz (used for playback/export). Actual model rate may differ.
-            use_cuda (bool): Whether to use GPU (requires onnxruntime-gpu).
             config (SynthesisConfig, optional): Custom synthesis config.
         """
         self.model_path = model_path or self.DEFAULT_MODEL_PATH
         self.sample_rate = sample_rate
-        self.voice = PiperVoice.load(self.model_path, use_cuda=use_cuda)
+        self.voice = PiperVoice.load(self.model_path)
 
         self.config = config or SynthesisConfig(
             length_scale=1.0,
@@ -49,6 +57,34 @@ class PiperTTS:
             volume=1.0,
             normalize_audio=True
         )
+
+        # Encoder/decoder pair for streaming synthesis, produced by split_voices.py
+        base_path = os.path.splitext(self.model_path)[0]
+        self.enc_session = self._make_session(f"{base_path}.enc.onnx")
+        self.dec_session = self._make_session(f"{base_path}.dec.onnx")
+        self.dec_input_name = self.dec_session.get_inputs()[0].name
+
+        # Trial run: warms both sessions and gives the samples-per-frame ratio
+        phoneme_ids = self.voice.phonemes_to_ids(self.voice.phonemize("Ready.")[0])
+        latent = self.enc_session.run(None, self._encoder_args(phoneme_ids))[0]
+        audio = self.dec_session.run(None, {self.dec_input_name: latent})[0].squeeze()
+        self.upsample_factor = round(audio.shape[0] / latent.shape[2])
+
+    def _make_session(self, model_path):
+        """Create an ONNX Runtime session with the thread count tuned for this CPU."""
+        options = onnxruntime.SessionOptions()
+        options.intra_op_num_threads = self.DEFAULT_NUM_THREADS
+        return onnxruntime.InferenceSession(model_path, sess_options=options,
+                                            providers=["CPUExecutionProvider"])
+
+    def _encoder_args(self, phoneme_ids):
+        """Build the encoder inputs, mirroring PiperVoice.phoneme_ids_to_audio."""
+        return {
+            "input": np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0),
+            "input_lengths": np.array([len(phoneme_ids)], dtype=np.int64),
+            "scales": np.array([self.config.noise_scale, self.config.length_scale,
+                                self.config.noise_w_scale], dtype=np.float32),
+        }
 
 
     def set_utterance_speed(self, speed):
@@ -76,6 +112,39 @@ class PiperTTS:
 
         os.remove(tmp_path)
         return io.BytesIO(audio_bytes)
+
+    def synthesize_stream(self, text):
+        """
+        Synthesize speech and yield a WAV buffer per piece as soon as it is ready.
+        """
+        for phonemes in self.voice.phonemize(text):
+            phoneme_ids = self.voice.phonemes_to_ids(phonemes)
+            latent = self.enc_session.run(None, self._encoder_args(phoneme_ids))[0]
+            total_frames = latent.shape[2]
+
+            start = 0
+            while start < total_frames:
+                end = min(start + self.CHUNK_FRAMES, total_frames)
+                padded_start = max(0, start - self.CHUNK_PADDING)
+                padded_end = min(total_frames, end + self.CHUNK_PADDING)
+
+                window = np.ascontiguousarray(latent[:, :, padded_start:padded_end])
+                audio = self.dec_session.run(None, {self.dec_input_name: window})[0].squeeze()
+
+                # Drop the padding; a relative -0 tail index would slice the last chunk away.
+                head = (start - padded_start) * self.upsample_factor
+                tail = audio.shape[0] - (padded_end - end) * self.upsample_factor
+                chunk = AudioChunk(self.voice.config.sample_rate, 2, 1, audio[head:tail])
+
+                buffer = io.BytesIO()
+                with wave.open(buffer, 'wb') as wav_file:
+                    wav_file.setnchannels(chunk.sample_channels)
+                    wav_file.setsampwidth(chunk.sample_width)
+                    wav_file.setframerate(chunk.sample_rate)
+                    wav_file.writeframes(chunk.audio_int16_bytes)
+                yield buffer
+
+                start = end
 
     def synthesize_base64(self, text):
         """

--- a/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
@@ -3,7 +3,8 @@ PiperTTS - A wrapper class for Piper TTS model to synthesize speech from text.
 
 This module provides an interface to load a Piper ONNX model and generate speech audio:
 - Supports WAV audio generation as a memory buffer
-- Streams audio in chunks so playback can start before synthesis finishes
+- Streams audio in chunks so playback can start before synthesis finishes, or
+  synthesizes whole sentences for voices without an encoder/decoder pair
 - Encodes audio as Base64 for WebSocket or network transmission
 - Saves generated audio to disk as a standard WAV file
 
@@ -37,7 +38,7 @@ class PiperTTS:
     CHUNK_FRAMES = 45         # latent frames per streaming step, about 0.5 s of audio
     CHUNK_PADDING = 10        # context frames decoded either side, then trimmed off
 
-    def __init__(self, model_path=None, sample_rate=DEFAULT_SAMPLE_RATE, config=None):
+    def __init__(self, model_path=None, sample_rate=DEFAULT_SAMPLE_RATE, config=None, streaming=True):
         """
         Initialize the Piper TTS engine.
 
@@ -45,6 +46,7 @@ class PiperTTS:
             model_path (str, optional): Path to the Piper ONNX model file.
             sample_rate (int): Desired sample rate in Hz (used for playback/export). Actual model rate may differ.
             config (SynthesisConfig, optional): Custom synthesis config.
+            streaming (bool): Decode the sentence in slices so playback can start early.
         """
         self.model_path = model_path or self.DEFAULT_MODEL_PATH
         self.sample_rate = sample_rate
@@ -58,17 +60,21 @@ class PiperTTS:
             normalize_audio=True
         )
 
-        # Encoder/decoder pair for streaming synthesis, produced by split_voices.py
         base_path = os.path.splitext(self.model_path)[0]
-        self.enc_session = self._make_session(f"{base_path}.enc.onnx")
-        self.dec_session = self._make_session(f"{base_path}.dec.onnx")
-        self.dec_input_name = self.dec_session.get_inputs()[0].name
+        encoder_path = f"{base_path}.enc.onnx"
+        decoder_path = f"{base_path}.dec.onnx"
+        self.streaming = (streaming and os.path.exists(encoder_path)
+                          and os.path.exists(decoder_path))
+        if self.streaming:
+            self.enc_session = self._make_session(encoder_path)
+            self.dec_session = self._make_session(decoder_path)
+            self.dec_input_name = self.dec_session.get_inputs()[0].name
 
-        # Trial run: warms both sessions and gives the samples-per-frame ratio
-        phoneme_ids = self.voice.phonemes_to_ids(self.voice.phonemize("Ready.")[0])
-        latent = self.enc_session.run(None, self._encoder_args(phoneme_ids))[0]
-        audio = self.dec_session.run(None, {self.dec_input_name: latent})[0].squeeze()
-        self.upsample_factor = round(audio.shape[0] / latent.shape[2])
+            # Trial run: warms both sessions and gives the samples-per-frame ratio
+            phoneme_ids = self.voice.phonemes_to_ids(self.voice.phonemize("Ready.")[0])
+            latent = self.enc_session.run(None, self._encoder_args(phoneme_ids))[0]
+            audio = self.dec_session.run(None, {self.dec_input_name: latent})[0].squeeze()
+            self.upsample_factor = round(audio.shape[0] / latent.shape[2])
 
     def _make_session(self, model_path):
         """Create an ONNX Runtime session with the thread count tuned for this CPU."""
@@ -115,8 +121,13 @@ class PiperTTS:
 
     def synthesize_stream(self, text):
         """
-        Synthesize speech and yield a WAV buffer per piece as soon as it is ready.
+        Synthesize speech and yield a WAV buffer per piece as soon as it is ready,
+        or the whole utterance as a single buffer when not streaming.
         """
+        if not self.streaming:
+            yield self.synthesize(text)
+            return
+
         for phonemes in self.voice.phonemize(text):
             phoneme_ids = self.voice.phonemes_to_ids(phonemes)
             latent = self.enc_session.run(None, self._encoder_args(phoneme_ids))[0]

--- a/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
+++ b/examples/genai/multimodal-assistant/src/python/ui/pipertts.py
@@ -37,6 +37,7 @@ class PiperTTS:
     DEFAULT_NUM_THREADS = 8   # ONNX Runtime's own default oversubscribes this CPU
     CHUNK_FRAMES = 45         # latent frames per streaming step, about 0.5 s of audio
     CHUNK_PADDING = 10        # context frames decoded either side, then trimmed off
+    STREAM_GAIN = 2.0         # makeup for the peak normalization a stream cannot do
 
     def __init__(self, model_path=None, sample_rate=DEFAULT_SAMPLE_RATE, config=None, streaming=True):
         """
@@ -145,7 +146,8 @@ class PiperTTS:
                 # Drop the padding; a relative -0 tail index would slice the last chunk away.
                 head = (start - padded_start) * self.upsample_factor
                 tail = audio.shape[0] - (padded_end - end) * self.upsample_factor
-                chunk = AudioChunk(self.voice.config.sample_rate, 2, 1, audio[head:tail])
+                samples = np.clip(audio[head:tail] * self.STREAM_GAIN, -1.0, 1.0)
+                chunk = AudioChunk(self.voice.config.sample_rate, 2, 1, samples)
 
                 buffer = io.BytesIO()
                 with wave.open(buffer, 'wb') as wav_file:

--- a/examples/genai/multimodal-assistant/src/python/ui/static/newui.js
+++ b/examples/genai/multimodal-assistant/src/python/ui/static/newui.js
@@ -1570,13 +1570,10 @@ async function processAudioQueue() {
 
     const source = currentAudioContext.createBufferSource();
     const analyser = currentAudioContext.createAnalyser();
-    const gainNode = currentAudioContext.createGain();
 
     source.buffer = audioBuffer;
-    gainNode.gain.value = 2.0;  // makeup for the peak normalization a stream cannot do
     source.connect(analyser);
-    analyser.connect(gainNode);
-    gainNode.connect(currentAudioContext.destination);
+    analyser.connect(currentAudioContext.destination);
 
     scheduledSources.push(source);
 
@@ -1599,7 +1596,6 @@ async function processAudioQueue() {
       try {
         source.disconnect();
         analyser.disconnect();
-        gainNode.disconnect();
       } catch (e) {
         console.warn('Error disconnecting nodes:', e);
       }

--- a/examples/genai/multimodal-assistant/src/python/ui/static/newui.js
+++ b/examples/genai/multimodal-assistant/src/python/ui/static/newui.js
@@ -30,7 +30,10 @@ let isPlaying = false;
 let currentAudioContext = null;
 let receivedEndSignal = false;
 let shouldPlayAudio = true;
-let currentSourceNode = null;
+// Chunks are scheduled ahead of playback, so several sources can be live at once.
+let scheduledSources = [];
+// Playback cursor for the shared AudioContext, so chunks are queued back to back.
+let nextStartTime = 0;
 let activeGeneration = false;
 let pendingNewGenerationAudio = false;
 let requestQueue = Promise.resolve();
@@ -1277,26 +1280,17 @@ function stopAudio() {
   shouldPlayAudio = false;
   isPlaying = false;
   audioQueue.length = 0;
+  nextStartTime = 0;
 
   try {
-    if (currentSourceNode) {
-      currentSourceNode.stop(0);
-      currentSourceNode.disconnect();
-    }
+    scheduledSources.forEach(source => {
+      source.stop(0);
+      source.disconnect();
+    });
   } catch (e) {
     console.warn("Error stopping source node:", e);
   } finally {
-    currentSourceNode = null;
-  }
-
-  try {
-    if (currentAudioContext) {
-      currentAudioContext.close();
-    }
-  } catch (e) {
-    console.warn("Error closing audio context:", e);
-  } finally {
-    currentAudioContext = null;
+    scheduledSources = [];
   }
 
   console.log("🧹 Audio playback completely stopped and cleaned up.");
@@ -1525,6 +1519,14 @@ socket.on('context_full', (data) => {
   window.pendingContextClear = true;
 });
 
+// One AudioContext for the page; creating one per chunk would start an audio device each time.
+function ensureAudioContext() {
+  if (!currentAudioContext) {
+    currentAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  currentAudioContext.resume();
+}
+
 async function processAudioQueue() {
   console.log(`Processing audio queue... Current queue length: ${audioQueue.length}`);
   const conditions = [];
@@ -1556,18 +1558,13 @@ async function processAudioQueue() {
   }
 
   try {
-    if (currentAudioContext) {
-      currentAudioContext.close();
-    }
-
-    currentAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+    ensureAudioContext();
     const audioBuffer = await currentAudioContext.decodeAudioData(arrayBuffer);
 
     // Final check before starting playback
     if (!shouldPlayAudio) {
       console.log('Audio playback cancelled before starting');
       isPlaying = false;
-      currentAudioContext.close();
       return;
     }
 
@@ -1576,13 +1573,17 @@ async function processAudioQueue() {
     const gainNode = currentAudioContext.createGain();
 
     source.buffer = audioBuffer;
+    gainNode.gain.value = 2.0;  // makeup for the peak normalization a stream cannot do
     source.connect(analyser);
     analyser.connect(gainNode);
     gainNode.connect(currentAudioContext.destination);
 
-    currentSourceNode = source;
+    scheduledSources.push(source);
 
-    source.start();
+    // Queue after the previous chunk; Math.max re-anchors to "now" after stopAudio reset it.
+    const startAt = Math.max(currentAudioContext.currentTime, nextStartTime);
+    source.start(startAt);
+    nextStartTime = startAt + audioBuffer.duration;
 
     // Track First Audio timing (only for the very first audio chunk)
     if (!firstAudioStarted && userInputStartTime) {
@@ -1592,8 +1593,7 @@ async function processAudioQueue() {
     }
 
     source.onended = () => {
-      isPlaying = false;
-      currentSourceNode = null;
+      scheduledSources = scheduledSources.filter(s => s !== source);
 
       // Disconnect and clean up
       try {
@@ -1608,13 +1608,8 @@ async function processAudioQueue() {
 
       // Check if we should hide the abort button
       // Hide it only if text streaming has ended AND no more audio in queue
-      if (receivedEndSignal && audioQueue.length === 0) {
+      if (receivedEndSignal && audioQueue.length === 0 && scheduledSources.length === 0) {
         hideAbortButton();
-      }
-
-      // Only continue processing if audio should still play
-      if (shouldPlayAudio) {
-        setTimeout(() => processAudioQueue(), 250);
       }
     };
   } catch (err) {
@@ -1622,10 +1617,12 @@ async function processAudioQueue() {
     isPlaying = false;
 
     // Hide abort button if text streaming ended and this was the last audio
-    if (receivedEndSignal && audioQueue.length === 0) {
+    if (receivedEndSignal && audioQueue.length === 0 && scheduledSources.length === 0) {
       hideAbortButton();
     }
   }
+  isPlaying = false;
+  processAudioQueue();
 }
 
 async function processSystemAudioOnce(data) {
@@ -1633,10 +1630,7 @@ async function processSystemAudioOnce(data) {
     const blob = new Blob([data], { type: 'audio/wav' });
     const arrayBuffer = await blob.arrayBuffer();
 
-    if (currentAudioContext) {
-      currentAudioContext.close();
-    }
-    currentAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+    ensureAudioContext();
     const audioBuffer = await currentAudioContext.decodeAudioData(arrayBuffer);
 
     const source = currentAudioContext.createBufferSource();

--- a/examples/genai/multimodal-assistant/src/python/voice_install.sh
+++ b/examples/genai/multimodal-assistant/src/python/voice_install.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Directory where voices are stored
 ASSETS_DIR="ui/assets"
+
+# Interpreter used to split voices for streaming synthesis. setup.sh passes the
+# app virtual environment; a manual run falls back to whatever python3 is on PATH.
+PYTHON="${PYTHON:-python3}"
 
 # Edit this list with the voices you want to install.
 # Use the format: "<lang_COUNTRY>-<voice>-<quality>"
@@ -70,5 +76,19 @@ for entry in "${VOICES[@]}"; do
   fi
 
 done
+
+# PiperTTS decodes the latent in slices so playback starts before the sentence is
+# finished, which means it loads an encoder/decoder pair rather than the whole
+# voice. Split every voice here so the app never sees one it cannot load.
+if ! "${PYTHON}" -c "import onnx" >/dev/null 2>&1; then
+  echo ""
+  echo "❌ Cannot split voices: '${PYTHON}' has no 'onnx' package."
+  echo "   Use the app environment, or point PYTHON at one:"
+  echo "     PYTHON=/path/to/.venv/bin/python bash voice_install.sh"
+  exit 1
+fi
+
+printf "\n🔪 Splitting voices for streaming synthesis\n"
+"${PYTHON}" "${SCRIPT_DIR}/split_voices.py" "${ASSETS_DIR}"
 
 printf "\n✅ Done. Voices are available in '%s/'.\n" "${ASSETS_DIR}"

--- a/examples/genai/multimodal-assistant/src/python/voice_install.sh
+++ b/examples/genai/multimodal-assistant/src/python/voice_install.sh
@@ -10,6 +10,10 @@ ASSETS_DIR="ui/assets"
 # app virtual environment; a manual run falls back to whatever python3 is on PATH.
 PYTHON="${PYTHON:-python3}"
 
+# Streaming synthesis decodes a sentence in slices, which needs an encoder/decoder
+# pair beside each voice. SPLIT_VOICES=0 skips it.
+SPLIT_VOICES="${SPLIT_VOICES:-1}"
+
 # Edit this list with the voices you want to install.
 # Use the format: "<lang_COUNTRY>-<voice>-<quality>"
 # Examples:
@@ -77,18 +81,20 @@ for entry in "${VOICES[@]}"; do
 
 done
 
-# PiperTTS decodes the latent in slices so playback starts before the sentence is
-# finished, which means it loads an encoder/decoder pair rather than the whole
-# voice. Split every voice here so the app never sees one it cannot load.
-if ! "${PYTHON}" -c "import onnx" >/dev/null 2>&1; then
-  echo ""
-  echo "❌ Cannot split voices: '${PYTHON}' has no 'onnx' package."
-  echo "   Use the app environment, or point PYTHON at one:"
-  echo "     PYTHON=/path/to/.venv/bin/python bash voice_install.sh"
-  exit 1
-fi
+if [[ "${SPLIT_VOICES}" == "1" ]]; then
+  if ! "${PYTHON}" -c "import onnx" >/dev/null 2>&1; then
+    echo ""
+    echo "❌ Cannot split voices: '${PYTHON}' has no 'onnx' package."
+    echo "   Use the app environment, or point PYTHON at one:"
+    echo "     PYTHON=/path/to/.venv/bin/python bash voice_install.sh"
+    echo "   Or skip streaming synthesis: SPLIT_VOICES=0 bash voice_install.sh"
+    exit 1
+  fi
 
-printf "\n🔪 Splitting voices for streaming synthesis\n"
-"${PYTHON}" "${SCRIPT_DIR}/split_voices.py" "${ASSETS_DIR}"
+  printf "\n🔪 Splitting voices for streaming synthesis\n"
+  "${PYTHON}" "${SCRIPT_DIR}/split_voices.py" "${ASSETS_DIR}"
+else
+  printf "\n⏭️  Skipping the split: voices are synthesized a whole sentence at a time.\n"
+fi
 
 printf "\n✅ Done. Voices are available in '%s/'.\n" "${ASSETS_DIR}"


### PR DESCRIPTION
## Summary

Time to first audio is what makes this example feel real-time. Streaming audio within a sentence, rather than waiting for the whole one, reduces it by roughly 1–1.5 s on average. The gap grows for long multi-clause sentences (10 s → 3 s).

The LLM already reaches its first token in ~275 ms, so synthesis is where the remaining headroom was. Splitting each Piper voice into encoder and decoder halves lets the latent be decoded in ~0.5 s slices, so the first slice plays while the rest is still generating. The browser side follows suit: one shared AudioContext for the page, and chunks scheduled back to back so playback stays gapless.

Measured on Modalix (Cortex-A65, `en_US-hfc_female-medium`), real chat requests, average of 3:

| | first token | first audio |
| --- | --- | --- 
| before | 273 ms | 3557 ms |
| after | 278 ms | **2412 ms** |

The assistant starts speaking in 2.4 s instead of 3.6 s.

`voice_install.sh` splits each downloaded voice, so `./setup.sh` still gives a working install with no extra steps. `SPLIT_VOICES=0` skips the split, `app.tts.streaming: false` turns streaming off.

Same technique as rhasspy/piper#255.

Closes https://github.com/sima-neat/apps/issues/423

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Tests / CI improvements

---

## Testing & Verification

- [ ] Unit tests added/updated
- [x] Built successfully on hardware (e.g., Modalix, Davinci DevKit)
- [ ] Verified with Yocto/SDK build
- [x] Manual functional tests (describe below)

All numbers measured on a Modalix board.

**End to end** — real chat through the app: first audio 3557 ms → 2412 ms.

**Synthesis in isolation** — time to first audio by sentence length: 21 chars 335 → 266 ms, 52 chars 732 → 422 ms, 151 chars 1768 → 671 ms.

**Audio correctness** — streamed output vs the unsplit model for the same text is identical in length, RMS, peak and clipping, with 50 of 96768 samples differing by 1 LSB of 32767 (~-90 dBFS rounding noise).

**Padding sweep** — chose 10 context frames: at 10 the error is 1 LSB, at 5 it rises to 5e-03, at 2 to 1.6e-01.

**Setup** — `./setup.sh` run end to end on the board: 11 of 12 default voices download and split; voice selection and playback verified in the browser.

---

## Checklist

- [x] Code follows project style guidelines
- [x] Comments/documentation updated where needed
- [x] New dependencies documented in README or `requirements.txt`
- [x] Related issues linked in PR description
- [x] Planned merge method matches the target branch policy in `CONTRIBUTING.md`
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)

---

## Additional Notes

**New dependency:** `onnx` in `requirements.txt`. It is needed by `split_voices.py`, which `setup.sh` runs on the board.

**Deliberate trade:** total synthesis time per sentence goes *up* (2336 ms vs 1563 ms for 151 chars) because each chunk decodes 20 extra context frames. At RTF 0.28 the board still synthesizes ~3.5x faster than playback, so audio never stalls, and time to first audio (what a listener actually waits for) goes down.

**Costs:** `ui/assets/` grows from ~760 MB to ~1.5 GB for the 12 default voices (the original is kept alongside the halves), and `PiperTTS` construction rises from ~6.9 s to ~12 s (three ONNX sessions instead of one).

**Known limitations:**

- Multi-speaker voices cannot be split (the decoder needs a speaker embedding). They are detected and reported, not silently skipped. `vi_VN-vivos-x_low` in the default list is one; Vietnamese remains covered by `vi_VN-vais1000-medium`.
- A voice with no `.enc.onnx`/`.dec.onnx` pair is spoken a whole sentence at a time. Existing installs re-run `./setup.sh` for the earlier first audio.
