### PR TITLE
feat(object-detection): add batch-4 YOLO26 detector

### DIFF
--- a/examples/object-detection/CMakeLists.txt
+++ b/examples/object-detection/CMakeLists.txt
@@ -3,6 +3,7 @@ foreach(example IN ITEMS
     detr-object-detector
     single-stream-object-detector
     yolo26-object-detector
+    yolo26-batch4-detector
 )
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${example}/src/cpp/CMakeLists.txt")
     add_subdirectory(${example}/src/cpp ${example})

--- a/examples/object-detection/yolo26-batch4-detector/README.md
+++ b/examples/object-detection/yolo26-batch4-detector/README.md
@@ -1,0 +1,191 @@
+# YOLO26 Batch-4 Detector
+
+## Metadata
+| Field | Value |
+| --- | --- |
+| Category | object-detection |
+| Difficulty | Advanced |
+| Tags | object-detection, yolo26, batching, rtsp, insight |
+| Languages | C++, Python |
+| Status | experimental |
+| Binary Name | yolo26-batch4-detector |
+| Model | yolo26m-det-int8-b4 |
+
+## Concept
+Four RTSP streams hosted by Insight are decoded, one frame is taken from each, and all four are submitted to the MLA as a single `[4, 640, 640, 3]` batch — one dispatch instead of four. The model returns the six YOLO26 heads, which are decoded on the CPU (A65) per batch lane, so each stream keeps its own detections. The analysed frame is published to Insight with its detections beside it as metadata.
+
+The example exercises batched inference across several streams, per-lane attribution of results, and a pipeline shaped so that ingest overlaps inference rather than queueing behind it.
+
+## Prerequisites
+
+- `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix DevKit.
+- A Modalix DevKit with the Neat runtime installed and `simaai-appcomplex` running.
+- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model above, or set `model.path` to another compatible batch-4 six-head package.
+- Four reachable RTSP H.264 sources, from Insight or from cameras.
+- A runtime containing the multi-output batch layout fix described below.
+- On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting if the runtime has been used by earlier ML/video apps.
+
+### Runtime requirement
+Older runtimes misaddress multi-output tensors when `batch_size > 1`, producing incorrect results without reporting an error. Use a Neat runtime that includes the batched multi-output OFM layout fix. If lane 0 looks correct while lanes 1–3 contain implausible detections, update the runtime before debugging the application.
+
+## Insight Setup
+[Neat Insight](https://developer.sima.ai/software/tools/insight/) can host RTSP streams, receive video from `VideoSender`, receive detection metadata from `MetadataSender`, and render the overlays in the browser.
+
+In the Neat Development Environment, install the sample video assets:
+
+```bash
+sima-cli install assets/multi-video-sources
+```
+
+Then create the inputs:
+1. Run `neat` in the Neat Development Environment and open the reported `Insight Web UI`.
+2. In Insight, open `RTSP Source`.
+3. Use the sample videos or upload your own.
+4. Start four streams and copy their RTSP URLs.
+5. Copy the Insight host and its `videoUDP` and `metadataUDP` base ports into the config. The defaults are 9000 and 9100.
+
+Stream N is published on `video_port_base + N` and `metadata_port_base + N`, as Insight channel N. The application prints the resulting map on startup.
+
+When the application runs on a DevKit and Insight runs in the Neat Development Environment, the RTSP host is the SDK host address, not `127.0.0.1`. No port mapping is needed: the DevKit reaches the RTSP port on that host directly.
+
+## Install Apps
+
+Install the latest Neat Apps runtime and enter the installed bundle:
+
+```bash
+sima-cli neat install apps
+cd prebuilt-apps
+```
+
+Run the remaining commands from `prebuilt-apps/`.
+
+## Prepare the Model
+
+Use the Model Zoo release version wherever `<modelzoo-version>` appears. It can differ from the installed platform version.
+
+Default model: `yolo26m-det-int8-b4.tar.gz`.
+
+Download the default model:
+
+```bash
+mkdir -p assets/models
+cd assets/models
+
+sima-cli download https://docs.sima.ai/pkg_downloads/SDK<modelzoo-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b4.tar.gz
+
+cd ../..
+```
+
+The command stores the model under `assets/models/` as a bundle-local convention. `model.path` can point to any readable model package path.
+
+The application requires a batch-4 YOLO26 package with six separate detection heads. It validates this contract at startup and rejects batch-1 or incompatible packages.
+
+## Configure
+
+Edit `examples/object-detection/yolo26-batch4-detector/src/common/config.yaml`. The checked-in file ships placeholders and the application rejects them, so no run can accidentally use someone else's addresses.
+
+```yaml
+model:
+  path: assets/models/yolo26m-det-int8-b4.tar.gz         # Batched, six-head pack.
+
+streams:
+  - <first-rtsp-url-copied-from-insight>
+  - <second-rtsp-url-copied-from-insight>
+  - <third-rtsp-url-copied-from-insight>
+  - <fourth-rtsp-url-copied-from-insight>
+
+inference:
+  frames: 0                                              # 0 runs continuously.
+  score_threshold: 0.35                                  # int8 score granularity is ~0.06.
+  max_detections: 100
+
+output:
+  insight:
+    host: <insight-host-ip>
+    video_port_base: <videoUDP start port from neat>
+    metadata_port_base: <metadataUDP start port from neat>
+```
+
+Fewer than four streams is allowed; the batch is filled by repeating the last frame, so the MLA still runs one dispatch.
+
+## Run
+
+### Validate Config Only
+
+Quick smoke test that opens no streams and touches no hardware.
+
+```bash
+python3 examples/object-detection/yolo26-batch4-detector/src/python/main.py \
+  --config examples/object-detection/yolo26-batch4-detector/src/common/config.yaml \
+  --validate-config-only
+```
+
+### Python
+
+On the Modalix DevKit, from the installed bundle root:
+
+```bash
+source ~/pyneat/bin/activate
+pip install -r examples/object-detection/yolo26-batch4-detector/src/python/requirements.txt
+SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 python3 \
+  examples/object-detection/yolo26-batch4-detector/src/python/main.py \
+  --config examples/object-detection/yolo26-batch4-detector/src/common/config.yaml
+```
+
+### C++
+
+```bash
+SIMA_GST_RUN_INPUT_TIMEOUT_MS=120000 \
+  ./examples/object-detection/yolo26-batch4-detector/src/cpp/pre-built/yolo26-batch4-detector \
+  --config examples/object-detection/yolo26-batch4-detector/src/common/config.yaml
+```
+
+Open the Insight Web UI to watch the four channels with detection overlays.
+
+## How It Works
+
+1. Each RTSP source is split before decode. Encoded H.264 is forwarded directly to Insight while the second branch is decoded to NV12.
+2. Worker threads take the latest frame from each stream, letterbox it to 640×640 RGB, and write it into one lane of a reusable `[4, 640, 640, 3]` tensor.
+3. One synchronous `model.run(...)` call submits all four lanes. Batch preparation for the next dispatch continues in parallel.
+4. The six raw YOLO26 heads are decoded on the CPU per lane and mapped back to source-frame coordinates.
+5. Detection metadata carries the analysed frame's `_insight.rtp_timestamp`; C++ and Python use the same video and metadata topology.
+
+CPU decode is required because the current model-managed `YoloV26` box decode only returns lane 0 for this batched six-head package. YOLO26 is end-to-end, so the application ranks detections but does not run NMS.
+
+The forwarded video can run at 30 FPS while inference produces fewer results per second. Insight therefore has intervening frames without detection metadata, so boxes may appear to flicker. Exact-frame alignment is intentional: repeating old boxes on newer frames makes them visibly trail moving objects.
+
+## Tests
+
+Unit tests cover config loading and validation, the shape-based head mapping, and the decode maths, and need no hardware:
+
+```bash
+./tests/test.sh --unit
+```
+
+End-to-end coverage downloads the batch-4 model declared in `tests/test-scope.yaml` and runs when the test environment provides four live RTSP sources plus the required Modalix services.
+
+## Debugging Notes
+
+- The checked-in `config.yaml` ships placeholder URLs and an Insight host. The application refuses to start until they are replaced, rather than failing later with a connection error.
+- `output.debug_dir` plus `output.save_every` write annotated JPEGs per stream without changing the Insight output contract — useful when Insight is not reachable.
+- `runtime.profile` prints throughput and a phase breakdown every `runtime.profile_interval` dispatches.
+- `method DESCRIBE failed: 404 Not Found` means the RTSP path exists as a naming scheme but Insight has no media source assigned to it. Assign the sources in the Insight UI first.
+- If `pyneat` fails to import with `libsima_neat.so.2: cannot open shared object file`, the DevKit has a `pyneat` wheel that does not match the installed `sima-neat` package. Install the wheel that matches the runtime.
+- If lanes 1–3 look incorrect while lane 0 is sensible, update to a runtime containing the multi-output batch fix.
+
+## Source Files
+
+- Test scope: `tests/test-scope.yaml`
+- Python source: `src/python/main.py`
+- C++ source: `src/cpp/main.cpp`
+- Python tests: `tests/python/test_unit.py`
+- Python e2e test: `tests/python/test_e2e.py`
+- C++ tests: `tests/cpp/test_unit.cpp`
+- C++ e2e test: `tests/cpp/test_e2e.cpp`
+- Shared assets: `src/common/config.yaml`, `src/common/coco_label.txt`
+
+The packaged C++ source is an implementation reference. Run the executable under `src/cpp/pre-built/`; the installed bundle does not include CMake files.
+
+## Development From Source
+
+To modify, compile, or test this example, use the [Apps contributor workflow](https://github.com/sima-neat/apps/blob/main/CONTRIBUTING.md).

--- a/examples/object-detection/yolo26-batch4-detector/README.md
+++ b/examples/object-detection/yolo26-batch4-detector/README.md
@@ -20,10 +20,9 @@ The example exercises batched inference across several streams, per-lane attribu
 
 - `sima-cli` ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a supported Modalix DevKit.
 - A Modalix DevKit with the Neat runtime installed and `simaai-appcomplex` running.
-- Model artifacts are user-managed and should be downloaded into `assets/models/`. Download the default model above, or set `model.path` to another compatible batch-4 six-head package.
+- Model artifacts are user-managed. Download the default model as described below, or set `model.path` to another compatible batch-4 six-head package.
 - Four reachable RTSP H.264 sources, from Insight or from cameras.
 - A runtime containing the multi-output batch layout fix described below.
-- On Modalix DevKit, run `bash /usr/bin/fix_devkit_runtime.sh` before starting if the runtime has been used by earlier ML/video apps.
 
 ### Runtime requirement
 Older runtimes misaddress multi-output tensors when `batch_size > 1`, producing incorrect results without reporting an error. Use a Neat runtime that includes the batched multi-output OFM layout fix. If lane 0 looks correct while lanes 1–3 contain implausible detections, update the runtime before debugging the application.
@@ -68,15 +67,15 @@ Default model: `yolo26m-det-int8-b4.tar.gz`.
 Download the default model:
 
 ```bash
-mkdir -p assets/models
-cd assets/models
+mkdir -p models
+cd models
 
 sima-cli download https://docs.sima.ai/pkg_downloads/SDK<modelzoo-version>/models/modalix/yolo26-detection/yolo26m-det-int8-b4.tar.gz
 
-cd ../..
+cd ..
 ```
 
-The command stores the model under `assets/models/` as a bundle-local convention. `model.path` can point to any readable model package path.
+The command stores the model under `models/` as a bundle-local convention. `model.path` can point to any readable model package path.
 
 The application requires a batch-4 YOLO26 package with six separate detection heads. It validates this contract at startup and rejects batch-1 or incompatible packages.
 
@@ -86,7 +85,7 @@ Edit `examples/object-detection/yolo26-batch4-detector/src/common/config.yaml`. 
 
 ```yaml
 model:
-  path: assets/models/yolo26m-det-int8-b4.tar.gz         # Batched, six-head pack.
+  path: <model-path>                                     # Example: models/yolo26m-det-int8-b4.tar.gz
 
 streams:
   - <first-rtsp-url-copied-from-insight>

--- a/examples/object-detection/yolo26-batch4-detector/src/common/coco_label.txt
+++ b/examples/object-detection/yolo26-batch4-detector/src/common/coco_label.txt
@@ -1,0 +1,80 @@
+person
+bicycle
+car
+motorcycle
+airplane
+bus
+train
+truck
+boat
+traffic light
+fire hydrant
+stop sign
+parking meter
+bench
+bird
+cat
+dog
+horse
+sheep
+cow
+elephant
+bear
+zebra
+giraffe
+backpack
+umbrella
+handbag
+tie
+suitcase
+frisbee
+skis
+snowboard
+sports ball
+kite
+baseball bat
+baseball glove
+skateboard
+surfboard
+tennis racket
+bottle
+wine glass
+cup
+fork
+knife
+spoon
+bowl
+banana
+apple
+sandwich
+orange
+broccoli
+carrot
+hot dog
+pizza
+donut
+cake
+chair
+couch
+potted plant
+bed
+dining table
+toilet
+tv
+laptop
+mouse
+remote
+keyboard
+cell phone
+microwave
+oven
+toaster
+sink
+refrigerator
+book
+clock
+vase
+scissors
+teddy bear
+hair drier
+toothbrush

--- a/examples/object-detection/yolo26-batch4-detector/src/common/config.yaml
+++ b/examples/object-detection/yolo26-batch4-detector/src/common/config.yaml
@@ -1,0 +1,39 @@
+model:                       # Batched detector selection.
+  path: assets/models/yolo26m-det-int8-b4.tar.gz        # Six-head pack compiled with --batch_size 4.
+  labels: examples/object-detection/yolo26-batch4-detector/src/common/coco_label.txt
+
+streams:                     # RTSP inputs from Insight, one entry per batch lane.
+  - <first-rtsp-url-copied-from-insight>
+  - <second-rtsp-url-copied-from-insight>
+  - <third-rtsp-url-copied-from-insight>
+  - <fourth-rtsp-url-copied-from-insight>
+
+input:                       # RTSP input transport settings.
+  tcp: true                  # Use TCP for RTSP transport.
+  latency_ms: 100            # RTSP receive latency in milliseconds.
+
+inference:                   # Detection controls. No NMS: the YOLO26 head is end-to-end.
+  frames: 0                  # Frame limit per stream. 0 runs continuously.
+  score_threshold: 0.35      # Minimum class confidence. int8 score granularity is ~0.06.
+  max_detections: 100        # Keep at most this many detections per frame.
+
+output:                      # Insight output plus optional local debug saves.
+  insight:                   # Live video and metadata destination.
+    host: <insight-host-ip>   # Host running the Insight receiver/viewer.
+    video_port_base: 9000    # Base UDP port for video channels (videoUDP start port).
+    metadata_port_base: 9100 # Base UDP port for metadata channels (metadataUDP start port).
+  video_enabled: true        # Disable to publish metadata only.
+  debug_dir: null            # Optional directory for periodic annotated frame saves.
+  save_every: 0              # Save every Nth frame per stream. 0 disables saving.
+
+runtime:                     # Runtime settings.
+  timeout_ms: 20000          # Frame pull and inference timeout in milliseconds.
+  warmup_frames: 10          # Drain this many frames per stream before publishing.
+  profile: false             # Print throughput and a phase breakdown periodically.
+  profile_interval: 50       # Dispatches between profile lines.
+
+testing:                     # Values the e2e tests override this config with.
+  e2e:
+    output:
+      save_every: 10         # Save every Nth frame per stream during the test.
+      total_saved_frames: 20 # Stop once this many sampled frames exist.

--- a/examples/object-detection/yolo26-batch4-detector/src/common/config.yaml
+++ b/examples/object-detection/yolo26-batch4-detector/src/common/config.yaml
@@ -1,5 +1,5 @@
 model:                       # Batched detector selection.
-  path: assets/models/yolo26m-det-int8-b4.tar.gz        # Six-head pack compiled with --batch_size 4.
+  path: <model-path>         # Example: models/yolo26m-det-int8-b4.tar.gz
   labels: examples/object-detection/yolo26-batch4-detector/src/common/coco_label.txt
 
 streams:                     # RTSP inputs from Insight, one entry per batch lane.

--- a/examples/object-detection/yolo26-batch4-detector/src/cpp/CMakeLists.txt
+++ b/examples/object-detection/yolo26-batch4-detector/src/cpp/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(yolo26-batch4-detector LANGUAGES CXX)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  include(CTest)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../cmake/ExampleModule.cmake")
+
+sima_neat_apps_module(
+  "yolo26-batch4-detector"
+  UNIT_TEST
+  E2E_TEST
+  OUTPUT_TARGET_VAR YOLO26_BATCH4_DETECTOR_TARGET
+)

--- a/examples/object-detection/yolo26-batch4-detector/src/cpp/main.cpp
+++ b/examples/object-detection/yolo26-batch4-detector/src/cpp/main.cpp
@@ -1,0 +1,1082 @@
+// Copyright 2026 SiMa Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Batch-4 YOLO26 detector: four Insight RTSP streams, one MLA dispatch, CPU decode.
+//
+// Up to four RTSP streams are decoded, one frame is taken from each, and all
+// four are submitted to the MLA as a single [4, 640, 640, 3] batch. The model
+// returns the six YOLO26 heads, which are decoded on the CPU (A65) per batch
+// lane, so every stream gets its own detections. The source H.264 is forwarded
+// to Insight and detections are timestamped to the exact analysed frame.
+//
+// Why the batch is assembled here
+//   Model-managed preprocessing is a single-image convenience path; it rejects
+//   a multi-image submission outright. A batched pack therefore has to be fed
+//   one already-assembled [N, 640, 640, 3] tensor, which is what the prefetcher
+//   below builds.
+//
+// Why the decode runs on the CPU
+//   The model-managed box decode (decode_type=YoloV26) is not batch-aware. It
+//   collapses the six heads into one BBOX payload and decodes lane 0 only,
+//   silently discarding lanes 1-3 — no error, no warning. Using it here would
+//   report one stream's detections on all four channels. Decoding the raw heads
+//   per lane is what keeps detections attributed to the frame they came from.
+//
+// Heads are matched by shape, not by output order
+//   A bbox head carries 4 channels and a class head 80, and the grid size (80,
+//   40, 20) orders the three levels. Nothing depends on the order in which the
+//   compiler happens to emit the outputs.
+
+#include "neat.h"
+#include "neat/models.h"
+#include "neat/node_groups.h"
+#include "neat/nodes.h"
+#include "support/object_detection/obj_detection_utils.h"
+#include "support/runtime/config_utils.h"
+#include "support/runtime/example_utils.h"
+
+#include <nodes/groups/VideoSender.h>
+#include <nodes/io/MetadataSender.h>
+#include <nlohmann/json.hpp>
+
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <csignal>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+volatile std::sig_atomic_t g_stop_requested = 0;
+
+void request_stop(int) {
+  g_stop_requested = 1;
+}
+
+// The YOLO26 head set: three detection levels, each a bbox head and a class
+// head. Channel count tells the two apart, grid size orders the levels.
+constexpr int kBboxChannels = 4;
+constexpr int kClassChannels = 80;
+constexpr int kLevels = 3;
+constexpr int kExpectedOutputs = 2 * kLevels;
+constexpr int kMaxStreams = 4;
+constexpr int kPadValue = 114;
+
+struct AppConfig {
+  std::string model_path;
+  fs::path labels_path;
+  std::vector<std::string> rtsp_urls;
+  bool tcp = true;
+  int latency_ms = 100;
+  int frames = 0;
+  double score_threshold = 0.35;
+  int max_detections = 100;
+  std::string insight_host;
+  int video_port_base = 9000;
+  int metadata_port_base = 9100;
+  bool video_enabled = true;
+  fs::path debug_dir;
+  int save_every = 0;
+  int timeout_ms = 20000;
+  int warmup_frames = 10;
+  bool profile = false;
+  int profile_interval = 50;
+};
+
+struct CliOptions {
+  fs::path config_path;
+  bool validate_config_only = false;
+};
+
+// One dispatch carries one frame per stream, so each stream sees the dispatch
+// rate and the aggregate frame rate is that times the stream count.
+struct ProfileWindow {
+  bool enabled = false;
+  int streams = 1;
+  int interval = 50;
+  int dispatches = 0;
+  int detections = 0;
+  double start_ms = 0.0;
+  double batch_ms = 0.0;
+  double infer_ms = 0.0;
+  double decode_ms = 0.0;
+  double publish_ms = 0.0;
+
+  void add(double batch, double infer, double decode, double publish, int found) {
+    if (!enabled)
+      return;
+    if (dispatches == 0)
+      start_ms = sima_examples::time_ms();
+    ++dispatches;
+    batch_ms += batch;
+    infer_ms += infer;
+    decode_ms += decode;
+    publish_ms += publish;
+    detections += found;
+    if (dispatches >= interval)
+      flush();
+  }
+
+  void flush() {
+    if (!enabled || dispatches == 0)
+      return;
+    const double elapsed = std::max(sima_examples::time_ms() - start_ms, 1e-6);
+    const double dispatch_fps = static_cast<double>(dispatches) * 1000.0 / elapsed;
+    const auto avg = [this](double value) { return value / static_cast<double>(dispatches); };
+    std::cout << "[profile] dispatch_fps=" << dispatch_fps << " per_stream_fps=" << dispatch_fps
+              << " aggregate_fps=" << dispatch_fps * static_cast<double>(streams)
+              << " | avg_batch_ms=" << avg(batch_ms) << " avg_infer_ms=" << avg(infer_ms)
+              << " avg_decode_ms=" << avg(decode_ms) << " avg_publish_ms=" << avg(publish_ms)
+              << " | avg_detections="
+              << static_cast<double>(detections) / static_cast<double>(dispatches) << "\n";
+    dispatches = 0;
+    detections = 0;
+    start_ms = 0.0;
+    batch_ms = 0.0;
+    infer_ms = 0.0;
+    decode_ms = 0.0;
+    publish_ms = 0.0;
+  }
+};
+
+struct StreamRuntime {
+  int index = 0;
+  std::string url;
+  simaai::neat::nodes::groups::RtspDecodedInputOptions source_options;
+  std::unique_ptr<simaai::neat::MetadataSender> metadata_sender;
+  int frame_w = 0;
+  int frame_h = 0;
+  int fps = 0;
+  int video_port = 0;
+  int processed = 0;
+};
+
+// Letterbox geometry needed to map boxes back onto the source frame.
+struct Geometry {
+  double scale = 1.0;
+  int dx = 0;
+  int dy = 0;
+};
+
+// One reusable batch: the MLA input plus what the lanes came from. Two of these
+// alternate so the next batch can be pulled and letterboxed while the current
+// one is still being inferred and decoded.
+struct BatchSlot {
+  std::vector<float> data;
+  std::vector<cv::Mat> frames;
+  std::vector<Geometry> geometry;
+  std::vector<simaai::neat::Sample> samples;
+  bool ready = false;
+};
+
+// --------------------------------------------------------------------------
+// configuration
+// --------------------------------------------------------------------------
+CliOptions parse_args(int argc, char** argv) {
+  CliOptions options;
+  options.config_path = sima_examples::default_config_path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR);
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--config") {
+      if (i + 1 >= argc) {
+        throw std::runtime_error("--config requires a path");
+      }
+      options.config_path = argv[++i];
+    } else if (arg == "--validate-config-only") {
+      options.validate_config_only = true;
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: " << argv[0] << " [--config <path>] [--validate-config-only]\n";
+      std::exit(0);
+    } else {
+      throw std::runtime_error("unknown argument: " + arg);
+    }
+  }
+  return options;
+}
+
+std::string strip_inline_comment(const std::string& line) {
+  bool in_single = false;
+  bool in_double = false;
+  std::string out;
+  out.reserve(line.size());
+  for (char c : line) {
+    if (c == '\'' && !in_double) {
+      in_single = !in_single;
+    } else if (c == '"' && !in_single) {
+      in_double = !in_double;
+    } else if (c == '#' && !in_single && !in_double) {
+      break;
+    }
+    out.push_back(c);
+  }
+  return out;
+}
+
+std::string unquote(std::string value) {
+  value = sima_examples::trim_copy(value);
+  if (value.size() >= 2 && ((value.front() == '"' && value.back() == '"') ||
+                            (value.front() == '\'' && value.back() == '\''))) {
+    return value.substr(1, value.size() - 2);
+  }
+  return value;
+}
+
+// ScalarConfig handles dotted scalar keys; the stream list needs its own pass.
+std::vector<std::string> parse_streams(const fs::path& config_path) {
+  std::ifstream input(config_path);
+  if (!input.is_open()) {
+    throw std::runtime_error("failed to open config file: " + config_path.string());
+  }
+
+  std::vector<std::string> streams;
+  bool in_streams = false;
+  int streams_indent = -1;
+  std::string raw_line;
+  while (std::getline(input, raw_line)) {
+    const std::string without_comment = strip_inline_comment(raw_line);
+    if (sima_examples::trim_copy(without_comment).empty()) {
+      continue;
+    }
+
+    int indent = 0;
+    while (indent < static_cast<int>(without_comment.size()) &&
+           (without_comment[static_cast<std::size_t>(indent)] == ' ' ||
+            without_comment[static_cast<std::size_t>(indent)] == '\t')) {
+      ++indent;
+    }
+    const std::string line = sima_examples::trim_copy(without_comment);
+
+    if (in_streams && indent <= streams_indent && line.rfind("- ", 0) != 0) {
+      in_streams = false;
+    }
+    if (!in_streams && line == "streams:") {
+      in_streams = true;
+      streams_indent = indent;
+      continue;
+    }
+    if (in_streams && line.rfind("- ", 0) == 0) {
+      const std::string value = unquote(line.substr(2));
+      if (value.empty()) {
+        throw std::runtime_error("streams entries must be non-empty strings");
+      }
+      streams.push_back(value);
+    }
+  }
+  if (streams.empty()) {
+    throw std::runtime_error("streams must list at least one RTSP URL");
+  }
+  return streams;
+}
+
+void validate_config(const AppConfig& cfg) {
+  sima_examples::require(!cfg.model_path.empty(), "model.path must be set");
+  sima_examples::require(!cfg.rtsp_urls.empty(), "streams must list at least one RTSP URL");
+  sima_examples::require(cfg.rtsp_urls.size() <= kMaxStreams,
+                         "this example supports up to 4 streams");
+  for (const auto& url : cfg.rtsp_urls) {
+    sima_examples::require(!url.empty() && url.front() != '<',
+                           "streams still contains a placeholder URL");
+  }
+  sima_examples::require(!cfg.insight_host.empty() && cfg.insight_host.front() != '<',
+                         "output.insight.host must be set");
+  sima_examples::require(cfg.score_threshold > 0.0 && cfg.score_threshold < 1.0,
+                         "inference.score_threshold must be between 0 and 1");
+  sima_examples::require(cfg.max_detections > 0, "inference.max_detections must be > 0");
+  sima_examples::require(cfg.frames >= 0, "inference.frames must be >= 0");
+  sima_examples::require(cfg.timeout_ms > 0, "runtime.timeout_ms must be > 0");
+  sima_examples::require(cfg.warmup_frames >= 0, "runtime.warmup_frames must be >= 0");
+  sima_examples::require(cfg.profile_interval > 0, "runtime.profile_interval must be > 0");
+  sima_examples::require(cfg.save_every >= 0, "output.save_every must be >= 0");
+  sima_examples::require(cfg.video_port_base > 0, "output.insight.video_port_base must be > 0");
+  sima_examples::require(cfg.metadata_port_base > 0,
+                         "output.insight.metadata_port_base must be > 0");
+}
+
+AppConfig load_app_config(const fs::path& config_path) {
+  const auto raw = sima_examples::ScalarConfig::load(config_path);
+  const auto default_labels =
+      fs::path(SIMANEAT_APPS_EXAMPLE_SOURCE_DIR).parent_path() / "common" / "coco_label.txt";
+
+  AppConfig cfg;
+  cfg.model_path = raw.string_or("model.path", "");
+  cfg.labels_path = raw.string_or("model.labels", default_labels.string());
+  cfg.rtsp_urls = parse_streams(config_path);
+  cfg.tcp = raw.bool_or("input.tcp", true);
+  cfg.latency_ms = raw.int_or("input.latency_ms", 100);
+  cfg.frames = raw.int_or("inference.frames", 0);
+  cfg.score_threshold = raw.double_or("inference.score_threshold", 0.35);
+  cfg.max_detections = raw.int_or("inference.max_detections", 100);
+  cfg.insight_host = raw.string_or("output.insight.host", "");
+  cfg.video_port_base = raw.int_or("output.insight.video_port_base", 9000);
+  cfg.metadata_port_base = raw.int_or("output.insight.metadata_port_base", 9100);
+  cfg.video_enabled = raw.bool_or("output.video_enabled", true);
+  cfg.debug_dir = raw.string_or("output.debug_dir", "");
+  cfg.save_every = raw.int_or("output.save_every", 0);
+  cfg.timeout_ms = raw.int_or("runtime.timeout_ms", 20000);
+  cfg.warmup_frames = raw.int_or("runtime.warmup_frames", 10);
+  cfg.profile = raw.bool_or("runtime.profile", false);
+  cfg.profile_interval = raw.int_or("runtime.profile_interval", 50);
+  validate_config(cfg);
+  return cfg;
+}
+
+std::vector<std::string> load_labels(const fs::path& labels_path) {
+  std::ifstream in(labels_path);
+  if (!in.good()) {
+    throw std::runtime_error("labels file does not exist: " + labels_path.string());
+  }
+  std::vector<std::string> labels;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) {
+      labels.push_back(line);
+    }
+  }
+  if (labels.empty()) {
+    throw std::runtime_error("labels file is empty: " + labels_path.string());
+  }
+  return labels;
+}
+
+// --------------------------------------------------------------------------
+// preprocessing
+// --------------------------------------------------------------------------
+// Aspect-preserving resize into net x net, pad 114, centered. The scaled pixels
+// are written straight into the batch lane as normalised RGB float32, so the
+// batch buffer is filled in place instead of being stacked from four freshly
+// allocated frames.
+Geometry letterbox_into(const cv::Mat& bgr, int net, float* dst) {
+  const double scale =
+      std::min(static_cast<double>(net) / bgr.cols, static_cast<double>(net) / bgr.rows);
+  const int new_w = static_cast<int>(std::lround(bgr.cols * scale));
+  const int new_h = static_cast<int>(std::lround(bgr.rows * scale));
+  const int dx = (net - new_w) / 2;
+  const int dy = (net - new_h) / 2;
+
+  cv::Mat lane(net, net, CV_32FC3, dst);
+  lane.setTo(cv::Scalar::all(static_cast<double>(kPadValue) / 255.0));
+
+  // Resize and colour-convert at the scaled size, not at the full canvas size.
+  cv::Mat resized;
+  cv::resize(bgr, resized, cv::Size(new_w, new_h), 0, 0, cv::INTER_LINEAR);
+  cv::cvtColor(resized, resized, cv::COLOR_BGR2RGB);
+  cv::Mat roi = lane(cv::Rect(dx, dy, new_w, new_h));
+  resized.convertTo(roi, CV_32FC3, 1.0 / 255.0);
+
+  return Geometry{scale, dx, dy};
+}
+
+// --------------------------------------------------------------------------
+// six model outputs -> heads -> detections (all on the CPU)
+// --------------------------------------------------------------------------
+// A single head plane for one lane: a dense [H, W, C] view over the output.
+struct HeadPlane {
+  const float* data = nullptr;
+  int grid = 0;
+  int channels = 0;
+
+  const float* cell(int row, int col) const {
+    return data + (static_cast<std::size_t>(row) * static_cast<std::size_t>(grid) +
+                   static_cast<std::size_t>(col)) *
+                      static_cast<std::size_t>(channels);
+  }
+};
+
+struct LaneHeads {
+  std::array<HeadPlane, kLevels> bbox;
+  std::array<HeadPlane, kLevels> cls;
+};
+
+// One model output, copied to the host. The MLA writes its heads into device
+// memory that `Tensor::data_ptr` cannot address, so each dispatch materialises
+// them once here and all lanes then read the same buffers.
+struct HeadTensor {
+  std::vector<float> data;
+  std::vector<int64_t> shape;
+};
+
+// Six [N,H,W,C] outputs -> the head planes of one lane, sorted by descending
+// grid so level 0 is the 80x80 map, matching the strides decode_lane derives.
+LaneHeads heads_from_outputs(const std::vector<HeadTensor>& outputs, int lane) {
+  std::vector<HeadPlane> bbox;
+  std::vector<HeadPlane> cls;
+  for (const auto& tensor : outputs) {
+    if (tensor.shape.size() != 4) {
+      throw std::runtime_error("expected [N,H,W,C] outputs, got rank " +
+                               std::to_string(tensor.shape.size()));
+    }
+    const int batch = static_cast<int>(tensor.shape[0]);
+    if (lane >= batch) {
+      throw std::runtime_error("lane " + std::to_string(lane) + " out of range for batch " +
+                               std::to_string(batch));
+    }
+    const int grid = static_cast<int>(tensor.shape[1]);
+    const int channels = static_cast<int>(tensor.shape[3]);
+    const std::size_t lane_stride =
+        static_cast<std::size_t>(grid) * static_cast<std::size_t>(tensor.shape[2]) *
+        static_cast<std::size_t>(channels);
+    if (tensor.data.size() < (static_cast<std::size_t>(lane) + 1) * lane_stride) {
+      throw std::runtime_error("output smaller than its declared shape");
+    }
+
+    HeadPlane plane;
+    plane.data = tensor.data.data() + static_cast<std::size_t>(lane) * lane_stride;
+    plane.grid = grid;
+    plane.channels = channels;
+
+    if (channels == kBboxChannels) {
+      bbox.push_back(plane);
+    } else if (channels == kClassChannels) {
+      cls.push_back(plane);
+    } else {
+      throw std::runtime_error("output with " + std::to_string(channels) +
+                               " channels is neither a bbox head nor a class head");
+    }
+  }
+  if (bbox.size() != kLevels || cls.size() != kLevels) {
+    throw std::runtime_error("expected 3 bbox and 3 class heads, got " +
+                             std::to_string(bbox.size()) + " and " + std::to_string(cls.size()));
+  }
+
+  const auto by_descending_grid = [](const HeadPlane& a, const HeadPlane& b) {
+    return a.grid > b.grid;
+  };
+  std::sort(bbox.begin(), bbox.end(), by_descending_grid);
+  std::sort(cls.begin(), cls.end(), by_descending_grid);
+
+  LaneHeads heads;
+  for (int level = 0; level < kLevels; ++level) {
+    if (bbox[static_cast<std::size_t>(level)].grid != cls[static_cast<std::size_t>(level)].grid) {
+      throw std::runtime_error("bbox and class grids disagree at level " + std::to_string(level));
+    }
+    heads.bbox[static_cast<std::size_t>(level)] = bbox[static_cast<std::size_t>(level)];
+    heads.cls[static_cast<std::size_t>(level)] = cls[static_cast<std::size_t>(level)];
+  }
+  return heads;
+}
+
+// YOLO26 reg_max=1: raw l/t/r/b distances plus class logits. No NMS — the
+// one-to-one head is already deduplicated, so detections are only ranked and
+// capped.
+//
+// The class heads hold 672 000 logits per frame, so the decode is dominated by
+// whatever runs across all of them. Sigmoid is monotonic, which means a cell
+// clears a probability threshold exactly when its logit clears the matching
+// logit threshold. Thresholding the raw logits keeps the exponential and the
+// per-cell argmax on the handful of surviving cells instead of the whole tensor.
+std::vector<objdet::Box> decode_lane(const LaneHeads& heads, int net, double score_threshold,
+                                     int max_detections) {
+  const float logit_threshold =
+      static_cast<float>(std::log(score_threshold / (1.0 - score_threshold)));
+  std::vector<objdet::Box> detections;
+
+  for (int level = 0; level < kLevels; ++level) {
+    const HeadPlane& box = heads.bbox[static_cast<std::size_t>(level)];
+    const HeadPlane& cls = heads.cls[static_cast<std::size_t>(level)];
+    const float stride = static_cast<float>(net) / static_cast<float>(box.grid);
+
+    for (int row = 0; row < cls.grid; ++row) {
+      for (int col = 0; col < cls.grid; ++col) {
+        const float* logits = cls.cell(row, col);
+        int best_class = 0;
+        float best_logit = logits[0];
+        for (int c = 1; c < cls.channels; ++c) {
+          if (logits[c] > best_logit) {
+            best_logit = logits[c];
+            best_class = c;
+          }
+        }
+        if (best_logit < logit_threshold) {
+          continue;
+        }
+
+        const float* ltrb = box.cell(row, col);
+        const float anchor_x = static_cast<float>(col) + 0.5f;
+        const float anchor_y = static_cast<float>(row) + 0.5f;
+
+        objdet::Box det;
+        det.score = 1.0f / (1.0f + std::exp(-std::clamp(best_logit, -30.0f, 30.0f)));
+        det.class_id = best_class;
+        det.x1 = (anchor_x - ltrb[0]) * stride;
+        det.y1 = (anchor_y - ltrb[1]) * stride;
+        det.x2 = (anchor_x + ltrb[2]) * stride;
+        det.y2 = (anchor_y + ltrb[3]) * stride;
+        detections.push_back(det);
+      }
+    }
+  }
+
+  std::sort(detections.begin(), detections.end(),
+            [](const objdet::Box& a, const objdet::Box& b) { return a.score > b.score; });
+  if (static_cast<int>(detections.size()) > max_detections) {
+    detections.resize(static_cast<std::size_t>(max_detections));
+  }
+  return detections;
+}
+
+// Undo the letterbox so boxes are in source-frame coordinates.
+std::vector<objdet::Box> to_original(const std::vector<objdet::Box>& detections,
+                                     const Geometry& geometry, int width, int height) {
+  std::vector<objdet::Box> mapped;
+  mapped.reserve(detections.size());
+  const auto map = [&geometry](float value, int offset, int limit) {
+    const double out = (static_cast<double>(value) - offset) / geometry.scale;
+    return static_cast<float>(std::clamp(out, 0.0, static_cast<double>(limit) - 1.0));
+  };
+  for (const auto& det : detections) {
+    objdet::Box box = det;
+    box.x1 = map(det.x1, geometry.dx, width);
+    box.y1 = map(det.y1, geometry.dy, height);
+    box.x2 = map(det.x2, geometry.dx, width);
+    box.y2 = map(det.y2, geometry.dy, height);
+    if (box.x2 > box.x1 && box.y2 > box.y1) {
+      mapped.push_back(box);
+    }
+  }
+  return mapped;
+}
+
+// --------------------------------------------------------------------------
+// runtime plumbing
+// --------------------------------------------------------------------------
+// RTSP source, depayload, parse and hardware H.264 decode to NV12, in one
+// group. The frames leave here and the batch is assembled by the app.
+simaai::neat::nodes::groups::RtspDecodedInputOptions
+build_source_options(const AppConfig& cfg, const std::string& url, int& width, int& height,
+                     int& fps) {
+  sima_examples::RtspStreamInfo probe;
+  sima_examples::RtspProbeOptions probe_options;
+  probe_options.payload_type = 96;
+  probe_options.latency_ms = cfg.latency_ms;
+  probe_options.rtsp_tcp = cfg.tcp;
+  (void)sima_examples::probe_rtsp_stream_info(url, probe_options, probe);
+  sima_examples::require(probe.width > 0 && probe.height > 0,
+                         "failed to probe RTSP frame size: " + url);
+  width = probe.width;
+  height = probe.height;
+  fps = probe.fps > 0 ? probe.fps : 30;
+
+  simaai::neat::nodes::groups::RtspDecodedInputOptions opt;
+  opt.url = url;
+  opt.latency_ms = cfg.latency_ms;
+  opt.tcp = cfg.tcp;
+  opt.payload_type = 96;
+  opt.insert_queue = true;
+  opt.out_format = simaai::neat::FormatTag::NV12;
+  opt.decoder_name = "decoder_" + std::to_string(width) + "x" + std::to_string(height);
+  opt.decoder_raw_output = true;
+  opt.auto_caps_from_stream = true;
+  opt.fallback_h264_width = width;
+  opt.fallback_h264_height = height;
+  opt.fallback_h264_fps = fps;
+  opt.source_fps = fps;
+  opt.output_caps.enable = true;
+  opt.output_caps.format = simaai::neat::FormatTag::NV12;
+  opt.output_caps.width = width;
+  opt.output_caps.height = height;
+  opt.output_caps.fps = fps;
+  opt.output_caps.memory = simaai::neat::CapsMemory::Any;
+  return opt;
+}
+
+simaai::neat::InputOptions h264_decode_input_options() {
+  simaai::neat::InputOptions options;
+  options.payload_type = simaai::neat::PayloadType::Encoded;
+  options.format = simaai::neat::FormatTag::H264;
+  options.memory_policy = simaai::neat::InputMemoryPolicy::Ev74;
+  return options;
+}
+
+simaai::neat::InputOptions h264_video_input_options() {
+  auto options = h264_decode_input_options();
+  options.memory_policy = simaai::neat::InputMemoryPolicy::SystemMemory;
+  return options;
+}
+
+simaai::neat::Graph build_encoded_source_graph(
+    int index, const simaai::neat::nodes::groups::RtspDecodedInputOptions& options) {
+  simaai::neat::nodes::groups::RtspEncodedInputOptions encoded;
+  encoded.url = options.url;
+  encoded.codec = simaai::neat::nodes::groups::RtspCodec::H264;
+  encoded.latency_ms = options.latency_ms;
+  encoded.tcp = options.tcp;
+  encoded.source_fps = options.source_fps;
+  encoded.fallback_h264_width = options.fallback_h264_width;
+  encoded.fallback_h264_height = options.fallback_h264_height;
+
+  simaai::neat::Graph source("rtsp_source_" + std::to_string(index));
+  source.add(simaai::neat::nodes::groups::RtspEncodedInput(encoded));
+  return source;
+}
+
+simaai::neat::Graph build_decode_graph(
+    int index, const simaai::neat::nodes::groups::RtspDecodedInputOptions& options) {
+  simaai::neat::SimaDecodeOptions decode_options;
+  decode_options.type = simaai::neat::SimaDecodeType::H264;
+  decode_options.sima_allocator_type = options.sima_allocator_type;
+  decode_options.out_format = options.out_format;
+  decode_options.decoder_name = options.decoder_name;
+  decode_options.raw_output = options.decoder_raw_output;
+  decode_options.dec_width = options.fallback_h264_width;
+  decode_options.dec_height = options.fallback_h264_height;
+  decode_options.dec_fps = options.source_fps;
+
+  simaai::neat::Graph decode("decode_" + std::to_string(index));
+  decode.connect(simaai::neat::nodes::Input("decode_h264", h264_decode_input_options()),
+                 simaai::neat::nodes::SimaDecode(decode_options));
+  decode.add(simaai::neat::nodes::CapsRaw(
+      "NV12", options.output_caps.width, options.output_caps.height, options.output_caps.fps,
+      options.output_caps.memory));
+  decode.add(simaai::neat::nodes::Output("frame_" + std::to_string(index),
+                                         simaai::neat::OutputOptions::Latest()));
+  return decode;
+}
+
+simaai::neat::Graph build_video_sender_graph(
+    int index, const simaai::neat::nodes::groups::VideoSenderOptions& options) {
+  simaai::neat::Graph video("video_sender_" + std::to_string(index));
+  video.connect(simaai::neat::nodes::Input("video_h264", h264_video_input_options()),
+                simaai::neat::nodes::groups::VideoSender(options));
+  return video;
+}
+
+simaai::neat::GraphLinkOptions realtime_link(int index, int queue_depth = 3) {
+  simaai::neat::GraphLinkOptions link;
+  link.policy = simaai::neat::GraphLinkPolicy::RealtimeLatestByStream;
+  link.queue_depth = queue_depth;
+  link.stream_id = "stream" + std::to_string(index);
+  return link;
+}
+
+simaai::neat::RunOptions build_run_options() {
+  simaai::neat::RunOptions run_options;
+  run_options.preset = simaai::neat::RunPreset::Realtime;
+  run_options.queue_depth = 4;
+  run_options.overflow_policy = simaai::neat::OverflowPolicy::KeepLatest;
+  run_options.output_memory = simaai::neat::OutputMemory::ZeroCopy;
+  return run_options;
+}
+
+// Block for one frame, then drain so the caller always gets the newest.
+bool pull_latest(simaai::neat::Run& run, const std::string& output_name, int timeout_ms,
+                 simaai::neat::Sample& out) {
+  simaai::neat::PullError pull_error;
+  auto status = run.pull(output_name, timeout_ms, out, &pull_error);
+  if (status == simaai::neat::PullStatus::Timeout ||
+      status == simaai::neat::PullStatus::Closed) {
+    return false;
+  }
+  if (status != simaai::neat::PullStatus::Ok) {
+    throw std::runtime_error("failed to pull " + output_name + ": " + pull_error.message);
+  }
+  for (;;) {
+    simaai::neat::Sample newer;
+    status = run.pull(output_name, 0, newer, &pull_error);
+    if (status != simaai::neat::PullStatus::Ok) {
+      return true;
+    }
+    out = std::move(newer);
+  }
+}
+
+// Keeps one batch in flight so ingest overlaps inference.
+//
+// A frame pull blocks until the source produces its next picture — about 33 ms
+// at 30 fps — and the letterbox costs a few ms more per lane. Doing that
+// between dispatches would serialize it with the MLA and the decode. Instead
+// the lanes for the next batch are filled on worker threads while the caller
+// works on the current one.
+class BatchPrefetcher {
+public:
+  BatchPrefetcher(simaai::neat::Run& run, std::vector<StreamRuntime>& streams, int net,
+                  int batch_size, int timeout_ms)
+      : run_(run), streams_(streams), net_(net), batch_size_(batch_size), timeout_ms_(timeout_ms) {
+    const std::size_t lane_floats =
+        static_cast<std::size_t>(net) * static_cast<std::size_t>(net) * 3U;
+    for (auto& slot : slots_) {
+      slot.data.assign(lane_floats * static_cast<std::size_t>(batch_size), 0.0f);
+      slot.frames.resize(streams.size());
+      slot.geometry.resize(streams.size());
+      slot.samples.resize(streams.size());
+    }
+    submit(0);
+  }
+
+  // Hand back the filled batch and immediately start filling the other.
+  BatchSlot* next() {
+    pending_.wait();
+    BatchSlot* ready = &slots_[static_cast<std::size_t>(slot_)];
+    slot_ ^= 1;
+    submit(slot_);
+    return ready->ready ? ready : nullptr;
+  }
+
+  // The in-flight fill has lane threads sitting inside run.pull, so it has to
+  // finish before the caller tears the Run down.
+  void close() {
+    closed_ = true;
+    if (pending_.valid()) {
+      pending_.wait();
+    }
+  }
+
+private:
+  void submit(int slot_index) {
+    pending_ = std::async(std::launch::async, [this, slot_index] {
+      fill(slots_[static_cast<std::size_t>(slot_index)]);
+    });
+  }
+
+  void fill(BatchSlot& slot) {
+    const std::size_t lane_floats =
+        static_cast<std::size_t>(net_) * static_cast<std::size_t>(net_) * 3U;
+
+    std::vector<std::future<bool>> lanes;
+    lanes.reserve(streams_.size());
+    for (auto& stream : streams_) {
+      lanes.push_back(std::async(std::launch::async, [this, &slot, &stream, lane_floats] {
+        return fill_lane(slot, stream, lane_floats);
+      }));
+    }
+    bool ok = true;
+    for (auto& lane : lanes) {
+      ok = lane.get() && ok;
+    }
+    slot.ready = ok;
+
+    // Fewer streams than the compiled batch: repeat the last lane so the MLA
+    // still runs exactly one dispatch.
+    for (std::size_t lane = streams_.size(); lane < static_cast<std::size_t>(batch_size_); ++lane) {
+      std::copy_n(slot.data.data() + (streams_.size() - 1) * lane_floats, lane_floats,
+                  slot.data.data() + lane * lane_floats);
+    }
+  }
+
+  bool fill_lane(BatchSlot& slot, StreamRuntime& stream, std::size_t lane_floats) {
+    if (closed_) {
+      return false;
+    }
+    const auto lane = static_cast<std::size_t>(stream.index);
+    simaai::neat::Sample sample;
+    if (!pull_latest(run_, "frame_" + std::to_string(stream.index), timeout_ms_, sample)) {
+      return false;
+    }
+    const auto tensors = simaai::neat::tensors_from_sample(sample, false);
+    if (tensors.empty()) {
+      return false;
+    }
+    cv::Mat bgr;
+    std::string err;
+    if (!sima_examples::nv12_to_bgr(tensors.front(), bgr, err)) {
+      throw std::runtime_error("failed to convert decoded frame: " + err);
+    }
+    slot.geometry[lane] = letterbox_into(bgr, net_, slot.data.data() + lane * lane_floats);
+    slot.frames[lane] = std::move(bgr);
+    slot.samples[lane] = std::move(sample);
+    return true;
+  }
+
+  simaai::neat::Run& run_;
+  std::vector<StreamRuntime>& streams_;
+  int net_ = 0;
+  int batch_size_ = 0;
+  int timeout_ms_ = 0;
+  std::array<BatchSlot, 2> slots_;
+  int slot_ = 0;
+  std::future<void> pending_;
+  std::atomic<bool> closed_{false};
+};
+
+// --------------------------------------------------------------------------
+// output
+// --------------------------------------------------------------------------
+void send_metadata(StreamRuntime& stream, const simaai::neat::Sample& sample,
+                   const std::vector<objdet::Box>& boxes,
+                   const std::vector<std::string>& labels) {
+  std::vector<sima_examples::MetadataBox> metadata_boxes;
+  metadata_boxes.reserve(boxes.size());
+  int object_index = 1;
+  for (const auto& box : boxes) {
+    sima_examples::MetadataBox obj;
+    obj.id = "obj_" + std::to_string(object_index++);
+    obj.label = (box.class_id >= 0 && box.class_id < static_cast<int>(labels.size()))
+                    ? labels[static_cast<std::size_t>(box.class_id)]
+                    : "unknown";
+    obj.confidence = box.score;
+    obj.x = box.x1;
+    obj.y = box.y1;
+    obj.w = box.x2 - box.x1;
+    obj.h = box.y2 - box.y1;
+    metadata_boxes.push_back(obj);
+  }
+  const std::string data_json = sima_examples::metadata_boxes_data_json("objects", metadata_boxes);
+  const int64_t timestamp_ms = sample.pts_ns >= 0 ? sample.pts_ns / 1'000'000 : -1;
+  const std::string frame_id = sample.frame_id >= 0 ? std::to_string(sample.frame_id) : "";
+  nlohmann::json message;
+  message["type"] = "object-detection";
+  message["data"] = nlohmann::json::parse(data_json);
+  message["timestamp"] = timestamp_ms;
+  message["frame_id"] = frame_id;
+  if (sample.pts_ns >= 0) {
+    const auto ticks =
+        (static_cast<__int128>(sample.pts_ns) * 90'000) / 1'000'000'000;
+    message["_insight"]["rtp_timestamp"] =
+        static_cast<std::uint32_t>(static_cast<std::uint64_t>(ticks));
+  }
+  std::string err;
+  if (!stream.metadata_sender->send_raw_json(message.dump(), &err)) {
+    std::cerr << "[warn] stream " << stream.index << " metadata send failed: " << err << "\n";
+  }
+}
+
+void save_debug_frame(const AppConfig& cfg, const StreamRuntime& stream, const cv::Mat& bgr,
+                      const std::vector<objdet::Box>& boxes) {
+  if (cfg.debug_dir.empty() || cfg.save_every <= 0 || stream.processed % cfg.save_every != 0) {
+    return;
+  }
+  cv::Mat frame = bgr.clone();
+  objdet::draw_boxes(frame, boxes, cfg.score_threshold, cv::Scalar(0, 255, 0), "");
+  const auto out_path = cfg.debug_dir / ("stream_" + std::to_string(stream.index) + "_frame_" +
+                                         std::to_string(stream.processed) + ".jpg");
+  if (!cv::imwrite(out_path.string(), frame)) {
+    std::cerr << "[warn] failed to write " << out_path.string() << "\n";
+  }
+}
+
+// --------------------------------------------------------------------------
+// application
+// --------------------------------------------------------------------------
+void build_streams(const AppConfig& cfg, simaai::neat::Graph& graph,
+                   std::vector<StreamRuntime>& streams) {
+  for (std::size_t index = 0; index < cfg.rtsp_urls.size(); ++index) {
+    StreamRuntime stream;
+    stream.index = static_cast<int>(index);
+    stream.url = cfg.rtsp_urls[index];
+    stream.source_options =
+        build_source_options(cfg, stream.url, stream.frame_w, stream.frame_h, stream.fps);
+
+    simaai::neat::MetadataSenderOptions metadata_options;
+    metadata_options.host = cfg.insight_host;
+    metadata_options.channel = stream.index;
+    metadata_options.metadata_port_base = cfg.metadata_port_base;
+    std::string metadata_err;
+    stream.metadata_sender =
+        std::make_unique<simaai::neat::MetadataSender>(metadata_options, &metadata_err);
+    sima_examples::require(stream.metadata_sender->ok(), metadata_err);
+
+    auto source = build_encoded_source_graph(stream.index, stream.source_options);
+    auto decoder = build_decode_graph(stream.index, stream.source_options);
+    if (cfg.video_enabled) {
+      auto branch = simaai::neat::graphs::Branch(
+          "encoded_" + std::to_string(stream.index), {"decode_h264", "video_h264"});
+      graph.connect(source, branch);
+      graph.connect(branch, decoder, realtime_link(stream.index));
+
+      auto video_options =
+          simaai::neat::nodes::groups::VideoSenderOptions::Passthrough(
+              simaai::neat::nodes::groups::RtspCodec::H264);
+      video_options.host = cfg.insight_host;
+      video_options.channel = stream.index;
+      video_options.video_port_base = cfg.video_port_base;
+      video_options.async = true;
+      stream.video_port = video_options.video_port();
+      graph.connect(branch, build_video_sender_graph(stream.index, video_options),
+                    realtime_link(stream.index));
+    } else {
+      graph.connect(source, decoder, realtime_link(stream.index));
+    }
+
+    std::cout << "[stream " << stream.index << "] rtsp=" << stream.url << " " << stream.frame_w
+              << "x" << stream.frame_h << "@" << stream.fps << " video=";
+    if (cfg.video_enabled) {
+      std::cout << stream.video_port;
+    } else {
+      std::cout << "disabled";
+    }
+    std::cout << " metadata=" << stream.metadata_sender->metadata_port() << "\n";
+    streams.push_back(std::move(stream));
+  }
+}
+
+bool all_streams_done(const std::vector<StreamRuntime>& streams, int frame_limit) {
+  if (frame_limit <= 0) {
+    return false;
+  }
+  return std::all_of(streams.begin(), streams.end(), [frame_limit](const StreamRuntime& stream) {
+    return stream.processed >= frame_limit;
+  });
+}
+
+void run_app(const AppConfig& cfg) {
+  g_stop_requested = 0;
+  auto previous_sigint = std::signal(SIGINT, request_stop);
+  if (!cfg.debug_dir.empty()) {
+    fs::create_directories(cfg.debug_dir);
+  }
+
+  const auto labels = load_labels(cfg.labels_path);
+  simaai::neat::Model model(cfg.model_path);
+
+  const auto input_specs = model.input_specs();
+  sima_examples::require(!input_specs.empty(), "model exposes no inputs");
+  const auto& input_shape = input_specs.front().shape;
+  if (input_shape.size() != 4) {
+    throw std::runtime_error("this example needs a batched model; compile with --batch_size 4");
+  }
+  const int batch_size = static_cast<int>(input_shape[0]);
+  const int net = static_cast<int>(input_shape[1]);
+  if (batch_size != kMaxStreams) {
+    throw std::runtime_error("model batch size is " + std::to_string(batch_size) +
+                             "; this example requires batch size " +
+                             std::to_string(kMaxStreams));
+  }
+
+  const auto output_specs = model.output_specs();
+  if (static_cast<int>(output_specs.size()) != kExpectedOutputs) {
+    throw std::runtime_error("expected " + std::to_string(kExpectedOutputs) +
+                             " YOLO26 head tensors, model has " +
+                             std::to_string(output_specs.size()));
+  }
+  std::cout << "Model loaded: batch=" << batch_size << " net=" << net
+            << " heads=" << output_specs.size() << "\n";
+
+  simaai::neat::Graph graph;
+  std::vector<StreamRuntime> streams;
+  streams.reserve(cfg.rtsp_urls.size());
+  build_streams(cfg, graph, streams);
+  auto run = graph.build(build_run_options());
+
+  ProfileWindow profile;
+  profile.enabled = cfg.profile;
+  profile.streams = static_cast<int>(streams.size());
+  profile.interval = cfg.profile_interval;
+
+  BatchPrefetcher prefetcher(run, streams, net, batch_size, cfg.timeout_ms);
+
+  while (g_stop_requested == 0 && !all_streams_done(streams, cfg.frames)) {
+    const double start = sima_examples::time_ms();
+    BatchSlot* batch = prefetcher.next();
+    if (batch == nullptr) {
+      const auto last_error = run.last_error();
+      if (!last_error.empty()) {
+        break;
+      }
+      std::cerr << "[warn] timed out waiting for frames\n";
+      continue;
+    }
+    const double batched = sima_examples::time_ms();
+
+    // One dispatch for all lanes.
+    const auto input = simaai::neat::Tensor::from_vector(
+        batch->data, {batch_size, net, net, 3}, simaai::neat::TensorMemory::EV74);
+    const auto outputs = model.run(simaai::neat::TensorList{input}, cfg.timeout_ms);
+    if (static_cast<int>(outputs.size()) != kExpectedOutputs) {
+      throw std::runtime_error("expected " + std::to_string(kExpectedOutputs) +
+                               " head tensors, got " + std::to_string(outputs.size()));
+    }
+    // Materialise the heads on the host once per dispatch, not once per lane.
+    std::vector<HeadTensor> heads;
+    heads.reserve(outputs.size());
+    for (const auto& tensor : outputs) {
+      heads.push_back(HeadTensor{sima_examples::tensor_to_floats(tensor), tensor.shape});
+    }
+    const double inferred = sima_examples::time_ms();
+
+    // Each lane's heads are an independent read of the same output tensors.
+    std::vector<std::future<std::vector<objdet::Box>>> lanes;
+    lanes.reserve(streams.size());
+    for (const auto& stream : streams) {
+      const int index = stream.index;
+      const int frame_w = stream.frame_w;
+      const int frame_h = stream.frame_h;
+      lanes.push_back(std::async(std::launch::async, [&, index, frame_w, frame_h] {
+        const auto lane_heads = heads_from_outputs(heads, index);
+        auto detections = decode_lane(lane_heads, net, cfg.score_threshold, cfg.max_detections);
+        return to_original(detections, batch->geometry[static_cast<std::size_t>(index)], frame_w,
+                           frame_h);
+      }));
+    }
+    std::vector<std::vector<objdet::Box>> per_stream;
+    per_stream.reserve(lanes.size());
+    for (auto& lane : lanes) {
+      per_stream.push_back(lane.get());
+    }
+    const double decoded = sima_examples::time_ms();
+
+    int found = 0;
+    for (std::size_t i = 0; i < streams.size(); ++i) {
+      auto& stream = streams[i];
+      const auto& detections = per_stream[i];
+      found += static_cast<int>(detections.size());
+      ++stream.processed;
+      if (stream.processed <= cfg.warmup_frames) {
+        continue;
+      }
+      const auto lane = static_cast<std::size_t>(stream.index);
+      const auto& sample = batch->samples[lane];
+      const auto& frame = batch->frames[lane];
+      send_metadata(stream, sample, detections, labels);
+      save_debug_frame(cfg, stream, frame, detections);
+    }
+    profile.add(batched - start, inferred - batched, decoded - inferred,
+                sima_examples::time_ms() - decoded, found);
+  }
+
+  profile.flush();
+  prefetcher.close();
+  run.close();
+  for (auto& stream : streams) {
+    std::cout << "[stream " << stream.index << "] processed=" << stream.processed << "\n";
+  }
+  std::signal(SIGINT, previous_sigint);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  try {
+    const CliOptions cli = parse_args(argc, argv);
+    if (!fs::exists(cli.config_path)) {
+      std::cerr << "Error: config file not found: " << cli.config_path << "\n";
+      return 2;
+    }
+
+    const AppConfig cfg = load_app_config(cli.config_path);
+    if (cli.validate_config_only) {
+      std::cout << "Config validated: " << cli.config_path << " (streams=" << cfg.rtsp_urls.size()
+                << ", score_threshold=" << cfg.score_threshold
+                << ", max_detections=" << cfg.max_detections << ")\n";
+      return 0;
+    }
+    run_app(cfg);
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "[ERR] " << e.what() << "\n";
+    return 1;
+  }
+}

--- a/examples/object-detection/yolo26-batch4-detector/src/python/main.py
+++ b/examples/object-detection/yolo26-batch4-detector/src/python/main.py
@@ -1,0 +1,974 @@
+"""Batch-4 YOLO26 object detection over four Insight RTSP streams.
+
+One frame is taken from each stream and the four are submitted to the MLA as a
+single `[4, 640, 640, 3]` batch, so four streams cost one dispatch instead of
+four. The six YOLO26 heads come back with a leading batch axis, are decoded per
+lane on the CPU, and each stream's detections are published to Insight on its
+own channel.
+
+Flow: RTSP ingest -> decode to NV12 -> letterbox into a batch lane ->
+one MLA dispatch -> per-lane head decode -> Insight video + metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+import glob
+import json
+from pathlib import Path
+import sys
+import time
+
+import yaml
+
+DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "common" / "config.yaml"
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+# YOLO26 emits three levels, each as a bbox head and a class head.
+LEVELS = 3
+EXPECTED_OUTPUTS = 2 * LEVELS
+BBOX_CHANNELS = 4
+CLASS_CHANNELS = 80
+PAD_VALUE = 114
+MAX_STREAMS = 4
+
+cv2 = None
+np = None
+pyneat = None
+
+
+# --------------------------------------------------------------------------
+# configuration
+# --------------------------------------------------------------------------
+@dataclass(frozen=True)
+class AppConfig:
+    model_path: str
+    labels_path: Path
+    rtsp_urls: list[str]
+    tcp: bool = True
+    latency_ms: int = 100
+    frames: int = 0
+    score_threshold: float = 0.35
+    max_detections: int = 100
+    insight_host: str = ""
+    video_port_base: int = 9000
+    metadata_port_base: int = 9100
+    video_enabled: bool = True
+    debug_dir: str = ""
+    save_every: int = 0
+    timeout_ms: int = 20000
+    warmup_frames: int = 10
+    profile: bool = False
+    profile_interval: int = 50
+
+
+def section(raw: dict, key: str) -> dict:
+    value = raw.get(key) or {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a mapping")
+    return value
+
+
+def string_or(raw: dict, key: str, default: str = "") -> str:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def int_or(raw: dict, key: str, default: int) -> int:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def float_or(raw: dict, key: str, default: float) -> float:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{key} must be numeric")
+    return float(value)
+
+
+def bool_or(raw: dict, key: str, default: bool) -> bool:
+    value = raw.get(key, default)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be true or false")
+    return value
+
+
+def resolve(path_str: str) -> Path:
+    path = Path(path_str)
+    return path if path.is_absolute() else (REPO_ROOT / path)
+
+
+def validate_config(cfg: AppConfig) -> None:
+    if not cfg.model_path:
+        raise ValueError("model.path must be set")
+    if not cfg.rtsp_urls:
+        raise ValueError("streams must list at least one RTSP URL")
+    if len(cfg.rtsp_urls) > MAX_STREAMS:
+        raise ValueError(f"this example supports up to {MAX_STREAMS} streams")
+    if any(not url or url.startswith("<") for url in cfg.rtsp_urls):
+        raise ValueError("streams still contains a placeholder URL")
+    if not cfg.insight_host or cfg.insight_host.startswith("<"):
+        raise ValueError("output.insight.host must be set")
+    if not 0.0 < cfg.score_threshold < 1.0:
+        raise ValueError("inference.score_threshold must be between 0 and 1")
+    if cfg.max_detections <= 0:
+        raise ValueError("inference.max_detections must be > 0")
+    if cfg.frames < 0:
+        raise ValueError("inference.frames must be >= 0")
+    if cfg.timeout_ms <= 0:
+        raise ValueError("runtime.timeout_ms must be > 0")
+    if cfg.warmup_frames < 0:
+        raise ValueError("runtime.warmup_frames must be >= 0")
+    if cfg.profile_interval <= 0:
+        raise ValueError("runtime.profile_interval must be > 0")
+    if cfg.save_every < 0:
+        raise ValueError("output.save_every must be >= 0")
+    if cfg.video_port_base <= 0:
+        raise ValueError("output.insight.video_port_base must be > 0")
+    if cfg.metadata_port_base <= 0:
+        raise ValueError("output.insight.metadata_port_base must be > 0")
+
+
+def load_app_config(path: Path) -> AppConfig:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("config root must be a mapping")
+
+    model = section(raw, "model")
+    source = section(raw, "input")
+    inference = section(raw, "inference")
+    output = section(raw, "output")
+    insight = section(output, "insight")
+    runtime = section(raw, "runtime")
+
+    streams = raw.get("streams") or []
+    if not isinstance(streams, list) or not all(isinstance(url, str) for url in streams):
+        raise ValueError("streams must be a list of RTSP URLs")
+
+    default_labels = Path(__file__).resolve().parents[1] / "common" / "coco_label.txt"
+    cfg = AppConfig(
+        model_path=string_or(model, "path"),
+        labels_path=resolve(string_or(model, "labels", str(default_labels))),
+        rtsp_urls=list(streams),
+        tcp=bool_or(source, "tcp", True),
+        latency_ms=int_or(source, "latency_ms", 100),
+        frames=int_or(inference, "frames", 0),
+        score_threshold=float_or(inference, "score_threshold", 0.35),
+        max_detections=int_or(inference, "max_detections", 100),
+        insight_host=string_or(insight, "host"),
+        video_port_base=int_or(insight, "video_port_base", 9000),
+        metadata_port_base=int_or(insight, "metadata_port_base", 9100),
+        video_enabled=bool_or(output, "video_enabled", True),
+        debug_dir=string_or(output, "debug_dir"),
+        save_every=int_or(output, "save_every", 0),
+        timeout_ms=int_or(runtime, "timeout_ms", 20000),
+        warmup_frames=int_or(runtime, "warmup_frames", 10),
+        profile=bool_or(runtime, "profile", False),
+        profile_interval=int_or(runtime, "profile_interval", 50),
+    )
+    validate_config(cfg)
+    return cfg
+
+
+def load_labels(path: Path) -> list[str]:
+    if not path.is_file():
+        raise RuntimeError(f"labels file does not exist: {path}")
+    labels = [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    labels = [label for label in labels if label]
+    if not labels:
+        raise RuntimeError(f"labels file is empty: {path}")
+    return labels
+
+
+# --------------------------------------------------------------------------
+# preprocessing
+# --------------------------------------------------------------------------
+def nv12_to_rgb(tensor, out):
+    """Decoded NV12 straight to RGB in a caller-owned buffer.
+
+    RGB is what both the MLA input and the Insight video sender want, so the
+    frame is converted once here and never touched again.
+    """
+    width = tensor_dim(tensor, "width")
+    height = tensor_dim(tensor, "height")
+    payload = np.frombuffer(tensor.contiguous().copy_payload_bytes(), dtype=np.uint8)
+    expected = width * height * 3 // 2
+    if payload.size < expected:
+        raise RuntimeError(f"NV12 payload too small: {payload.size} < {expected}")
+    nv12 = payload[:expected].reshape((height * 3 // 2, width))
+    cv2.cvtColor(nv12, cv2.COLOR_YUV2RGB_NV12, dst=out)
+    return out
+
+
+def letterbox_into(rgb, lane, net: int):
+    """Aspect-preserving resize into one batch lane, pad 114, centered.
+
+    The scaled pixels are written directly into the lane as normalized float32,
+    so the batch tensor is filled in place instead of being stacked from four
+    freshly allocated frames.
+    """
+    height, width = rgb.shape[:2]
+    scale = min(net / width, net / height)
+    new_w, new_h = round(width * scale), round(height * scale)
+    dx, dy = (net - new_w) // 2, (net - new_h) // 2
+    lane.fill(PAD_VALUE / 255.0)
+    resized = cv2.resize(rgb, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+    np.multiply(
+        resized,
+        np.float32(1.0 / 255.0),
+        out=lane[dy:dy + new_h, dx:dx + new_w],
+        dtype=np.float32,
+    )
+    return scale, dx, dy
+
+
+# --------------------------------------------------------------------------
+# postprocessing
+# --------------------------------------------------------------------------
+def heads_from_outputs(arrays: list, lane: int) -> dict:
+    """Six `[N, H, W, C]` outputs -> `{head_name: [H, W, C]}` for one lane.
+
+    Heads are matched by shape, not by output order: 4 channels is a bbox head,
+    80 a class head, and the grid size orders the three levels. Sorted by
+    descending grid so level 0 is the 80x80 map, matching the strides
+    `decode_heads` derives from the grid size.
+    """
+    bbox, cls = [], []
+    for array in arrays:
+        if array.ndim != 4:
+            raise RuntimeError(f"expected [N,H,W,C] outputs, got {array.shape}")
+        if lane >= array.shape[0]:
+            raise RuntimeError(f"lane {lane} out of range for output {array.shape}")
+        plane = array[lane]
+        channels = plane.shape[2]
+        if channels == BBOX_CHANNELS:
+            bbox.append(plane)
+        elif channels == CLASS_CHANNELS:
+            cls.append(plane)
+        else:
+            raise RuntimeError(
+                f"output with {channels} channels is neither a bbox head "
+                f"({BBOX_CHANNELS}) nor a class head ({CLASS_CHANNELS})"
+            )
+    if len(bbox) != LEVELS or len(cls) != LEVELS:
+        raise RuntimeError(
+            f"expected {LEVELS} bbox and {LEVELS} class heads, got {len(bbox)} and {len(cls)}"
+        )
+    bbox.sort(key=lambda plane: -plane.shape[0])
+    cls.sort(key=lambda plane: -plane.shape[0])
+
+    heads = {}
+    for level in range(LEVELS):
+        if bbox[level].shape[:2] != cls[level].shape[:2]:
+            raise RuntimeError(
+                f"level {level} bbox grid {bbox[level].shape[:2]} does not match "
+                f"class grid {cls[level].shape[:2]}"
+            )
+        heads[f"bbox_{level}"] = bbox[level]
+        heads[f"class_logit_{level}"] = cls[level]
+    return heads
+
+
+def decode_heads(heads: dict, net: int, score_threshold: float, max_detections: int) -> list[dict]:
+    """YOLO26 reg_max=1: raw l/t/r/b distances plus class logits. No NMS.
+
+    The one-to-one head is already deduplicated, so detections are only ranked
+    by score and capped.
+
+    The class heads hold 672 000 logits per frame, so the decode is dominated by
+    whatever runs across all of them. Sigmoid is monotonic, which means a cell
+    clears a probability threshold exactly when its logit clears the matching
+    logit threshold. Thresholding the raw logits keeps the exponential and the
+    per-cell argmax on the handful of surviving cells instead of the whole
+    tensor, and the box arithmetic is done once per level as array operations.
+    """
+    logit_threshold = float(np.log(score_threshold / (1.0 - score_threshold)))
+    detections = []
+    for level in range(LEVELS):
+        box = heads[f"bbox_{level}"]
+        cls = heads[f"class_logit_{level}"]
+        stride = net / box.shape[0]
+
+        best_logit = cls.max(-1)
+        rows, cols = np.nonzero(best_logit >= logit_threshold)
+        if rows.size == 0:
+            continue
+
+        scores = 1.0 / (1.0 + np.exp(-np.clip(best_logit[rows, cols], -30.0, 30.0)))
+        class_ids = cls[rows, cols].argmax(-1)
+        ltrb = box[rows, cols]
+        anchor_x = cols + 0.5
+        anchor_y = rows + 0.5
+        x1 = (anchor_x - ltrb[:, 0]) * stride
+        y1 = (anchor_y - ltrb[:, 1]) * stride
+        x2 = (anchor_x + ltrb[:, 2]) * stride
+        y2 = (anchor_y + ltrb[:, 3]) * stride
+
+        detections.extend(
+            {
+                "score": float(s),
+                "class_id": int(c),
+                "x1": float(a),
+                "y1": float(b),
+                "x2": float(cc),
+                "y2": float(dd),
+            }
+            for s, c, a, b, cc, dd in zip(
+                scores.tolist(), class_ids.tolist(),
+                x1.tolist(), y1.tolist(), x2.tolist(), y2.tolist(),
+            )
+        )
+    detections.sort(key=lambda d: d["score"], reverse=True)
+    return detections[:max_detections]
+
+
+def to_original(detections: list[dict], scale: float, dx: int, dy: int, width: int, height: int):
+    """Undo the letterbox so boxes are in source-frame coordinates."""
+    mapped = []
+    for det in detections:
+        x1 = min(max((det["x1"] - dx) / scale, 0.0), width - 1.0)
+        y1 = min(max((det["y1"] - dy) / scale, 0.0), height - 1.0)
+        x2 = min(max((det["x2"] - dx) / scale, 0.0), width - 1.0)
+        y2 = min(max((det["y2"] - dy) / scale, 0.0), height - 1.0)
+        if x2 <= x1 or y2 <= y1:
+            continue
+        mapped.append({**det, "x1": x1, "y1": y1, "x2": x2, "y2": y2})
+    return mapped
+
+
+# --------------------------------------------------------------------------
+# runtime plumbing
+# --------------------------------------------------------------------------
+def load_runtime_dependencies() -> None:
+    global cv2, np, pyneat
+    if pyneat is not None:
+        return
+    for path in glob.glob("/usr/lib/python3*/dist-packages"):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    import cv2 as cv2_module
+    import numpy as np_module
+    import pyneat as pyneat_module
+
+    cv2, np, pyneat = cv2_module, np_module, pyneat_module
+
+
+def time_ms() -> float:
+    return time.perf_counter() * 1000.0
+
+
+def tensor_dim(tensor, name: str) -> int:
+    value = getattr(tensor, name)
+    return int(value() if callable(value) else value)
+
+
+def first_tensor(sample):
+    if sample is None:
+        return None
+    if sample.kind == pyneat.SampleKind.Tensor and sample.tensor is not None:
+        return sample.tensor
+    if sample.kind == pyneat.SampleKind.TensorSet and sample.tensors:
+        return sample.tensors[0]
+    for nested in sample.fields:
+        tensor = first_tensor(nested)
+        if tensor is not None:
+            return tensor
+    return None
+
+
+def pull_latest(run, output_name: str, timeout_ms: int):
+    """Block for one frame, then drain so the caller always gets the newest."""
+    sample = run.pull(output_name, timeout_ms)
+    if sample is None:
+        return None
+    while True:
+        newer = run.pull(output_name, 0)
+        if newer is None:
+            return sample
+        sample = newer
+
+
+def probe_rtsp(url: str) -> tuple[int, int, int]:
+    capture = cv2.VideoCapture(url)
+    if not capture.isOpened():
+        raise RuntimeError(f"failed to open RTSP source for probing: {url}")
+    width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+    height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+    fps = int(round(capture.get(cv2.CAP_PROP_FPS) or 0))
+    capture.release()
+    if width <= 0 or height <= 0:
+        raise RuntimeError(f"failed to probe RTSP frame size: {url}")
+    return width, height, fps if fps > 0 else 30
+
+
+# --------------------------------------------------------------------------
+# graph construction
+# --------------------------------------------------------------------------
+def build_source_options(cfg: AppConfig, url: str, width: int, height: int, fps: int):
+    opt = pyneat.RtspDecodedInputOptions()
+    opt.url = url
+    opt.latency_ms = cfg.latency_ms
+    opt.tcp = cfg.tcp
+    opt.payload_type = 96
+    opt.insert_queue = True
+    opt.decoder_name = "decoder"
+    opt.decoder_raw_output = True
+    opt.auto_caps_from_stream = True
+    opt.fallback_h264_width = width
+    opt.fallback_h264_height = height
+    opt.source_fps = fps
+    opt.output_caps.enable = True
+    opt.output_caps.format = pyneat.Format.NV12
+    opt.output_caps.width = width
+    opt.output_caps.height = height
+    opt.output_caps.fps = fps
+    opt.output_caps.memory = pyneat.CapsMemory.Any
+    return opt
+
+
+def build_encoded_source_graph(index: int, opt):
+    """RTSP pulled as encoded H.264, decoded by the graph below."""
+    encoded = pyneat.RtspEncodedInputOptions()
+    encoded.url = opt.url
+    encoded.codec = pyneat.RtspCodec.H264
+    encoded.latency_ms = opt.latency_ms
+    encoded.tcp = opt.tcp
+    encoded.source_fps = opt.source_fps
+    encoded.fallback_h264_width = opt.fallback_h264_width
+    encoded.fallback_h264_height = opt.fallback_h264_height
+
+    source = pyneat.Graph(f"rtsp_source_{index}")
+    source.add(pyneat.groups.rtsp_encoded_input(encoded))
+    return source
+
+
+def encoded_input_options():
+    opt = pyneat.InputOptions()
+    opt.payload_type = pyneat.PayloadType.Encoded
+    opt.format = pyneat.Format.H264
+    opt.memory_policy = pyneat.InputMemoryPolicy.Ev74
+    return opt
+
+
+def build_decode_graph(index: int, opt):
+    """Hardware decode to NV12, published as this stream's `frame_N` output.
+
+    `OutputOptions.latest()` keeps the newest frame rather than a backlog, so a
+    dispatch always batches current pictures.
+    """
+    decode = pyneat.Graph(f"decode_{index}")
+    dec = pyneat.SimaDecodeOptions()
+    dec.type = pyneat.SimaDecodeType.H264
+    dec.sima_allocator_type = opt.sima_allocator_type
+    dec.out_format = pyneat.Format.NV12
+    dec.decoder_name = opt.decoder_name
+    dec.raw_output = opt.decoder_raw_output
+    dec.dec_width = opt.fallback_h264_width
+    dec.dec_height = opt.fallback_h264_height
+    dec.dec_fps = opt.source_fps
+    decode.connect(
+        pyneat.nodes.input("decode_h264", encoded_input_options()),
+        pyneat.nodes.sima_decode(dec),
+    )
+    decode.add(
+        pyneat.nodes.caps_raw(
+            "NV12",
+            opt.output_caps.width,
+            opt.output_caps.height,
+            opt.output_caps.fps,
+            opt.output_caps.memory,
+        )
+    )
+    decode.add(pyneat.nodes.output(f"frame_{index}", pyneat.OutputOptions.latest()))
+    return decode
+
+
+def realtime_link(index: int, queue_depth: int = 3):
+    link = pyneat.GraphLinkOptions()
+    link.policy = pyneat.GraphLinkPolicy.RealtimeLatestByStream
+    link.queue_depth = queue_depth
+    link.stream_id = f"stream{index}"
+    return link
+
+
+def build_run_options():
+    run_options = pyneat.RunOptions()
+    run_options.preset = pyneat.RunPreset.Realtime
+    run_options.queue_depth = 4
+    run_options.overflow_policy = pyneat.OverflowPolicy.KeepLatest
+    run_options.output_memory = pyneat.OutputMemory.ZeroCopy
+    return run_options
+
+
+def h264_video_input_options():
+    opt = pyneat.InputOptions()
+    opt.payload_type = pyneat.PayloadType.Encoded
+    opt.format = pyneat.Format.H264
+    opt.memory_policy = pyneat.InputMemoryPolicy.SystemMemory
+    return opt
+
+
+def build_video_sender_graph(cfg: AppConfig, index: int):
+    """Forward the source H.264 to Insight without re-encoding it.
+
+    The stream arrives already compressed, so the cheap thing to do is hand
+    those bytes straight to the sender. Decoding, converting to RGB and running
+    a hardware encoder per channel to rebuild an equivalent stream costs four
+    encoders and a full-frame copy per channel, and it was the largest single
+    item in the publish path.
+
+    The trade is that the picture reaches the viewer as soon as it arrives while
+    its detections only exist an inference later, so overlays lag the video
+    slightly and refresh at the dispatch rate rather than the source rate. The
+    metadata carries the source `pts_ns`/`frame_id`, so a viewer that aligns on
+    those can still pair them up.
+    """
+    options = pyneat.VideoSenderOptions.passthrough(pyneat.RtspCodec.H264)
+    options.host = cfg.insight_host
+    options.channel = index
+    options.video_port_base = cfg.video_port_base
+    options.async_ = True
+
+    video = pyneat.Graph(f"video_sender_{index}")
+    video.connect(
+        pyneat.nodes.input("video_h264", h264_video_input_options()),
+        pyneat.groups.video_sender(options),
+    )
+    return video, options.video_port
+
+
+# --------------------------------------------------------------------------
+# streams and batching
+# --------------------------------------------------------------------------
+@dataclass
+class Stream:
+    index: int
+    url: str
+    frame_w: int
+    frame_h: int
+    fps: int
+    metadata_sender: object
+    video_port: int = 0
+    processed: int = 0
+
+
+@dataclass(frozen=True)
+class FrameRef:
+    """Metadata retained after the decoder-backed Sample is released."""
+    pts_ns: int
+    frame_id: int
+
+
+@dataclass
+class BatchSlot:
+    """One reusable batch: the MLA input plus what the lanes came from.
+
+    Two of these rotate between ingest and synchronous MLA/decode/publish.
+    Keeping those phases on separate slots lets ingest overlap processing.
+    """
+    tensor: object
+    rgb: list = field(default_factory=list)
+    geometry: list = field(default_factory=list)
+    samples: list = field(default_factory=list)
+    ready: bool = False
+
+
+def make_batch_slot(batch_size: int, net: int, streams: list[Stream]) -> BatchSlot:
+    return BatchSlot(
+        tensor=np.empty((batch_size, net, net, 3), dtype=np.float32),
+        rgb=[np.empty((s.frame_h, s.frame_w, 3), dtype=np.uint8) for s in streams],
+        geometry=[(1.0, 0, 0)] * len(streams),
+        samples=[None] * len(streams),
+    )
+
+
+class BatchPrefetcher:
+    """Keeps one batch in flight so ingest overlaps inference.
+
+    A frame pull blocks until the source produces its next picture — about
+    33 ms at 30 fps — and the letterbox costs another few ms per lane. Doing
+    that between dispatches would serialize it with the MLA and the decode.
+    Instead the lanes for the next batch are filled on worker threads while the
+    caller works on the current one, and both cv2 and the pull release the GIL.
+    """
+
+    def __init__(self, run, streams: list[Stream], net: int, batch_size: int, timeout_ms: int):
+        self.run = run
+        self.streams = streams
+        self.net = net
+        self.batch_size = batch_size
+        self.timeout_ms = timeout_ms
+        self.closed = False
+        self.lane_pool = ThreadPoolExecutor(max_workers=max(1, len(streams)))
+        self.fill_pool = ThreadPoolExecutor(max_workers=1)
+        self.slots = [make_batch_slot(batch_size, net, streams) for _ in range(2)]
+        self.slot = 0
+        self.pending = self.fill_pool.submit(self._fill, self.slots[0])
+
+    def next(self) -> BatchSlot | None:
+        """Hand back the filled batch and immediately start filling the other."""
+        slot = self.pending.result()
+        self.slot = (self.slot + 1) % len(self.slots)
+        self.pending = self.fill_pool.submit(self._fill, self.slots[self.slot])
+        return slot if slot.ready else None
+
+    def _fill(self, slot: BatchSlot) -> BatchSlot:
+        results = list(self.lane_pool.map(lambda s: self._fill_lane(slot, s), self.streams))
+        slot.ready = all(results)
+        # Fewer streams than the compiled batch: repeat the last lane so the MLA
+        # still runs exactly one dispatch.
+        for lane in range(len(self.streams), self.batch_size):
+            slot.tensor[lane] = slot.tensor[len(self.streams) - 1]
+        return slot
+
+    def _fill_lane(self, slot: BatchSlot, stream: Stream) -> bool:
+        if self.closed:
+            return False
+        sample = pull_latest(self.run, f"frame_{stream.index}", self.timeout_ms)
+        if sample is None:
+            return False
+        tensor = first_tensor(sample)
+        if tensor is None:
+            return False
+        rgb = nv12_to_rgb(tensor, slot.rgb[stream.index])
+        slot.geometry[stream.index] = letterbox_into(rgb, slot.tensor[stream.index], self.net)
+        # Do not retain the zero-copy decoder Sample across inference. Four
+        # pipeline slots would otherwise pin enough decoder buffers to starve
+        # the live graph. Insight publication only needs these scalar fields.
+        slot.samples[stream.index] = FrameRef(
+            pts_ns=int(getattr(sample, "pts_ns", -1)),
+            frame_id=int(getattr(sample, "frame_id", -1)),
+        )
+        return True
+
+    def close(self) -> None:
+        """Let the in-flight fill finish before the caller closes the Run.
+
+        Its lane threads are inside `run.pull`, so tearing the Run down first
+        would pull the runtime out from under them.
+        """
+        self.closed = True
+        try:
+            self.pending.result(timeout=self.timeout_ms / 1000.0 + 1.0)
+        except Exception:
+            pass
+        self.fill_pool.shutdown(wait=True, cancel_futures=True)
+        self.lane_pool.shutdown(wait=True, cancel_futures=True)
+
+
+# --------------------------------------------------------------------------
+# output
+# --------------------------------------------------------------------------
+def send_metadata(stream: Stream, sample, detections: list[dict], labels: list[str]) -> None:
+    objects = []
+    for index, det in enumerate(detections, start=1):
+        class_id = det["class_id"]
+        objects.append(
+            {
+                "id": f"obj_{index}",
+                "label": labels[class_id] if 0 <= class_id < len(labels) else "unknown",
+                "confidence": det["score"],
+                "bbox": [
+                    det["x1"],
+                    det["y1"],
+                    det["x2"] - det["x1"],
+                    det["y2"] - det["y1"],
+                ],
+            }
+        )
+    timestamp_ms = int(sample.pts_ns // 1_000_000) if sample.pts_ns >= 0 else -1
+    frame_id = str(sample.frame_id) if sample.frame_id >= 0 else ""
+
+    message = {
+        "type": "object-detection",
+        "data": {"objects": objects},
+        "timestamp": timestamp_ms,
+        "frame_id": frame_id,
+    }
+    if sample.pts_ns >= 0:
+        message["_insight"] = {
+            "rtp_timestamp": (sample.pts_ns * 90_000) // 1_000_000_000
+        }
+    stream.metadata_sender.send_raw_json(json.dumps(message, separators=(",", ":")))
+
+
+def save_debug_frame(cfg: AppConfig, stream: Stream, rgb, detections, labels) -> None:
+    if not cfg.debug_dir or cfg.save_every <= 0 or stream.processed % cfg.save_every != 0:
+        return
+    annotated = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+    for det in detections:
+        p1 = (int(round(det["x1"])), int(round(det["y1"])))
+        p2 = (int(round(det["x2"])), int(round(det["y2"])))
+        cv2.rectangle(annotated, p1, p2, (0, 255, 0), 2)
+        class_id = det["class_id"]
+        label = labels[class_id] if 0 <= class_id < len(labels) else "unknown"
+        cv2.putText(
+            annotated,
+            f"{label} {det['score']:.2f}",
+            (p1[0], max(0, p1[1] - 4)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            (0, 255, 0),
+            1,
+        )
+    out_path = Path(cfg.debug_dir) / f"stream_{stream.index}_frame_{stream.processed}.jpg"
+    if not cv2.imwrite(str(out_path), annotated):
+        print(f"[warn] failed to write {out_path}", file=sys.stderr)
+
+
+def publish_stream(cfg: AppConfig, slot: BatchSlot, labels: list[str],
+                   stream: Stream, detections: list[dict]) -> None:
+    """Send one stream's detections for the exact analysed frame."""
+    sample = slot.samples[stream.index]
+    rgb = slot.rgb[stream.index]
+    send_metadata(stream, sample, detections, labels)
+    save_debug_frame(cfg, stream, rgb, detections, labels)
+
+
+class ProfileWindow:
+    """Throughput and a phase breakdown, printed every `interval` dispatches."""
+
+    def __init__(self, cfg: AppConfig, streams: int) -> None:
+        self.enabled = cfg.profile
+        self.interval = cfg.profile_interval
+        self.streams = streams
+        self.reset()
+
+    def reset(self) -> None:
+        self.dispatches = 0
+        self.batch_ms = 0.0
+        self.infer_ms = 0.0
+        self.decode_ms = 0.0
+        self.publish_ms = 0.0
+        self.detections = 0
+        self.start_ms = 0.0
+
+    def add(self, batch_ms, infer_ms, decode_ms, publish_ms, detections) -> None:
+        if not self.enabled:
+            return
+        if self.dispatches == 0:
+            self.start_ms = time_ms()
+        self.dispatches += 1
+        self.batch_ms += batch_ms
+        self.infer_ms += infer_ms
+        self.decode_ms += decode_ms
+        self.publish_ms += publish_ms
+        self.detections += detections
+        if self.dispatches >= self.interval:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self.enabled or self.dispatches == 0:
+            return
+        elapsed = time_ms() - self.start_ms
+        dispatch_fps = self.dispatches * 1000.0 / elapsed if elapsed > 0 else 0.0
+        n = self.dispatches
+        print(
+            f"[profile] dispatch_fps={dispatch_fps:.2f} "
+            f"per_stream_fps={dispatch_fps:.2f} "
+            f"aggregate_fps={dispatch_fps * self.streams:.2f} | "
+            f"avg_batch_ms={self.batch_ms / n:.1f} "
+            f"avg_infer_ms={self.infer_ms / n:.1f} "
+            f"avg_decode_ms={self.decode_ms / n:.1f} "
+            f"avg_publish_ms={self.publish_ms / n:.1f} | "
+            f"avg_detections={self.detections / n:.1f}",
+            flush=True,
+        )
+        self.reset()
+
+
+# --------------------------------------------------------------------------
+# application
+# --------------------------------------------------------------------------
+def load_model(cfg: AppConfig) -> tuple[object, int, int]:
+    """Load the batched pack and refuse anything that is not a six-head batch model."""
+    model = pyneat.Model(str(resolve(cfg.model_path)))
+    shape = [int(x) for x in model.input_specs()[0].shape]
+    if len(shape) != 4:
+        raise RuntimeError(
+            f"this example needs a batched model, got input shape {shape}. "
+            "Compile the detector with --batch_size 4."
+        )
+    batch_size, net = shape[0], shape[1]
+    if batch_size != MAX_STREAMS:
+        raise RuntimeError(
+            f"model batch size is {batch_size}; this example requires batch size {MAX_STREAMS}"
+        )
+    outputs = model.output_specs()
+    if len(outputs) != EXPECTED_OUTPUTS:
+        raise RuntimeError(
+            f"expected {EXPECTED_OUTPUTS} YOLO26 head tensors, model has {len(outputs)}"
+        )
+    print(
+        f"Model loaded: batch={batch_size} net={net} "
+        f"heads={[list(spec.shape) for spec in outputs]}",
+        flush=True,
+    )
+    return model, batch_size, net
+
+
+def build_streams(cfg: AppConfig, graph) -> list[Stream]:
+    streams: list[Stream] = []
+    for index, url in enumerate(cfg.rtsp_urls):
+        width, height, fps = probe_rtsp(url)
+
+        metadata_options = pyneat.MetadataSenderOptions()
+        metadata_options.host = cfg.insight_host
+        metadata_options.channel = index
+        metadata_options.metadata_port_base = cfg.metadata_port_base
+        metadata_sender = pyneat.MetadataSender(metadata_options)
+
+        options = build_source_options(cfg, url, width, height, fps)
+        source = build_encoded_source_graph(index, options)
+        decoder = build_decode_graph(index, options)
+
+        video_port = 0
+        if cfg.video_enabled:
+            # Split the encoded stream: one copy is decoded for detection, the
+            # other goes to Insight untouched.
+            branch = pyneat.graphs.branch(f"encoded_{index}", ["decode_h264", "video_h264"])
+            graph.connect(source, branch)
+            graph.connect(branch, decoder, realtime_link(index))
+            sender, video_port = build_video_sender_graph(cfg, index)
+            graph.connect(branch, sender, realtime_link(index))
+        else:
+            graph.connect(source, decoder, realtime_link(index))
+
+        stream = Stream(
+            index=index,
+            url=url,
+            frame_w=width,
+            frame_h=height,
+            fps=fps,
+            metadata_sender=metadata_sender,
+            video_port=video_port,
+        )
+        print(
+            f"[stream {index}] rtsp={url} {width}x{height}@{fps} "
+            f"video={stream.video_port if cfg.video_enabled else 'disabled'} "
+            f"metadata={metadata_sender.metadata_port()}",
+            flush=True,
+        )
+        streams.append(stream)
+    return streams
+
+
+def run_app(cfg: AppConfig) -> None:
+    labels = load_labels(cfg.labels_path)
+    if cfg.debug_dir:
+        Path(cfg.debug_dir).mkdir(parents=True, exist_ok=True)
+
+    model, batch_size, net = load_model(cfg)
+
+    graph = pyneat.Graph()
+    streams = build_streams(cfg, graph)
+    run = graph.build(build_run_options())
+    profile = ProfileWindow(cfg, len(streams))
+    prefetcher = BatchPrefetcher(run, streams, net, batch_size, cfg.timeout_ms)
+    decode_pool = ThreadPoolExecutor(max_workers=len(streams))
+
+    def decode_lane(stream: Stream, head_arrays: list, slot: BatchSlot):
+        """One lane's heads -> detections in that stream's source coordinates."""
+        heads = heads_from_outputs(head_arrays, stream.index)
+        detections = decode_heads(heads, net, cfg.score_threshold, cfg.max_detections)
+        scale, dx, dy = slot.geometry[stream.index]
+        return to_original(detections, scale, dx, dy, stream.frame_w, stream.frame_h)
+
+    try:
+        while cfg.frames <= 0 or min(s.processed for s in streams) < cfg.frames:
+            batch_started = time_ms()
+            batch = prefetcher.next()
+            batch_ms = time_ms() - batch_started
+            if batch is None:
+                last_error = run.last_error()
+                if last_error:
+                    raise RuntimeError(f"runtime error: {last_error}")
+                raise RuntimeError("timed out waiting for frames")
+
+            input_tensor = pyneat.Tensor.from_numpy(batch.tensor, copy=False)
+            infer_started = time_ms()
+            head_tensors = model.run([input_tensor], timeout_ms=cfg.timeout_ms)
+            if len(head_tensors) != EXPECTED_OUTPUTS:
+                raise RuntimeError(
+                    f"expected {EXPECTED_OUTPUTS} head tensors, got {len(head_tensors)}"
+                )
+            head_arrays = [tensor.to_numpy() for tensor in head_tensors]
+            infer_ms = time_ms() - infer_started
+
+            decode_started = time_ms()
+            per_stream = list(
+                decode_pool.map(lambda s: decode_lane(s, head_arrays, batch), streams)
+            )
+            decoded = time_ms()
+
+            found = 0
+            publish: list[tuple[Stream, list]] = []
+            for stream, detections in zip(streams, per_stream):
+                found += len(detections)
+                stream.processed += 1
+                if stream.processed > cfg.warmup_frames:
+                    publish.append((stream, detections))
+            # Each stream has its own sender, so the encodes proceed in parallel.
+            list(decode_pool.map(lambda item: publish_stream(cfg, batch, labels, *item), publish))
+
+            profile.add(
+                batch_ms, infer_ms, decoded - decode_started,
+                time_ms() - decoded, found,
+            )
+    except KeyboardInterrupt:
+        raise
+    finally:
+        profile.flush()
+        decode_pool.shutdown(wait=False, cancel_futures=True)
+        prefetcher.close()
+        run.close()
+        for stream in streams:
+            print(f"[stream {stream.index}] processed={stream.processed}")
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Batch-4 YOLO26 detector over four RTSP streams")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--validate-config-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        if not args.config.is_file():
+            print(f"Error: config file not found: {args.config}", file=sys.stderr)
+            return 2
+        cfg = load_app_config(args.config)
+        if args.validate_config_only:
+            print(
+                f"Config validated: {args.config} (streams={len(cfg.rtsp_urls)}, "
+                f"score_threshold={cfg.score_threshold}, max_detections={cfg.max_detections})"
+            )
+            return 0
+        load_runtime_dependencies()
+        run_app(cfg)
+        return 0
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:
+        print(f"[ERR] {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/object-detection/yolo26-batch4-detector/src/python/requirements.txt
+++ b/examples/object-detection/yolo26-batch4-detector/src/python/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+opencv-python
+PyYAML

--- a/examples/object-detection/yolo26-batch4-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/yolo26-batch4-detector/tests/cpp/test_e2e.cpp
@@ -1,0 +1,137 @@
+// E2E test for yolo26-batch4-detector.
+// Runs the four-stream batched pipeline and verifies that sampled debug frames
+// are written and that per-stream detection metadata reaches Insight.
+#include "support/testing/metadata_json_listener.h"
+#include "support/testing/test_config.h"
+#include "support/testing/test_process.h"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace sima_examples::testing;
+
+namespace {
+constexpr const char* kExample = "yolo26-batch4-detector";
+constexpr const char* kE2eInsightHost = "127.0.0.1";
+// The model is compiled for batch 4, so the test needs all four lanes fed.
+constexpr std::size_t kRequiredStreams = 4;
+} // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+
+  const std::string binary = argv[1];
+
+  const std::vector<std::string> rtsp_urls = rtsp_h264_urls_from_env();
+  if (rtsp_urls.size() < kRequiredStreams) {
+    return skip_or_fail("need four RTSP URLs to fill the batch-4 lanes");
+  }
+
+  const char* models_dir_raw = env_or_null("SIMANEAT_APPS_TEST_MODELS_DIR");
+  const std::string models_dir = models_dir_raw ? models_dir_raw : "assets/models";
+  const std::string model_path = configured_model_path(kExample, models_dir);
+  if (model_path.empty() || !fs::exists(model_path)) {
+    return skip_or_fail("configured batch-4 model not found under SIMANEAT_APPS_TEST_MODELS_DIR");
+  }
+
+  const std::string output_dir =
+      create_test_output_dir(kExample, "test_batch4_insight_and_save_pipeline");
+  if (output_dir.empty()) {
+    return 1;
+  }
+
+  const fs::path labels_file =
+      example_common_config_path(kExample).parent_path() / "coco_label.txt";
+  if (!fs::exists(labels_file)) {
+    return skip_or_fail("src/common/coco_label.txt not found for yolo26-batch4-detector");
+  }
+
+  const fs::path config_path = fs::path(output_dir).parent_path() / "config.yaml";
+  const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
+  const int metadata_port_base =
+      env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
+  const int save_every = e2e_int(kExample, "testing.e2e.output", "save_every");
+  const int total_saved_frames = e2e_int(kExample, "testing.e2e.output", "total_saved_frames");
+  write_e2e_config(kExample, config_path,
+                   {{"model.path", model_path},
+                    {"model.labels", labels_file.string()},
+                    {"output.debug_dir", output_dir},
+                    {"output.save_every", std::to_string(save_every)},
+                    {"output.insight.host", kE2eInsightHost},
+                    {"output.insight.video_port_base", std::to_string(video_port_base)},
+                    {"output.insight.metadata_port_base", std::to_string(metadata_port_base)},
+                    {"inference.frames", "140"}},
+                   {{"streams",
+                     {rtsp_urls[0], rtsp_urls[1], rtsp_urls[2], rtsp_urls[3]}}});
+
+  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
+  MetadataJsonListenerOptions metadata_options;
+  metadata_options.host = kE2eInsightHost;
+  metadata_options.base_port = metadata_port_base;
+  metadata_options.num_ports = static_cast<int>(kRequiredStreams);
+  metadata_options.timeout_ms = 5000;
+  metadata_options.require_all_ports = true;
+  MetadataJsonListener metadata_listener(metadata_options);
+  if (!metadata_listener.ok()) {
+    std::cerr << "[FAIL] metadata listener failed: " << metadata_listener.error() << "\n";
+    remove_dir(output_dir);
+    return 1;
+  }
+
+  const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
+                                                        output_dir, total_saved_frames, timeout_ms);
+
+  int rc = 0;
+  if (result.exit_code != 0) {
+    std::cerr << "[FAIL] exit code " << result.exit_code << "\n";
+    std::cerr << "stdout:\n" << result.stdout_text << "\n";
+    std::cerr << "stderr:\n" << result.stderr_text << "\n";
+    rc = 1;
+  } else {
+    const int files = count_output_files(output_dir);
+    if (files < total_saved_frames) {
+      std::cerr << "[FAIL] expected at least " << total_saved_frames
+                << " sampled output files, got " << files << "\n";
+      rc = 1;
+    } else if (!all_output_files_nonempty(output_dir)) {
+      std::cerr << "[FAIL] some sampled output files are empty\n";
+      rc = 1;
+    } else {
+      std::cout << "[OK] batch-4 detector produced " << files << " sampled output files\n";
+    }
+  }
+  if (rc == 0) {
+    const MetadataJsonListenerResult metadata = metadata_listener.wait_for_messages();
+    if (!metadata.success) {
+      std::cerr << "[FAIL] object-detection metadata was not received on all lanes: "
+                << metadata.error << "\n";
+      rc = 1;
+    } else {
+      for (const auto& message : metadata.messages) {
+        const auto payload = nlohmann::json::parse(message.payload);
+        if (!payload.contains("_insight") ||
+            !payload["_insight"].contains("rtp_timestamp") ||
+            !payload["_insight"]["rtp_timestamp"].is_number_unsigned()) {
+          std::cerr << "[FAIL] metadata is missing _insight.rtp_timestamp\n";
+          rc = 1;
+          break;
+        }
+      }
+    }
+    if (rc == 0) {
+      std::cout << "[OK] object-detection metadata received on "
+                << metadata.ports_with_valid_json.size() << " lanes\n";
+    }
+  }
+
+  remove_dir(output_dir);
+  return rc;
+}

--- a/examples/object-detection/yolo26-batch4-detector/tests/cpp/test_e2e.cpp
+++ b/examples/object-detection/yolo26-batch4-detector/tests/cpp/test_e2e.cpp
@@ -7,7 +7,9 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <filesystem>
+#include <future>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -58,6 +60,7 @@ int main(int argc, char** argv) {
   const int video_port_base = env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000);
   const int metadata_port_base =
       env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100);
+  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   const int save_every = e2e_int(kExample, "testing.e2e.output", "save_every");
   const int total_saved_frames = e2e_int(kExample, "testing.e2e.output", "total_saved_frames");
   write_e2e_config(kExample, config_path,
@@ -72,12 +75,11 @@ int main(int argc, char** argv) {
                    {{"streams",
                      {rtsp_urls[0], rtsp_urls[1], rtsp_urls[2], rtsp_urls[3]}}});
 
-  const int timeout_ms = env_int_or_default("SIMANEAT_APPS_TEST_TIMEOUT_MS", 180000);
   MetadataJsonListenerOptions metadata_options;
   metadata_options.host = kE2eInsightHost;
   metadata_options.base_port = metadata_port_base;
   metadata_options.num_ports = static_cast<int>(kRequiredStreams);
-  metadata_options.timeout_ms = 5000;
+  metadata_options.timeout_ms = std::min(timeout_ms, 30000);
   metadata_options.require_all_ports = true;
   MetadataJsonListener metadata_listener(metadata_options);
   if (!metadata_listener.ok()) {
@@ -86,8 +88,14 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  // Drain UDP while the application runs. Waiting until process exit can
+  // overflow receive buffers when four lanes publish at once.
+  auto metadata_future = std::async(std::launch::async, [&metadata_listener] {
+    return metadata_listener.wait_for_messages();
+  });
   const ProcessResult result = spawn_until_output_files(binary, {"--config", config_path.string()},
                                                         output_dir, total_saved_frames, timeout_ms);
+  const MetadataJsonListenerResult metadata = metadata_future.get();
 
   int rc = 0;
   if (result.exit_code != 0) {
@@ -109,7 +117,6 @@ int main(int argc, char** argv) {
     }
   }
   if (rc == 0) {
-    const MetadataJsonListenerResult metadata = metadata_listener.wait_for_messages();
     if (!metadata.success) {
       std::cerr << "[FAIL] object-detection metadata was not received on all lanes: "
                 << metadata.error << "\n";

--- a/examples/object-detection/yolo26-batch4-detector/tests/cpp/test_unit.cpp
+++ b/examples/object-detection/yolo26-batch4-detector/tests/cpp/test_unit.cpp
@@ -1,0 +1,184 @@
+// Unit tests for yolo26-batch4-detector (C++).
+// Cover the parts that need no hardware: CLI handling and config validation.
+#include "support/testing/test_process.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+using sima_examples::testing::create_test_scratch_dir;
+using sima_examples::testing::remove_dir;
+using sima_examples::testing::spawn_and_wait;
+
+namespace {
+
+constexpr const char* kModelLine = "  path: assets/models/yolo26m-det-int8-b4.tar.gz\n";
+
+bool expect_true(bool condition, const std::string& message) {
+  if (!condition) {
+    std::cerr << "[FAIL] " << message << "\n";
+    return false;
+  }
+  std::cout << "[OK] " << message << "\n";
+  return true;
+}
+
+bool expect_contains(const std::string& haystack, const std::string& needle,
+                     const std::string& message) {
+  return expect_true(haystack.find(needle) != std::string::npos, message);
+}
+
+fs::path write_config(const std::string& test_name, const std::string& body) {
+  const std::string temp_dir = create_test_scratch_dir("yolo26-batch4-detector", test_name);
+  if (temp_dir.empty()) {
+    throw std::runtime_error("failed to create temp directory");
+  }
+  const fs::path config_path = fs::path(temp_dir) / "config.yaml";
+  std::ofstream out(config_path);
+  out << body;
+  return config_path;
+}
+
+bool test_help_runs(const std::string& binary) {
+  const auto result = spawn_and_wait(binary, {"--help"}, 20000);
+  return expect_true(result.exit_code == 0, "help exits with code 0") &&
+         expect_contains(result.stdout_text, "--config", "help mentions --config") &&
+         expect_contains(result.stdout_text, "--validate-config-only",
+                         "help mentions --validate-config-only");
+}
+
+bool test_missing_config_file_fails_cleanly(const std::string& binary) {
+  const auto result = spawn_and_wait(binary, {"--config", "does-not-exist.yaml"}, 20000);
+  return expect_true(result.exit_code == 2, "missing config exits with code 2") &&
+         expect_contains(result.stderr_text, "config file not found",
+                         "missing config error mentions config file not found");
+}
+
+bool test_validate_config_only_accepts_four_streams(const std::string& binary) {
+  const fs::path config_path =
+      write_config("test_validate_config_only_accepts_four_streams",
+                   std::string("model:\n") + kModelLine +
+                       "streams:\n"
+                       "  - rtsp://127.0.0.1:8554/src1\n"
+                       "  - rtsp://127.0.0.1:8554/src2\n"
+                       "  - rtsp://127.0.0.1:8554/src3\n"
+                       "  - rtsp://127.0.0.1:8554/src4\n"
+                       "inference:\n"
+                       "  max_detections: 42\n"
+                       "output:\n"
+                       "  insight:\n"
+                       "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok =
+      expect_true(result.exit_code == 0, "four-stream config validates") &&
+      expect_contains(result.stdout_text, "streams=4", "validate output reports stream count") &&
+      expect_contains(result.stdout_text, "max_detections=42",
+                      "validate output reports the detection cap");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+bool test_validate_config_only_rejects_too_many_streams(const std::string& binary) {
+  const fs::path config_path =
+      write_config("test_validate_config_only_rejects_too_many_streams",
+                   std::string("model:\n") + kModelLine +
+                       "streams:\n"
+                       "  - rtsp://127.0.0.1:8554/src1\n"
+                       "  - rtsp://127.0.0.1:8554/src2\n"
+                       "  - rtsp://127.0.0.1:8554/src3\n"
+                       "  - rtsp://127.0.0.1:8554/src4\n"
+                       "  - rtsp://127.0.0.1:8554/src5\n"
+                       "output:\n"
+                       "  insight:\n"
+                       "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok = expect_true(result.exit_code == 1, "five-stream config is rejected") &&
+                  expect_contains(result.stderr_text, "up to 4 streams",
+                                  "too-many-stream error names the batch limit");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+bool test_validate_config_only_rejects_empty_streams(const std::string& binary) {
+  const fs::path config_path = write_config("test_validate_config_only_rejects_empty_streams",
+                                            std::string("model:\n") + kModelLine +
+                                                "streams: []\n"
+                                                "output:\n"
+                                                "  insight:\n"
+                                                "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok =
+      expect_true(result.exit_code == 1, "empty stream config is rejected") &&
+      expect_contains(result.stderr_text, "streams", "empty-stream error mentions streams");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+bool test_validate_config_only_rejects_out_of_range_threshold(const std::string& binary) {
+  const fs::path config_path =
+      write_config("test_validate_config_only_rejects_out_of_range_threshold",
+                   std::string("model:\n") + kModelLine +
+                       "streams:\n"
+                       "  - rtsp://127.0.0.1:8554/src1\n"
+                       "inference:\n"
+                       "  score_threshold: 1.5\n"
+                       "output:\n"
+                       "  insight:\n"
+                       "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok = expect_true(result.exit_code == 1, "out-of-range score threshold is rejected") &&
+                  expect_contains(result.stderr_text, "score_threshold must be between 0 and 1",
+                                  "threshold error names the setting");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+bool test_validate_config_only_rejects_placeholder_stream(const std::string& binary) {
+  const fs::path config_path =
+      write_config("test_validate_config_only_rejects_placeholder_stream",
+                   std::string("model:\n") + kModelLine +
+                       "streams:\n"
+                       "  - <rtsp-url-1>\n"
+                       "output:\n"
+                       "  insight:\n"
+                       "    host: 127.0.0.1\n");
+
+  const auto result =
+      spawn_and_wait(binary, {"--config", config_path.string(), "--validate-config-only"}, 20000);
+  const bool ok = expect_true(result.exit_code == 1, "placeholder stream URL is rejected") &&
+                  expect_contains(result.stderr_text, "placeholder",
+                                  "placeholder error says so explicitly");
+  remove_dir(config_path.parent_path().string());
+  return ok;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "[ERR] usage: " << argv[0] << " <example-binary>\n";
+    return 2;
+  }
+
+  const std::string binary = argv[1];
+  bool ok = true;
+  ok &= test_help_runs(binary);
+  ok &= test_missing_config_file_fails_cleanly(binary);
+  ok &= test_validate_config_only_accepts_four_streams(binary);
+  ok &= test_validate_config_only_rejects_too_many_streams(binary);
+  ok &= test_validate_config_only_rejects_empty_streams(binary);
+  ok &= test_validate_config_only_rejects_out_of_range_threshold(binary);
+  ok &= test_validate_config_only_rejects_placeholder_stream(binary);
+  return ok ? 0 : 1;
+}

--- a/examples/object-detection/yolo26-batch4-detector/tests/python/test_e2e.py
+++ b/examples/object-detection/yolo26-batch4-detector/tests/python/test_e2e.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import importlib.util
 import json
 import os
@@ -87,14 +88,21 @@ class TestE2E:
             num_ports=REQUIRED_STREAMS,
             require_all_ports=True,
         ) as metadata_listener:
-            result = run_until_output_files(
-                cmd,
-                tmp_output_dir,
-                total_saved_frames,
-                test_timeout_ms / 1000,
-                cwd=str(EXAMPLE_DIR),
-            )
-            metadata = metadata_listener.wait_for_messages(5.0)
+            # Drain UDP while the application runs. Waiting until process exit
+            # can overflow receive buffers when four lanes publish at once.
+            with ThreadPoolExecutor(max_workers=1) as listener_pool:
+                metadata_future = listener_pool.submit(
+                    metadata_listener.wait_for_messages,
+                    min(test_timeout_ms / 1000, 30.0),
+                )
+                result = run_until_output_files(
+                    cmd,
+                    tmp_output_dir,
+                    total_saved_frames,
+                    test_timeout_ms / 1000,
+                    cwd=str(EXAMPLE_DIR),
+                )
+                metadata = metadata_future.result()
 
         assert result.returncode == 0, (
             f"main.py exited with code {result.returncode}\n"

--- a/examples/object-detection/yolo26-batch4-detector/tests/python/test_e2e.py
+++ b/examples/object-detection/yolo26-batch4-detector/tests/python/test_e2e.py
@@ -1,0 +1,119 @@
+"""E2E tests for yolo26-batch4-detector (Python)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+from tests.utils.metadata_json_listener import MetadataJsonListener
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = EXAMPLE_DIR / "src" / "python" / "main.py"
+E2E_INSIGHT_HOST = "127.0.0.1"
+# The model is compiled for batch 4, so the test needs all four lanes fed.
+REQUIRED_STREAMS = 4
+
+
+def _runtime_deps_ready() -> bool:
+    return all(importlib.util.find_spec(name) is not None for name in ("cv2", "numpy", "pyneat"))
+
+
+def _env_int_or_default(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    return int(raw) if raw else default
+
+
+@pytest.mark.e2e
+class TestE2E:
+    def test_batch4_insight_and_save_pipeline(
+        self,
+        e2e_model_path,
+        tmp_output_dir,
+        rtsp_h264_urls,
+        test_timeout_ms,
+        skip_unless_e2e_ready,
+        e2e_config_writer,
+        e2e_config_section,
+        run_until_output_files,
+    ):
+        skip_unless_e2e_ready(
+            _runtime_deps_ready(),
+            "python runtime dependencies (cv2, numpy, pyneat) are not available",
+        )
+        skip_unless_e2e_ready(
+            len(rtsp_h264_urls) >= REQUIRED_STREAMS,
+            "need four RTSP H.264 URLs to fill the batch-4 lanes",
+        )
+        output_cfg = e2e_config_section("yolo26-batch4-detector", "testing.e2e.output")
+        save_every = int(output_cfg["save_every"])
+        total_saved_frames = int(output_cfg["total_saved_frames"])
+        metadata_port_base = _env_int_or_default("SIMANEAT_APPS_TEST_INSIGHT_METADATA_PORT", 9100)
+
+        config_path = e2e_config_writer(
+            {
+                "streams": rtsp_h264_urls[:REQUIRED_STREAMS],
+                "output": {
+                    "insight": {
+                        "host": E2E_INSIGHT_HOST,
+                        "video_port_base": _env_int_or_default(
+                            "SIMANEAT_APPS_TEST_INSIGHT_VIDEO_PORT", 9000
+                        ),
+                        "metadata_port_base": metadata_port_base,
+                    },
+                    "debug_dir": str(tmp_output_dir),
+                    "save_every": save_every,
+                },
+                "inference": {
+                    "frames": 140,
+                },
+            }
+        )
+
+        cmd = [
+            sys.executable,
+            str(MAIN_PY),
+            "--config",
+            str(config_path),
+        ]
+        with MetadataJsonListener(
+            E2E_INSIGHT_HOST,
+            metadata_port_base,
+            num_ports=REQUIRED_STREAMS,
+            require_all_ports=True,
+        ) as metadata_listener:
+            result = run_until_output_files(
+                cmd,
+                tmp_output_dir,
+                total_saved_frames,
+                test_timeout_ms / 1000,
+                cwd=str(EXAMPLE_DIR),
+            )
+            metadata = metadata_listener.wait_for_messages(5.0)
+
+        assert result.returncode == 0, (
+            f"main.py exited with code {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert metadata.success, (
+            f"object-detection metadata was not received on all lanes: {metadata.error}"
+        )
+        assert all(
+            isinstance(json.loads(message.payload).get("_insight", {}).get("rtp_timestamp"), int)
+            for message in metadata.messages
+        ), "metadata must carry the analysed frame's RTP timestamp"
+
+        files = [
+            path
+            for path in tmp_output_dir.rglob("*")
+            if path.is_file() and path.name != "config.yaml"
+        ]
+        assert len(files) >= total_saved_frames, (
+            f"Expected at least {total_saved_frames} sampled output files, got {len(files)}"
+        )
+        assert all(path.stat().st_size > 0 for path in files)

--- a/examples/object-detection/yolo26-batch4-detector/tests/python/test_unit.py
+++ b/examples/object-detection/yolo26-batch4-detector/tests/python/test_unit.py
@@ -1,0 +1,335 @@
+"""Unit tests for the batch-4 YOLO26 detector example.
+
+These cover the parts that need no hardware: config loading and validation, and
+the shape-based head mapping, which is the one piece of plumbing this example adds
+on top of the standard YOLO26 decode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import subprocess
+import sys
+import textwrap
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent.parent
+PYTHON_DIR = EXAMPLE_DIR / "src" / "python"
+MAIN_PY = PYTHON_DIR / "main.py"
+
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+pytestmark = pytest.mark.unit
+
+
+def write_config(tmp_path: Path, streams: list[str], **overrides) -> Path:
+    stream_lines = "\n".join(f"  - {url}" for url in streams)
+    inference = ""
+    if overrides:
+        lines = "\n".join(f"  {key}: {value}" for key, value in overrides.items())
+        inference = f"inference:\n{lines}\n"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "model:\n"
+        "  path: assets/models/yolo26m-det-int8-b4.tar.gz\n"
+        "streams:\n"
+        f"{stream_lines}\n"
+        f"{inference}"
+        "output:\n"
+        "  insight:\n"
+        "    host: 127.0.0.1\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+class TestMainEntrypoint:
+    def test_help_runs(self):
+        result = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--help"],
+            capture_output=True, text=True, cwd=str(EXAMPLE_DIR), timeout=20,
+        )
+        assert result.returncode == 0
+        assert "--config" in result.stdout
+        assert "--validate-config-only" in result.stdout
+
+    def test_missing_config_file_fails_cleanly(self):
+        result = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--config", "does-not-exist.yaml"],
+            capture_output=True, text=True, cwd=str(EXAMPLE_DIR), timeout=20,
+        )
+        assert result.returncode == 2
+        assert "config file not found" in result.stderr
+
+    def test_validate_config_only_reports_stream_count(self, tmp_path: Path):
+        config_path = write_config(
+            tmp_path, ["rtsp://127.0.0.1:8554/src1", "rtsp://127.0.0.1:8554/src2"]
+        )
+        result = subprocess.run(
+            [sys.executable, str(MAIN_PY), "--config", str(config_path), "--validate-config-only"],
+            capture_output=True, text=True, cwd=str(EXAMPLE_DIR), timeout=20,
+        )
+        assert result.returncode == 0
+        assert "streams=2" in result.stdout
+
+
+class TestConfigLoading:
+    def test_accepts_four_streams(self, tmp_path: Path):
+        from main import load_app_config
+
+        cfg = load_app_config(
+            write_config(tmp_path, [f"rtsp://127.0.0.1:8554/src{i}" for i in range(4)])
+        )
+        assert len(cfg.rtsp_urls) == 4
+        assert cfg.insight_host == "127.0.0.1"
+        assert cfg.score_threshold == 0.35
+        assert cfg.max_detections == 100
+
+    def test_rejects_more_than_four_streams(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = write_config(
+            tmp_path, [f"rtsp://127.0.0.1:8554/src{i}" for i in range(5)]
+        )
+        with pytest.raises(ValueError, match="up to 4 streams"):
+            load_app_config(config_path)
+
+    def test_rejects_placeholder_stream(self, tmp_path: Path):
+        from main import load_app_config
+
+        with pytest.raises(ValueError, match="placeholder"):
+            load_app_config(write_config(tmp_path, ["<rtsp-url-1>"]))
+
+    def test_rejects_out_of_range_score_threshold(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = write_config(
+            tmp_path, ["rtsp://127.0.0.1:8554/src1"], score_threshold=1.5
+        )
+        with pytest.raises(ValueError, match="score_threshold"):
+            load_app_config(config_path)
+
+    def test_rejects_empty_streams(self, tmp_path: Path):
+        from main import load_app_config
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            textwrap.dedent(
+                """
+                model:
+                  path: assets/models/yolo26m-det-int8-b4.tar.gz
+                streams: []
+                output:
+                  insight:
+                    host: 127.0.0.1
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="streams"):
+            load_app_config(config_path)
+
+
+class TestHeadMapping:
+    """The six model outputs must be sorted into levels by shape alone."""
+
+    GRIDS = (80, 40, 20)
+
+    @classmethod
+    def outputs(cls, batch: int = 4, shuffle: bool = False) -> list[np.ndarray]:
+        """Six [N,H,W,C] outputs, each filled with a value identifying it."""
+        arrays = []
+        for kind, channels in (("bbox", 4), ("cls", 80)):
+            for grid in cls.GRIDS:
+                marker = float(cls.GRIDS.index(grid) + (0 if kind == "bbox" else 10))
+                arrays.append(np.full((batch, grid, grid, channels), marker, dtype=np.float32))
+        if shuffle:
+            arrays = [arrays[i] for i in (4, 0, 5, 2, 3, 1)]
+        return arrays
+
+    def test_maps_heads_to_levels(self):
+        import main
+
+        heads = main.heads_from_outputs(self.outputs(), lane=0)
+        assert set(heads) == {f"bbox_{lv}" for lv in range(3)} | {
+            f"class_logit_{lv}" for lv in range(3)
+        }
+        for level, grid in enumerate(self.GRIDS):
+            assert heads[f"bbox_{level}"].shape == (grid, grid, 4)
+            assert heads[f"class_logit_{level}"].shape == (grid, grid, 80)
+
+    def test_output_order_does_not_matter(self):
+        import main
+
+        ordered = main.heads_from_outputs(self.outputs(shuffle=False), lane=0)
+        shuffled = main.heads_from_outputs(self.outputs(shuffle=True), lane=0)
+        for name, plane in ordered.items():
+            assert np.array_equal(shuffled[name], plane)
+
+    def test_lanes_are_independent(self):
+        import main
+
+        arrays = self.outputs()
+        arrays[0][2] = 7.0  # bbox level 0, lane 2 only
+        assert main.heads_from_outputs(arrays, lane=2)["bbox_0"][0, 0, 0] == 7.0
+        assert main.heads_from_outputs(arrays, lane=1)["bbox_0"][0, 0, 0] == 0.0
+
+    def test_rejects_unbatched_output(self):
+        import main
+
+        with pytest.raises(RuntimeError, match=r"\[N,H,W,C\]"):
+            main.heads_from_outputs([np.zeros((80, 80, 4), dtype=np.float32)], lane=0)
+
+    def test_rejects_lane_out_of_range(self):
+        import main
+
+        with pytest.raises(RuntimeError, match="out of range"):
+            main.heads_from_outputs(self.outputs(batch=4), lane=4)
+
+    def test_rejects_unknown_channel_count(self):
+        import main
+
+        arrays = self.outputs()
+        arrays[0] = np.zeros((4, 80, 80, 7), dtype=np.float32)
+        with pytest.raises(RuntimeError, match="neither a bbox head"):
+            main.heads_from_outputs(arrays, lane=0)
+
+    def test_rejects_wrong_head_count(self):
+        import main
+
+        with pytest.raises(RuntimeError, match="expected 3 bbox and 3 class heads"):
+            main.heads_from_outputs(self.outputs()[:4], lane=0)
+
+
+class TestModelContract:
+    def test_rejects_non_batch4_model(self, monkeypatch):
+        import main
+
+        model = SimpleNamespace(
+            input_specs=lambda: [SimpleNamespace(shape=[2, 640, 640, 3])],
+            output_specs=lambda: [SimpleNamespace(shape=[2, 80, 80, 4])] * 6,
+        )
+        monkeypatch.setattr(main, "pyneat", SimpleNamespace(Model=lambda _path: model))
+        cfg = SimpleNamespace(model_path="assets/models/wrong-batch.tar.gz")
+
+        with pytest.raises(RuntimeError, match="requires batch size 4"):
+            main.load_model(cfg)
+
+
+class TestDecode:
+    def test_decode_finds_a_planted_box(self):
+        import main
+
+        main.np = np  # decode_heads uses the module-level numpy handle
+        heads = {
+            f"bbox_{lv}": np.zeros((grid, grid, 4), dtype=np.float32)
+            for lv, grid in enumerate((80, 40, 20))
+        }
+        heads.update(
+            {
+                f"class_logit_{lv}": np.full((grid, grid, 80), -20.0, dtype=np.float32)
+                for lv, grid in enumerate((80, 40, 20))
+            }
+        )
+        # one confident cell at grid 20 (stride 32), class 2, half-cell box
+        heads["class_logit_2"][5, 7, 2] = 10.0
+        heads["bbox_2"][5, 7] = [0.5, 0.5, 0.5, 0.5]
+
+        dets = main.decode_heads(heads, net=640, score_threshold=0.35, max_detections=10)
+
+        assert len(dets) == 1
+        det = dets[0]
+        assert det["class_id"] == 2
+        assert det["score"] > 0.99
+        # anchor centre (7.5, 5.5) grid units, +/- 0.5 -> 7.0..8.0, 5.0..6.0, x32
+        assert det["x1"] == pytest.approx(224.0)
+        assert det["x2"] == pytest.approx(256.0)
+        assert det["y1"] == pytest.approx(160.0)
+        assert det["y2"] == pytest.approx(192.0)
+
+    def test_to_original_undoes_letterbox(self):
+        import main
+
+        dets = [{"score": 0.9, "class_id": 0, "x1": 100.0, "y1": 200.0, "x2": 200.0, "y2": 300.0}]
+        # 1280x720 letterboxed into 640: scale 0.5, dy 140, dx 0
+        mapped = main.to_original(dets, scale=0.5, dx=0, dy=140, width=1280, height=720)
+        assert len(mapped) == 1
+        assert mapped[0]["x1"] == pytest.approx(200.0)
+        assert mapped[0]["y1"] == pytest.approx(120.0)
+        assert mapped[0]["x2"] == pytest.approx(400.0)
+        assert mapped[0]["y2"] == pytest.approx(320.0)
+
+
+class TestMetadata:
+    def test_uses_the_analysed_frames_rtp_timestamp(self):
+        import main
+
+        class Sender:
+            payload = ""
+
+            def send_raw_json(self, payload):
+                self.payload = payload
+                return True
+
+        class Stream:
+            metadata_sender = Sender()
+
+        sample = main.FrameRef(pts_ns=12_402_999_999, frame_id=327)
+        main.send_metadata(Stream(), sample, [], ["person"])
+        payload = json.loads(Stream.metadata_sender.payload)
+
+        assert payload["timestamp"] == 12_402
+        assert payload["frame_id"] == "327"
+        assert payload["_insight"]["rtp_timestamp"] == (
+            sample.pts_ns * 90_000
+        ) // 1_000_000_000
+
+
+class TestLetterbox:
+    """The batch lane is filled in place, so geometry and padding must be exact."""
+
+    @staticmethod
+    def prepared():
+        cv2 = pytest.importorskip("cv2")
+        import main
+
+        main.np = np
+        main.cv2 = cv2
+        return main
+
+    def test_writes_lane_in_place_with_expected_geometry(self):
+        main = self.prepared()
+
+        rgb = np.full((720, 1280, 3), 255, dtype=np.uint8)
+        lane = np.empty((640, 640, 3), dtype=np.float32)
+        scale, dx, dy = main.letterbox_into(rgb, lane, 640)
+
+        # 1280x720 into 640 keeps aspect: 640x360, centered vertically.
+        assert scale == pytest.approx(0.5)
+        assert (dx, dy) == (0, 140)
+        # Image area is the scaled frame, the rest is pad 114.
+        assert lane[dy + 10, 10, 0] == pytest.approx(1.0)
+        assert lane[0, 0, 0] == pytest.approx(114.0 / 255.0)
+        assert lane[639, 639, 0] == pytest.approx(114.0 / 255.0)
+
+    def test_reuses_the_same_buffer(self):
+        main = self.prepared()
+
+        lane = np.zeros((640, 640, 3), dtype=np.float32)
+        before = lane.__array_interface__["data"][0]
+        main.letterbox_into(np.full((720, 1280, 3), 255, dtype=np.uint8), lane, 640)
+        assert lane.__array_interface__["data"][0] == before
+
+    def test_square_input_fills_the_lane(self):
+        main = self.prepared()
+
+        lane = np.empty((640, 640, 3), dtype=np.float32)
+        scale, dx, dy = main.letterbox_into(np.zeros((480, 480, 3), dtype=np.uint8), lane, 640)
+        assert (dx, dy) == (0, 0)
+        assert scale == pytest.approx(640.0 / 480.0)
+        assert float(lane.max()) == pytest.approx(0.0)

--- a/examples/object-detection/yolo26-batch4-detector/tests/test-scope.yaml
+++ b/examples/object-detection/yolo26-batch4-detector/tests/test-scope.yaml
@@ -1,0 +1,17 @@
+models:
+  yolo26m-det-int8-b4:
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b4.tar.gz
+    file: yolo26m-det-int8-b4.tar.gz
+unit:
+  python: true
+  cpp: true
+e2e:
+  python:
+    enabled: true
+    models:
+    - yolo26m-det-int8-b4
+  cpp:
+    enabled: true
+    models:
+    - yolo26m-det-int8-b4

--- a/examples/object-detection/yolo26-batch4-detector/tests/test-scope.yaml
+++ b/examples/object-detection/yolo26-batch4-detector/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   yolo26m-det-int8-b4:
     source: url
-    url: https://docs.sima.ai/pkg_downloads/SDK{platform_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b4.tar.gz
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26-detection/yolo26m-det-int8-b4.tar.gz
     file: yolo26m-det-int8-b4.tar.gz
 unit:
   python: true


### PR DESCRIPTION
## Summary

- add a dedicated C++ and Python `yolo26-batch4-detector` example for batch-size >1 YOLO26 models;
- assemble one `[4, 640, 640, 3]` input from up to four RTSP streams and decode all six raw YOLO26 heads per lane on the CPU;
- keep ingest overlapped with synchronous inference through reusable prefetched batch buffers;
- forward source H.264 to Insight without re-encoding and attach detection metadata to the exact analysed frame with `_insight.rtp_timestamp`;
- add portable config/head-mapping/decode/letterbox tests, hardware-gated e2e coverage, CMake registration, and full usage/runtime documentation.

C++ and Python use the same topology and metadata contract.

Closes #157

## Runtime dependency

> [!IMPORTANT]
> This example depends on the batched multi-output OFM layout fix from [sima-neat/internals#152](https://github.com/sima-neat/internals/pull/152). [sima-neat/core#705](https://github.com/sima-neat/core/pull/705) is its validation-only Core PR and must not be merged.

Without that fix, batch-size >1 models exposing multiple output tensors return silently misaddressed output lanes.

## Validation

- `./build.sh --clean` — passed on Modalix (all C++ examples and test targets built);
- `./tests/test.sh --unit` — all 13 C++ unit targets passed; the new Python suite passed 22/22;
- repository-wide Python unit run continued past the new suite, then hit pre-existing PyNeat/Core ABI errors in segmentation (`CameraInputWithCaptureBuffers` undefined);
- `python3 scripts/validate_readmes.py` — 15 READMEs passed;
- `python3 scripts/generate_catalog.py` — passed;
- `git diff --check` — passed;
- C++ hardware run: four 1280x720@30 RTSP streams, 20/20 batches completed per stream, about 19.2 dispatches/s and 76.8 aggregate frames/s;
- Python hardware run: four 1280x720@30 RTSP streams, 80/80 batches completed per stream, about 19.7 dispatches/s and 78.8 aggregate frames/s;
- C++ and Python both loaded the same `yolo26m-det-int8-b4` six-head model through the runtime hotpatch built from the dependency branch.

## Test scope

Unit and e2e coverage are enabled for both languages. The scope downloads `yolo26m-det-int8-b4.tar.gz` from the standard YOLO26 Model Zoo path; e2e uses the four RTSP sources provisioned by the hardware test environment and verifies metadata on all four lanes, including `_insight.rtp_timestamp`.

## Known behavior

The forwarded video remains 30 FPS while synchronous batch inference reaches about 18–20 results/s per stream. Insight therefore has intervening video frames without detection metadata, so overlays can appear to flicker. Carrying the last boxes onto newer frames was tested and rejected because it visibly delays boxes on moving objects; exact-frame alignment is the intended behavior.
