### PR TITLE
test(ssd): use staging Model Registry artifact

### DIFF
--- a/examples/object-detection/ssd-mobilenet-object-detector/README.md
+++ b/examples/object-detection/ssd-mobilenet-object-detector/README.md
@@ -43,19 +43,12 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-| Family | Frame | `model.preprocessing_profile` | Published variants |
-| --- | --- | --- | --- |
-| SSD-MobileNetV1 | 300 | `tensorflow_ssd` | INT8/BF16 × tessellation in/out of MLA |
-| SSD-MobileNetV2 | 300 | `tensorflow_ssd` | INT8/BF16 × tessellation in/out of MLA |
-| SSDlite-MobileNetV3 BF16 | 320 | `tensorflow_ssd` | BF16 × tessellation in/out of MLA |
-| SSDlite-MobileNetV3 QAT INT8 | 320 | `torchvision_ssdlite` | INT8 × tessellation in/out of MLA |
-
-Install all four compiled SSD-MobileNetV2 variants from the current develop catalog:
+The tested model is SSD-MobileNetV2 INT8 with tessellation inside the MLA. Install its production
+Model Registry package:
 
 ```bash
 mkdir -p models
-sima-cli neat install --stg \
-  models/ssd_mobilenet_v2@develop:latest \
+sima-cli neat install models/ssd_mobilenet_v2@main:latest \
   --install-dir ./models
 ```
 

--- a/examples/object-detection/ssd-mobilenet-object-detector/README.md
+++ b/examples/object-detection/ssd-mobilenet-object-detector/README.md
@@ -43,12 +43,12 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-The tested model is SSD-MobileNetV2 INT8 with tessellation inside the MLA. Install its production
+The tested model is SSD-MobileNetV2 INT8 with tessellation inside the MLA. Install its staging
 Model Registry package:
 
 ```bash
 mkdir -p models
-sima-cli neat install models/ssd_mobilenet_v2@main:latest \
+sima-cli neat install --stg models/ssd_mobilenet_v2@develop:latest \
   --install-dir ./models
 ```
 

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
@@ -2,7 +2,7 @@ models:
   ssd_v2_int8_tess_mla:
     source: model-registry
     name: ssd_mobilenet_v2
-    ref: main
+    ref: develop
     spec: latest
     file: ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz
 unit:

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
@@ -1,9 +1,10 @@
 models:
   ssd_v2_int8_tess_mla:
-    source: url
-    url: https://artifacts.stg.neat.sima.ai/models/feat%252Fssd-mobilenet-v1-model-matrix/195615d2856e/ssd_mobilenet_v2/modalix_int8_tess_mla/ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz
+    source: model-registry
+    name: ssd_mobilenet_v2
+    ref: main
+    spec: latest
     file: ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz
-    sha256: df63802305fffa634bb6368a9e3e964c54cdf249e7226e6c336f1994f1d13752
 unit:
   python: true
   cpp: true

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -330,7 +330,11 @@ download_model_registry_group() {
         return 1
     fi
     echo "[download] $resource (model-registry)"
-    if ! "$SIMA_CLI_BIN" neat install "$resource" --install-dir "$tmpdir"; then
+    local environment_args=()
+    if [[ "$registry_ref" == "develop" ]]; then
+        environment_args+=(--stg)
+    fi
+    if ! "$SIMA_CLI_BIN" neat install "${environment_args[@]}" "$resource" --install-dir "$tmpdir"; then
         rm -rf "$tmpdir"
         echo "[error] failed to install model-registry resource $resource" >&2
         return 1


### PR DESCRIPTION
## Why

The SSD E2E scope depended on a staging artifact URL tied to a feature branch and build ID instead of the published Model Registry catalog.

## What Changed

- Resolve the tested SSD-MobileNetV2 INT8 MLA archive from `models/ssd_mobilenet_v2@develop:latest`.
- Select the staging registry automatically for `develop` Model Registry resources.
- Simplify the README to document only the tested artifact and matching install command.

## Validation

- Installed the exact staging `develop:latest` package successfully with `sima-cli`.
- Confirmed the catalog contains `ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz`.
- Full test-scope validation passed.
- The SSD scope resolves the expected `develop:latest` entry.
- README validation passed for all 17 examples.
- Shell syntax and diff validation passed.
- The existing Python and C++ SSD E2E tests passed on Modalix with valid detection output.

Closes #430
