### PR TITLE
fix(skills): route end-to-end app requests

### DIFF
--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neat-application-builder
-description: Use when building Neat Library applications with public C++ or Python APIs, including choosing between Model, Graph, GenAIModel, and GenAIServer; using Run handles returned by built graphs; reading packaged core headers/docs; composing application pipelines; and validating Neat Development Environment or DevKit behavior. Do not use for repository maintenance, release automation, review workflows, or work outside the public Neat Library application surface.
+description: Builds runnable Neat Library applications with public C++ or Python APIs after ONNX compilation or from existing model artifacts. Use for end-to-end model apps, DevKit runs, classification or detection pipelines, and camera, file, or RTSP inputs that may require Model, Graph, SimaDecode, Preproc, GenAIModel, or GenAIServer. Chooses the API and input topology before consulting Apps examples. Do not use for model quantization or compilation, repository maintenance, release automation, or review workflows.
 ---
 
 # Neat Application Builder
@@ -18,12 +18,20 @@ reference implementations after the API shape is chosen.
    - In the Neat Development Environment, read `/neat-resources/core-src` first.
    - Prefer installed public headers under the Neat Development Environment sysroot when checking the user-facing contract.
    - Read `references/source-of-truth.md`.
-2. Choose the application API shape before writing code.
+2. Establish the artifact and input boundary before opening an Apps example.
+   - An ONNX file is compiler input, not the runtime artifact for a classic Neat
+     application. Treat compilation as a prerequisite outside this skill, then
+     continue with the compiled model archive.
+   - Decide whether application code supplies decoded images or tensors, or the
+     graph owns a camera, file, encoded stream, or other source.
+   - Inspect the model package before deciding whether preprocessing and
+     postprocessing already belong to its route.
+3. Choose the application API shape before writing code.
    - Read `references/api-decision-map.md`.
-3. If the request touches APIs outside the main Model/Graph/Run/GenAI path, read `references/api-surface-map.md` and inspect the referenced headers/docs.
-4. For classic compiled model applications, read `references/model-graph-run.md`.
-5. For LLM, VLM, ASR, or HTTP model serving applications, read `references/genai.md`.
-6. Before claiming success, read `references/validation.md` and run the validation that is possible in the current environment.
+4. If the request touches APIs outside the main Model/Graph/Run/GenAI path, read `references/api-surface-map.md` and inspect the referenced headers/docs.
+5. For classic compiled model applications, read `references/model-graph-run.md`.
+6. For LLM, VLM, ASR, or HTTP model serving applications, read `references/genai.md`.
+7. Before claiming success, read `references/validation.md` and run the validation that is possible in the current environment.
 
 ## Defaults
 
@@ -35,8 +43,11 @@ reference implementations after the API shape is chosen.
 
 ## API Selection
 
-- Use `Model` for a single classic compiled model archive and direct request/response inference.
-- Use `Graph` when the application needs multiple stages, named inputs or outputs, branching, fan-in, reusable fragments, or source/output nodes.
+- Use `Model` when application code owns decoded image or tensor input and the
+  model-owned route is the complete pipeline.
+- Use `Graph` when the application owns a source or explicitly composes
+  decoding, preprocessing, multiple stages, named endpoints, branching, fan-in,
+  reusable fragments, or output side paths.
 - Use `GenAIModel` for in-process GenAI calls against LLiMa model directories.
 - Use `GenAIServer` when a browser, service, or remote client should call GenAI models over HTTP.
 

--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neat-application-builder
-description: Build end-to-end Neat applications with public C++ or Python APIs. Use when a request starts from ONNX or a compiled model and targets a DevKit, including Model, Graph, GenAIModel, GenAIServer, camera, file, or RTSP pipelines. Choose the API shape before consulting Apps examples. Model compilation and repository workflows use separate skills.
+description: Build Neat applications with public C++ or Python APIs in the Neat Development Environment or on DevKit. Use for classic apps that start from ONNX or compiled model archives, GenAI apps from deployed model directories, and camera, file, or RTSP pipelines. Choose Model, Graph, GenAIModel, or GenAIServer before consulting Apps examples. Model compilation and repository workflows use separate skills.
 ---
 
 # Neat Application Builder

--- a/skills/neat-application-builder/SKILL.md
+++ b/skills/neat-application-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neat-application-builder
-description: Builds runnable Neat Library applications with public C++ or Python APIs after ONNX compilation or from existing model artifacts. Use for end-to-end model apps, DevKit runs, classification or detection pipelines, and camera, file, or RTSP inputs that may require Model, Graph, SimaDecode, Preproc, GenAIModel, or GenAIServer. Chooses the API and input topology before consulting Apps examples. Do not use for model quantization or compilation, repository maintenance, release automation, or review workflows.
+description: Build end-to-end Neat applications with public C++ or Python APIs. Use when a request starts from ONNX or a compiled model and targets a DevKit, including Model, Graph, GenAIModel, GenAIServer, camera, file, or RTSP pipelines. Choose the API shape before consulting Apps examples. Model compilation and repository workflows use separate skills.
 ---
 
 # Neat Application Builder
@@ -18,20 +18,13 @@ reference implementations after the API shape is chosen.
    - In the Neat Development Environment, read `/neat-resources/core-src` first.
    - Prefer installed public headers under the Neat Development Environment sysroot when checking the user-facing contract.
    - Read `references/source-of-truth.md`.
-2. Establish the artifact and input boundary before opening an Apps example.
-   - An ONNX file is compiler input, not the runtime artifact for a classic Neat
-     application. Treat compilation as a prerequisite outside this skill, then
-     continue with the compiled model archive.
-   - Decide whether application code supplies decoded images or tensors, or the
-     graph owns a camera, file, encoded stream, or other source.
-   - Inspect the model package before deciding whether preprocessing and
-     postprocessing already belong to its route.
-3. Choose the application API shape before writing code.
+2. Choose the application API shape before opening an Apps example.
    - Read `references/api-decision-map.md`.
-4. If the request touches APIs outside the main Model/Graph/Run/GenAI path, read `references/api-surface-map.md` and inspect the referenced headers/docs.
-5. For classic compiled model applications, read `references/model-graph-run.md`.
-6. For LLM, VLM, ASR, or HTTP model serving applications, read `references/genai.md`.
-7. Before claiming success, read `references/validation.md` and run the validation that is possible in the current environment.
+   - Continue after the runtime artifact, input owner, and API family are known.
+3. If the request touches APIs outside the main Model/Graph/Run/GenAI path, read `references/api-surface-map.md` and inspect the referenced headers/docs.
+4. For classic compiled model applications, read `references/model-graph-run.md`.
+5. For LLM, VLM, ASR, or HTTP model serving applications, read `references/genai.md`.
+6. Before claiming success, read `references/validation.md` and run the validation that is possible in the current environment.
 
 ## Defaults
 
@@ -40,16 +33,6 @@ reference implementations after the API shape is chosen.
 - Use only public APIs from installed headers and bindings.
 - Prefer clear application endpoint names such as `image`, `detections`, `classes`, `preview`, `prompt`, and `tokens`.
 - Keep generated application code runnable with explicit build and run commands.
-
-## API Selection
-
-- Use `Model` when application code owns decoded image or tensor input and the
-  model-owned route is the complete pipeline.
-- Use `Graph` when the application owns a source or explicitly composes
-  decoding, preprocessing, multiple stages, named endpoints, branching, fan-in,
-  reusable fragments, or output side paths.
-- Use `GenAIModel` for in-process GenAI calls against LLiMa model directories.
-- Use `GenAIServer` when a browser, service, or remote client should call GenAI models over HTTP.
 
 ## DevKit Local Display and Run
 

--- a/skills/neat-application-builder/agents/openai.yaml
+++ b/skills/neat-application-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Neat Application Builder"
-  short_description: "Build runnable Neat model applications"
-  default_prompt: "Use $neat-application-builder to choose the input topology and public API before building a runnable Neat application."
+  short_description: "Build applications with the Neat Library APIs"
+  default_prompt: "Use $neat-application-builder to build a Neat Library application with the right public API shape."

--- a/skills/neat-application-builder/agents/openai.yaml
+++ b/skills/neat-application-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Neat Application Builder"
-  short_description: "Build applications with the Neat Library APIs"
-  default_prompt: "Use $neat-application-builder to build a Neat Library application with the right public API shape."
+  short_description: "Build runnable Neat model applications"
+  default_prompt: "Use $neat-application-builder to choose the input topology and public API before building a runnable Neat application."

--- a/skills/neat-application-builder/playbook.yml
+++ b/skills/neat-application-builder/playbook.yml
@@ -2,7 +2,7 @@ id: neat-application-builder
 name: Neat Application Builder
 version: 0.1.2
 agents: [codex, claude]
-description: Build runnable Neat Library applications from compiled model artifacts, including API and input-topology selection for Model, Graph, GenAIModel, and GenAIServer.
+description: Build end-to-end Neat applications on DevKit after choosing the public API shape.
 compatibility:
   env_types: [sdk]
   env_subtypes: [linux, palette]

--- a/skills/neat-application-builder/playbook.yml
+++ b/skills/neat-application-builder/playbook.yml
@@ -1,8 +1,8 @@
 id: neat-application-builder
 name: Neat Application Builder
-version: 0.1.1
+version: 0.1.2
 agents: [codex, claude]
-description: Generic application-building guidance for the installed Neat Library public APIs, including Model, Graph, GenAIModel, and GenAIServer.
+description: Build runnable Neat Library applications from compiled model artifacts, including API and input-topology selection for Model, Graph, GenAIModel, and GenAIServer.
 compatibility:
   env_types: [sdk]
   env_subtypes: [linux, palette]

--- a/skills/neat-application-builder/playbook.yml
+++ b/skills/neat-application-builder/playbook.yml
@@ -2,7 +2,7 @@ id: neat-application-builder
 name: Neat Application Builder
 version: 0.1.2
 agents: [codex, claude]
-description: Build end-to-end Neat applications on DevKit after choosing the public API shape.
+description: Build Neat applications in the Neat Development Environment or on DevKit after choosing the public API shape.
 compatibility:
   env_types: [sdk]
   env_subtypes: [linux, palette]

--- a/skills/neat-application-builder/references/api-decision-map.md
+++ b/skills/neat-application-builder/references/api-decision-map.md
@@ -1,51 +1,39 @@
 # API Decision Map
 
 Choose the public API shape before writing code. Start with the artifact and
-input boundary, then select the smallest API that owns the required topology.
+input owner, then select the smallest API that fits the application.
 
 ## Artifact and input boundary
 
-- A classic Neat application consumes a compiled model archive, commonly an MPK
-  `.tar.gz`, rather than the source ONNX file. Compilation is a prerequisite
-  outside this skill; return to application design when the archive exists.
-- Application-owned input means the caller supplies decoded images or tensors
-  and controls request cadence.
-- Graph-owned input means the application topology owns a camera, file, RTSP
-  stream, encoded media source, or another producer.
-- Inspect the compiled package before adding preprocessing or postprocessing.
-  Keep stages already owned by the model route instead of rebuilding them as
-  application nodes.
+- Classic applications consume a compiled model archive, not ONNX. Complete
+  compilation before application design.
+- Decide whether the caller supplies decoded inputs or the application owns a
+  source and topology.
+- Inspect the model package before adding preprocessing or postprocessing.
 
 ## Classic Model
 
 Use `Model.run(...)` when:
 
-- The artifact is a compiled model archive, usually `.tar.gz`.
-- Application code supplies decoded image or tensor input.
-- The app runs one model on one request or one frame at a time.
+- The caller supplies decoded images or tensors.
 - Synchronous request/response behavior is acceptable.
 - The model-owned route is the complete pipeline.
 
 Use `Model.build(...)` when:
 
-- The app still centers on one model.
-- Application code still owns input and request cadence.
-- The app needs a long-lived runner with repeated `push` / `pull`.
+- The caller still owns input and request cadence.
+- The app needs repeated `push` / `pull`.
 - The model-owned `Runner` interface is enough.
 
 ## Graph
 
 Use `Graph` when:
 
-- The graph owns a camera, file, RTSP stream, encoded media source, or another
+- The application owns a camera, file, RTSP stream, encoded source, or other
   producer.
-- The application explicitly composes decoding, preprocessing, or output side
-  paths around the model route.
-- The app has multiple stages.
-- The app composes a model with public nodes or node groups.
-- The app needs named public inputs or outputs.
-- The app needs branching, fan-in, reusable graph fragments, or source/output nodes.
-- The app must expose an application boundary beyond a single model call.
+- The application composes decoding, preprocessing, or output paths around the
+  model route.
+- The application needs multiple stages, named endpoints, branching, or fan-in.
 
 ## GenAI
 

--- a/skills/neat-application-builder/references/api-decision-map.md
+++ b/skills/neat-application-builder/references/api-decision-map.md
@@ -1,20 +1,35 @@
 # API Decision Map
 
-Choose the public API shape before writing code. Start with the smallest API that
-matches the application boundary.
+Choose the public API shape before writing code. Start with the artifact and
+input boundary, then select the smallest API that owns the required topology.
+
+## Artifact and input boundary
+
+- A classic Neat application consumes a compiled model archive, commonly an MPK
+  `.tar.gz`, rather than the source ONNX file. Compilation is a prerequisite
+  outside this skill; return to application design when the archive exists.
+- Application-owned input means the caller supplies decoded images or tensors
+  and controls request cadence.
+- Graph-owned input means the application topology owns a camera, file, RTSP
+  stream, encoded media source, or another producer.
+- Inspect the compiled package before adding preprocessing or postprocessing.
+  Keep stages already owned by the model route instead of rebuilding them as
+  application nodes.
 
 ## Classic Model
 
 Use `Model.run(...)` when:
 
 - The artifact is a compiled model archive, usually `.tar.gz`.
+- Application code supplies decoded image or tensor input.
 - The app runs one model on one request or one frame at a time.
 - Synchronous request/response behavior is acceptable.
-- The app does not need custom input/output nodes, branching, fan-in, or a long-lived producer/consumer loop.
+- The model-owned route is the complete pipeline.
 
 Use `Model.build(...)` when:
 
 - The app still centers on one model.
+- Application code still owns input and request cadence.
 - The app needs a long-lived runner with repeated `push` / `pull`.
 - The model-owned `Runner` interface is enough.
 
@@ -22,6 +37,10 @@ Use `Model.build(...)` when:
 
 Use `Graph` when:
 
+- The graph owns a camera, file, RTSP stream, encoded media source, or another
+  producer.
+- The application explicitly composes decoding, preprocessing, or output side
+  paths around the model route.
 - The app has multiple stages.
 - The app composes a model with public nodes or node groups.
 - The app needs named public inputs or outputs.

--- a/skills/neat-application-builder/references/api-decision-map.md
+++ b/skills/neat-application-builder/references/api-decision-map.md
@@ -7,8 +7,8 @@ input owner, then select the smallest API that fits the application.
 
 - Classic applications consume a compiled model archive, not ONNX. Complete
   compilation before application design.
-- Decide whether the caller supplies decoded inputs or the application owns a
-  source and topology.
+- Decide whether the caller supplies decoded inputs or the `Graph` owns a source
+  and topology.
 - Inspect the model package before adding preprocessing or postprocessing.
 
 ## Classic Model
@@ -29,7 +29,7 @@ Use `Model.build(...)` when:
 
 Use `Graph` when:
 
-- The application owns a camera, file, RTSP stream, encoded source, or other
+- The `Graph` owns a camera, file, RTSP stream, encoded source, or other
   producer.
 - The application composes decoding, preprocessing, or output paths around the
   model route.

--- a/skills/neat-application-builder/references/model-graph-run.md
+++ b/skills/neat-application-builder/references/model-graph-run.md
@@ -5,11 +5,8 @@ packaged for Neat as compiled archives, commonly `.tar.gz` MPK artifacts.
 
 ## Model
 
-`Model` loads and validates a compiled model archive. Use it when application
-code supplies decoded images or tensors and the package-owned route is the
-complete pipeline. Classification, detection, segmentation, depth, or embedding
-describes the model task; it does not decide whether the application needs a
-`Model` or an explicit `Graph`.
+`Model` loads and validates a compiled model archive. Use it only when the API
+decision map identifies caller-owned input.
 
 Common application steps:
 
@@ -25,11 +22,6 @@ Do not manually recreate the model route unless the public API requires it. Let
 ## Graph
 
 `Graph` is the application assembly boundary.
-
-Use it when the application owns a source such as a camera, file, or RTSP
-stream, or when it explicitly composes decode, preprocessing, multiple model
-stages, branching, or output side paths. Keep package-owned stages inside the
-model route rather than recreating them as application nodes.
 
 Use `add(...)` for linear chains:
 

--- a/skills/neat-application-builder/references/model-graph-run.md
+++ b/skills/neat-application-builder/references/model-graph-run.md
@@ -5,9 +5,11 @@ packaged for Neat as compiled archives, commonly `.tar.gz` MPK artifacts.
 
 ## Model
 
-`Model` loads and validates a compiled model archive. Use it first for classic
-classification, detection, segmentation, depth, embedding, and similar fixed
-shape model workflows.
+`Model` loads and validates a compiled model archive. Use it when application
+code supplies decoded images or tensors and the package-owned route is the
+complete pipeline. Classification, detection, segmentation, depth, or embedding
+describes the model task; it does not decide whether the application needs a
+`Model` or an explicit `Graph`.
 
 Common application steps:
 
@@ -23,6 +25,11 @@ Do not manually recreate the model route unless the public API requires it. Let
 ## Graph
 
 `Graph` is the application assembly boundary.
+
+Use it when the application owns a source such as a camera, file, or RTSP
+stream, or when it explicitly composes decode, preprocessing, multiple model
+stages, branching, or output side paths. Keep package-owned stages inside the
+model route rather than recreating them as application nodes.
 
 Use `add(...)` for linear chains:
 
@@ -72,4 +79,3 @@ public input or output. If more than one endpoint exists, use the names.
 
 Use `Sample` when the application needs frame IDs, timestamps, bundled values,
 or other metadata. Use `TensorList` when raw tensor payloads are enough.
-


### PR DESCRIPTION
## Why

Requests to build an end-to-end DevKit application from ONNX could reach model compilation, then adapt an Apps example without first choosing between `Model` and `Graph`.

## What changed

- Add concise ONNX, compiled-model, end-to-end, and DevKit selection cues.
- Require the runtime artifact, input owner, and API family to be known before consulting examples.
- Keep Model-versus-Graph selection in one decision map and bump the skill to 0.1.2.

## Validation

- Passed the skill structure validator and metadata checks.
- Installed the final skill into isolated Claude and Codex homes.
- Verified the original ONNX-to-DevKit prompt chooses the compilation boundary before selecting `Model` or `Graph`.
- Passed `git diff --check`.

## Notes

This changes agent guidance only. It does not change examples, APIs, compilation, or runtime behavior.

Closes #374
