### PR TITLE
ci: align Apps sysroot with Core artifact

### DIFF
--- a/.github/workflows/vulcan-ci.yml
+++ b/.github/workflows/vulcan-ci.yml
@@ -73,6 +73,7 @@ jobs:
           -e NEAT_ARTIFACTS_BASE_URL="${artifact_base_url%/}/core" \
           -e NEAT_CORE_INSTALL_MODE="vulcan" \
           -e NEAT_INSTALLER_SKIP_PLATFORM_CHECK=ON \
+          -e NEAT_SYNC_SYSROOT=ON \
           -e NEAT_VULCAN_ENV="${{ needs.resolve-vulcan-config.outputs.vulcan_env }}" \
           "${sdk_container}" \
           bash -lc '

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ NEAT_CORE_METADATA="${DEPS_DIR}/neat-core.json"
 NEAT_DEBS_DIR="${DEPS_DIR}/debs"
 NEAT_INSTALLER_URL="${NEAT_INSTALLER_URL:-https://tools.sima-neat.com/install-neat.sh}"
 NEAT_ARTIFACTS_BASE_URL="${NEAT_ARTIFACTS_BASE_URL:-https://artifacts.neat.sima.ai/core}"
+ELXR_SDK_RELEASE_FILE="${ELXR_SDK_RELEASE_FILE:-/etc/sdk-release}"
 NEAT_CORE_INSTALL_DIR=""
 NEAT_CORE_INSTALL_DIR_OWNED=0
 LATEST_TAG_CACHE_DIR="$(mktemp -d /tmp/neat-apps-latest.XXXXXX)"
@@ -55,6 +56,7 @@ Environment:
                             (default: fresh /tmp/neat-apps-core-install.XXXXXX)
   NEAT_CORE_INSTALL_MODE    legacy or vulcan. Defaults to vulcan when NEAT_VULCAN_ENV is set.
   NEAT_VULCAN_ENV           Vulcan artifact environment for sima-cli core installs (default: production)
+  NEAT_SYNC_SYSROOT         Set to ON to align the eLxr SDK sysroot with the selected Core artifact
   CMAKE_TOOLCHAIN_FILE      Optional CMake toolchain file (auto-detected for cross)
   SYSROOT                   Target sysroot (used by the default cross toolchain file)
 EOF
@@ -863,8 +865,154 @@ run_sima_cli_core_install() {
   rm -f "${log_path}"
 }
 
+is_elxr_sdk() {
+  local sdk_version elxr_version
+  [[ -f "${ELXR_SDK_RELEASE_FILE}" ]] || return 1
+  sdk_version="$(sed -n 's/^SDK Version[[:space:]]*=[[:space:]]*//p' "${ELXR_SDK_RELEASE_FILE}" | head -n1)"
+  elxr_version="$(sed -n 's/^eLXr Version[[:space:]]*=[[:space:]]*//p' "${ELXR_SDK_RELEASE_FILE}" | head -n1)"
+  [[ -n "${sdk_version}" && -n "${elxr_version}" ]]
+}
+
+run_privileged() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "ERROR: root privileges are required to update the SDK sysroot." >&2
+    return 1
+  fi
+}
+
+sync_sysroot_from_core_artifact() (
+  local sima_cli_bin="$1"
+  local branch="$2"
+  local version="$3"
+  local vulcan_env="$4"
+  [[ "${NEAT_SYNC_SYSROOT:-OFF}" == "ON" ]] || return 0
+
+  if ! is_elxr_sdk; then
+    echo "ERROR: NEAT_SYNC_SYSROOT requires an eLxr SDK." >&2
+    return 1
+  fi
+  if ! command -v sysroot >/dev/null 2>&1; then
+    echo "ERROR: NEAT_SYNC_SYSROOT requires the sysroot command." >&2
+    return 1
+  fi
+
+  local resolve_output metadata_url
+  if ! resolve_output="$("${sima_cli_bin}" neat install \
+      --env "${vulcan_env}" -t minimal --json "core@${branch}:${version}")"; then
+    echo "ERROR: Failed to resolve Core metadata for sysroot alignment." >&2
+    return 1
+  fi
+  if ! metadata_url="$(RESOLVE_OUTPUT="${resolve_output}" python3 - "${branch}" "${version}" <<'PY'
+import json
+import os
+import sys
+
+text = os.environ["RESOLVE_OUTPUT"]
+start = text.find("{")
+if start < 0:
+    raise SystemExit("missing JSON object in sima-cli output")
+payload = json.loads(text[start:])
+if payload.get("repository") != "core":
+    raise SystemExit("resolved repository is not core")
+if payload.get("ref") != sys.argv[1] or payload.get("resolved_spec") != sys.argv[2]:
+    raise SystemExit("resolved Core target does not match the requested target")
+metadata_url = payload.get("metadata_url")
+if not isinstance(metadata_url, str) or not metadata_url:
+    raise SystemExit("resolved Core metadata URL is missing")
+print(metadata_url)
+PY
+  )"; then
+    echo "ERROR: Cannot verify resolved Core metadata identity." >&2
+    return 1
+  fi
+
+  local tmp_dir metadata_file manifest_file
+  tmp_dir="$(mktemp -d /tmp/neat-apps-sysroot.XXXXXX)"
+  trap 'rm -rf "${tmp_dir}"' EXIT
+  metadata_file="${tmp_dir}/metadata-minimal.json"
+  manifest_file="${tmp_dir}/internals-manifest.json"
+  if ! download_file "${metadata_url}" "${metadata_file}"; then
+    echo "ERROR: Failed to download selected Core metadata." >&2
+    return 1
+  fi
+
+  local resource_info manifest_url expected_checksum
+  if ! resource_info="$(python3 - "${metadata_file}" "${metadata_url}" <<'PY'
+import json
+import re
+import sys
+from urllib.parse import urljoin
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    metadata = json.load(handle)
+resource = "internals-manifest.json"
+if metadata.get("resources", []).count(resource) != 1:
+    raise SystemExit("Core metadata must contain exactly one Internals manifest")
+checksum = metadata.get("resources-checksum", {}).get(resource)
+if not isinstance(checksum, str) or not re.fullmatch(r"[0-9a-f]{64}", checksum):
+    raise SystemExit("Core metadata has no valid Internals manifest checksum")
+print(urljoin(sys.argv[2], resource) + "\t" + checksum)
+PY
+  )"; then
+    echo "ERROR: Cannot verify the Core Internals manifest resource." >&2
+    return 1
+  fi
+  manifest_url="${resource_info%%$'\t'*}"
+  expected_checksum="${resource_info#*$'\t'}"
+  if ! download_file "${manifest_url}" "${manifest_file}"; then
+    echo "ERROR: Failed to download the Core Internals manifest." >&2
+    return 1
+  fi
+
+  local receipt
+  if ! receipt="$(python3 - "${manifest_file}" "${APPS_MANIFEST}" "${expected_checksum}" <<'PY'
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != sys.argv[3]:
+    raise SystemExit("Internals manifest checksum mismatch")
+artifact = json.loads(manifest_path.read_text(encoding="utf-8"))
+consumer = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+receipt = artifact["sysroot-version"]
+consumer_base = consumer["platform-version"]
+if not isinstance(receipt, str) or (
+    receipt and not re.fullmatch(r"[0-9]+(?:[.][0-9]+){2}~pre[0-9]+", receipt)
+):
+    raise SystemExit("invalid sysroot-version")
+if receipt and consumer_base != receipt.split("~pre", 1)[0]:
+    raise SystemExit("platform-version does not match the Internals receipt")
+print(receipt)
+PY
+  )"; then
+    echo "ERROR: Cannot verify the Core Internals build receipt." >&2
+    return 1
+  fi
+  if [[ -z "${receipt}" ]]; then
+    echo "Apps is using the existing SDK sysroot."
+    return 0
+  fi
+
+  echo "Updating SDK sysroot to Core's Internals receipt ${receipt}"
+  if ! run_privileged sysroot update "${receipt}"; then
+    echo "ERROR: Failed to update SDK sysroot to ${receipt}." >&2
+    return 1
+  fi
+  if ! sysroot status; then
+    echo "ERROR: Failed to read SDK sysroot status." >&2
+    return 1
+  fi
+)
+
 ensure_neat_core() {
-  local branch install_mode sima_cli_bin version vulcan_env
+  local branch install_mode sima_cli_bin="" version vulcan_env
   mkdir -p "${DEPS_DIR}" "${NEAT_DEBS_DIR}"
   load_neat_core_target
   branch="${NEAT_CORE_TARGET_BRANCH}"
@@ -888,6 +1036,18 @@ ensure_neat_core() {
   NEAT_CORE_TARGET_VERSION="${version}"
   write_neat_core_metadata "${branch}" "${version}"
 
+  if [[ "${NEAT_SYNC_SYSROOT:-OFF}" == "ON" ]]; then
+    if [[ "${install_mode}" != "vulcan" ]]; then
+      echo "ERROR: NEAT_SYNC_SYSROOT requires NEAT_CORE_INSTALL_MODE=vulcan." >&2
+      exit 1
+    fi
+    if ! sima_cli_bin="$(resolve_sima_cli_bin)"; then
+      echo "ERROR: NEAT_SYNC_SYSROOT requires sima-cli on PATH or SIMA_CLI_BIN." >&2
+      exit 1
+    fi
+    sync_sysroot_from_core_artifact "${sima_cli_bin}" "${branch}" "${version}" "${vulcan_env}"
+  fi
+
   local expected_tag="${branch}/${version}"
   if neat_core_installed_matches "${branch}" "${version}" "${vulcan_env:-}"; then
     echo "NEAT core already installed (${expected_tag}). Skipping install."
@@ -898,7 +1058,7 @@ ensure_neat_core() {
 
   if [[ "${install_mode}" == "vulcan" ]]; then
     local install_status
-    if ! sima_cli_bin="$(resolve_sima_cli_bin)"; then
+    if [[ -z "${sima_cli_bin}" ]] && ! sima_cli_bin="$(resolve_sima_cli_bin)"; then
       echo "ERROR: NEAT_CORE_INSTALL_MODE=vulcan requires sima-cli on PATH or SIMA_CLI_BIN." >&2
       exit 1
     fi

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import os
@@ -260,6 +261,7 @@ def _write_fake_curl(tmp_path: Path) -> tuple[Path, Path]:
             #!/usr/bin/env python3
             from __future__ import annotations
 
+            import json
             import os
             import sys
             from pathlib import Path
@@ -315,11 +317,12 @@ def _write_fake_curl(tmp_path: Path) -> tuple[Path, Path]:
                 if line.strip()
             )
 
+            bodies = json.loads(os.environ.get("NEAT_APPS_TEST_URL_BODIES", "{}"))
             parts = [part for part in urlparse(url).path.split("/") if part]
-            body = None
-            if len(parts) >= 2 and parts[-1] == "latest.tag":
+            body = bodies.get(url)
+            if body is None and len(parts) >= 2 and parts[-1] == "latest.tag":
                 body = tags.get(parts[-2])
-            elif len(parts) >= 3 and parts[-1] == "metadata.json":
+            elif body is None and len(parts) >= 3 and parts[-1] == "metadata.json":
                 branch = parts[-3]
                 version = parts[-2]
                 if f"{branch}:{version}" in metadata:
@@ -388,6 +391,13 @@ def _write_fake_sima_cli(tmp_path: Path) -> Path:
             set -euo pipefail
             printf '%s\\n' "$PWD" >> "${NEAT_APPS_TEST_SIMA_CLI_CWD}"
             printf '%s\\n' "$*" >> "${NEAT_APPS_TEST_SIMA_CLI_ARGS}"
+            if [[ -n "${NEAT_APPS_TEST_EVENT_LOG:-}" ]]; then
+                printf 'sima-cli:%s\\n' "$*" >> "${NEAT_APPS_TEST_EVENT_LOG}"
+            fi
+            if [[ "$*" == *"--json"* ]]; then
+                printf '%s\\n' "${NEAT_APPS_TEST_SIMA_CLI_JSON:-}"
+                exit "${NEAT_APPS_TEST_SIMA_CLI_JSON_STATUS:-0}"
+            fi
             if [[ -n "${NEAT_APPS_TEST_FORBIDDEN_PATH:-}" ]]; then
                 [[ ! -e "${NEAT_APPS_TEST_FORBIDDEN_PATH}" ]]
             fi
@@ -597,6 +607,98 @@ def _write_fake_neat_json(
     )
     neat_path.chmod(0o755)
     return bin_dir
+
+
+def _write_fake_sysroot(tmp_path: Path) -> dict[str, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    sdk_release = tmp_path / "sdk-release"
+    sdk_release.write_text(
+        "SDK Version = 2.0.0\neLXr Version = 12.9.0\n", encoding="utf-8"
+    )
+    id_path = bin_dir / "id"
+    id_path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            [[ "${1:-}" == -u ]] && echo 0
+            """
+        ),
+        encoding="utf-8",
+    )
+    id_path.chmod(0o755)
+    sysroot_path = bin_dir / "sysroot"
+    sysroot_path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '%s\\n' "$*" >> "${NEAT_APPS_TEST_SYSROOT_LOG}"
+            if [[ -n "${NEAT_APPS_TEST_EVENT_LOG:-}" ]]; then
+                printf 'sysroot:%s\\n' "$*" >> "${NEAT_APPS_TEST_EVENT_LOG}"
+            fi
+            case "${1:-}" in
+              update) exit "${NEAT_APPS_TEST_SYSROOT_UPDATE_STATUS:-0}" ;;
+              status) exit "${NEAT_APPS_TEST_SYSROOT_STATUS_STATUS:-0}" ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    sysroot_path.chmod(0o755)
+    return {
+        "ELXR_SDK_RELEASE_FILE": str(sdk_release),
+        "NEAT_APPS_TEST_SYSROOT_LOG": str(tmp_path / "sysroot.log"),
+        "NEAT_APPS_TEST_EVENT_LOG": str(tmp_path / "events.log"),
+    }
+
+
+def _sysroot_sync_env(
+    tmp_path: Path,
+    *,
+    manifest_text: str = '{"sysroot-version":"2.0.0~pre9999"}\n',
+    metadata: dict[str, object] | None = None,
+    resolve: dict[str, object] | None = None,
+) -> dict[str, str]:
+    branch = "scratch-core-for-test"
+    version = "scratchsha1"
+    metadata_url = (
+        f"https://vulcan.test/core/{branch}/{version}/metadata-minimal.json"
+    )
+    manifest_url = (
+        f"https://vulcan.test/core/{branch}/{version}/internals-manifest.json"
+    )
+    checksum = hashlib.sha256(manifest_text.encode()).hexdigest()
+    if metadata is None:
+        metadata = {
+            "resources": ["internals-manifest.json"],
+            "resources-checksum": {"internals-manifest.json": checksum},
+        }
+    if resolve is None:
+        resolve = {
+            "repository": "core",
+            "ref": branch,
+            "resolved_spec": version,
+            "metadata_url": metadata_url,
+        }
+    bin_dir = _write_fake_sima_cli(tmp_path)
+    return {
+        **_write_fake_sysroot(tmp_path),
+        "NEAT_APPS_DEPENDENCY_BRANCH": branch,
+        "NEAT_CORE_INSTALL_MODE": "vulcan",
+        "NEAT_SYNC_SYSROOT": "ON",
+        "NEAT_VULCAN_ENV": "production",
+        "NEAT_APPS_TEST_SIMA_CLI_ARGS": str(tmp_path / "sima-cli-args.txt"),
+        "NEAT_APPS_TEST_SIMA_CLI_CWD": str(tmp_path / "sima-cli-cwd.txt"),
+        "NEAT_APPS_TEST_SIMA_CLI_JSON": json.dumps(resolve),
+        "NEAT_APPS_TEST_URL_BODIES": json.dumps(
+            {
+                metadata_url: json.dumps(metadata),
+                manifest_url: manifest_text,
+            }
+        ),
+        "SIMA_CLI_BIN": str(bin_dir / "sima-cli"),
+    }
 
 
 def test_empty_manifest_resolves_from_dependency_branch_and_platform_version(tmp_path):
@@ -904,6 +1006,187 @@ def test_vulcan_core_install_repairs_mixed_runtime_branch(tmp_path):
         .strip()
         .endswith("core@scratch-core-for-test:scratchsha1")
     )
+
+
+def test_vulcan_sysroot_sync_precedes_core_install(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env=_sysroot_sync_env(tmp_path),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (tmp_path / "events.log").read_text(encoding="utf-8").splitlines() == [
+        "sima-cli:neat install --env production -t minimal --json "
+        "core@scratch-core-for-test:scratchsha1",
+        "sysroot:update 2.0.0~pre9999",
+        "sysroot:status",
+        "sima-cli:neat install --env production -d . -t minimal "
+        "core@scratch-core-for-test:scratchsha1",
+    ]
+
+
+def test_vulcan_sysroot_sync_accepts_empty_receipt(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env=_sysroot_sync_env(
+            tmp_path, manifest_text='{"sysroot-version":""}\n'
+        ),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert not (tmp_path / "sysroot.log").exists()
+    assert "Apps is using the existing SDK sysroot." in proc.stdout
+
+
+def test_vulcan_sysroot_sync_runs_before_installed_core_shortcut(tmp_path):
+    env = _sysroot_sync_env(tmp_path)
+    _write_fake_neat_json(
+        tmp_path,
+        channel="scratch-core-for-test",
+        tag="scratchsha1",
+        env="prod",
+    )
+
+    proc = _run_build(tmp_path, args=["--only-install-neat-core"], env=env)
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (tmp_path / "events.log").read_text(encoding="utf-8").splitlines() == [
+        "sima-cli:neat install --env production -t minimal --json "
+        "core@scratch-core-for-test:scratchsha1",
+        "sysroot:update 2.0.0~pre9999",
+        "sysroot:status",
+    ]
+    assert "NEAT core already installed" in proc.stdout
+
+
+@pytest.mark.parametrize(
+    "manifest_text",
+    [
+        "{",
+        "{}",
+        '{"sysroot-version":"latest"}',
+        '{"sysroot-version":"2.0.0~pre9999; touch /tmp/nope"}',
+        '{"sysroot-version":"2.0.0~pre9999\\nstatus"}',
+        '{"sysroot-version":"2.0.1~pre9999"}',
+    ],
+)
+def test_vulcan_sysroot_sync_rejects_invalid_receipts(tmp_path, manifest_text):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env=_sysroot_sync_env(tmp_path, manifest_text=manifest_text),
+    )
+
+    assert proc.returncode != 0
+    assert "Cannot verify the Core Internals build receipt" in proc.stderr
+    assert not (tmp_path / "sysroot.log").exists()
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"resources": [], "resources-checksum": {}},
+        {
+            "resources": ["internals-manifest.json", "internals-manifest.json"],
+            "resources-checksum": {"internals-manifest.json": "0" * 64},
+        },
+        {
+            "resources": ["internals-manifest.json"],
+            "resources-checksum": {},
+        },
+        {
+            "resources": ["internals-manifest.json"],
+            "resources-checksum": {"internals-manifest.json": "0" * 64},
+        },
+    ],
+)
+def test_vulcan_sysroot_sync_rejects_untrusted_resource(tmp_path, metadata):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env=_sysroot_sync_env(tmp_path, metadata=metadata),
+    )
+
+    assert proc.returncode != 0
+    assert not (tmp_path / "sysroot.log").exists()
+
+
+def test_vulcan_sysroot_sync_rejects_wrong_core_identity(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env=_sysroot_sync_env(
+            tmp_path,
+            resolve={
+                "repository": "core",
+                "ref": "develop",
+                "resolved_spec": "scratchsha1",
+                "metadata_url": "https://vulcan.test/core/metadata-minimal.json",
+            },
+        ),
+    )
+
+    assert proc.returncode != 0
+    assert "Cannot verify resolved Core metadata identity" in proc.stderr
+    assert not (tmp_path / "sysroot.log").exists()
+
+
+@pytest.mark.parametrize(
+    ("status_env", "expected_calls"),
+    [
+        ("NEAT_APPS_TEST_SYSROOT_UPDATE_STATUS", ["update 2.0.0~pre9999"]),
+        (
+            "NEAT_APPS_TEST_SYSROOT_STATUS_STATUS",
+            ["update 2.0.0~pre9999", "status"],
+        ),
+    ],
+)
+def test_vulcan_sysroot_sync_propagates_command_failure(
+    tmp_path, status_env, expected_calls
+):
+    env = _sysroot_sync_env(tmp_path)
+    env[status_env] = "23"
+
+    proc = _run_build(tmp_path, args=["--only-install-neat-core"], env=env)
+
+    assert proc.returncode != 0
+    assert (tmp_path / "sysroot.log").read_text(encoding="utf-8").splitlines() == (
+        expected_calls
+    )
+
+
+def test_vulcan_sysroot_sync_requires_sysroot_tool(tmp_path):
+    env = _sysroot_sync_env(tmp_path)
+    (tmp_path / "bin/sysroot").unlink()
+
+    proc = _run_build(tmp_path, args=["--only-install-neat-core"], env=env)
+
+    assert proc.returncode != 0
+    assert "requires the sysroot command" in proc.stderr
+
+
+def test_vulcan_build_enables_ordered_sysroot_sync_without_receipt_pin():
+    script = BUILD_SH.read_text(encoding="utf-8")
+    workflow = VULCAN_WORKFLOW.read_text(encoding="utf-8")
+    manifest = json.loads(
+        (APPS_ROOT / "deps/manifest.json").read_text(encoding="utf-8")
+    )
+    sync = script.index(
+        'sync_sysroot_from_core_artifact "${sima_cli_bin}" "${branch}"'
+    )
+    installed = script.index("if neat_core_installed_matches", sync)
+    installer = script.index("run_sima_cli_core_install", installed)
+    ensure = script.index("  ensure_neat_core\n")
+    configure = script.index("  cmake -S . -B", ensure)
+
+    assert '[[ "${NEAT_SYNC_SYSROOT:-OFF}" == "ON" ]] || return 0' in script
+    assert "-e NEAT_SYNC_SYSROOT=ON" in workflow
+    assert "sysroot-version" not in manifest
+    assert "sysroot update --latest" not in script
+    assert sync < installed < installer
+    assert ensure < configure
 
 
 def test_vulcan_installer_creates_flat_prebuilt_apps_directory(tmp_path):


### PR DESCRIPTION
## Why

Apps installs an exact Core artifact in Vulcan, but it can still compile against a different cached SDK sysroot. Core now publishes the verified Internals receipt needed to align that sysroot.

## What Changed

- Resolve the selected Core artifact and verify its checksummed `internals-manifest.json` before installing Core.
- Validate the exact receipt against Apps' `platform-version`, then run `sysroot update` and `sysroot status`.
- Run synchronization before the installed-Core shortcut and Core installation.
- Enable synchronization only in Vulcan CI. Local builds remain off by default, and Apps does not own a `sysroot-version` pin.
- Extend the manifest-contract tests for valid, empty, malformed, mismatched, untrusted, and failed synchronization paths.

## Validation

- `bash -n build.sh`
- `git diff --check origin/develop...HEAD`

## Notes

The focused pytest suite was not run locally because the host interpreter does not have pytest installed. Core PR sima-neat/core#771 is merged, and its post-merge Vulcan publication is still running.

Closes #443