### PR TITLE
fix(ci): accept stable sysroot receipts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -984,7 +984,8 @@ consumer = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 receipt = artifact["sysroot-version"]
 consumer_base = consumer["platform-version"]
 if not isinstance(receipt, str) or (
-    receipt and not re.fullmatch(r"[0-9]+(?:[.][0-9]+){2}~pre[0-9]+", receipt)
+    receipt
+    and not re.fullmatch(r"[0-9]+(?:[.][0-9]+){2}(?:~pre[0-9]+)?", receipt)
 ):
     raise SystemExit("invalid sysroot-version")
 if receipt and consumer_base != receipt.split("~pre", 1)[0]:
@@ -1000,15 +1001,45 @@ PY
     return 0
   fi
 
-  echo "Updating SDK sysroot to Core's Internals receipt ${receipt}"
-  if ! run_privileged sysroot update "${receipt}"; then
-    echo "ERROR: Failed to update SDK sysroot to ${receipt}." >&2
-    return 1
+  if [[ "${receipt}" == *"~pre"* ]]; then
+    echo "Updating SDK sysroot to Core's Internals receipt ${receipt}"
+    if ! run_privileged sysroot update "${receipt}"; then
+      echo "ERROR: Failed to update SDK sysroot to ${receipt}." >&2
+      return 1
+    fi
+    if ! sysroot status; then
+      echo "ERROR: Failed to read SDK sysroot status." >&2
+      return 1
+    fi
+    return 0
   fi
-  if ! sysroot status; then
+
+  local status_output image_platform overlay_state overlay_revision
+  if ! status_output="$(sysroot status)"; then
     echo "ERROR: Failed to read SDK sysroot status." >&2
     return 1
   fi
+  printf '%s\n' "${status_output}"
+  image_platform="$(sed -nE \
+    's/^SDK image platform:[[:space:]]*([^[:space:]]+).*$/\1/p' \
+    <<< "${status_output}" | head -n1)"
+  overlay_state="$(sed -nE \
+    's/^Sysroot overlay state:[[:space:]]*([^[:space:]]+).*$/\1/p' \
+    <<< "${status_output}" | head -n1)"
+  overlay_revision="$(sed -nE \
+    's/^Sysroot overlay revision:[[:space:]]*([^[:space:]]+).*$/\1/p' \
+    <<< "${status_output}" | head -n1)"
+
+  if [[ "${image_platform}" != "${receipt}" ]]; then
+    echo "ERROR: SDK image platform ${image_platform:-unknown} does not match required stable platform ${receipt}." >&2
+    return 1
+  fi
+  if [[ "${overlay_state}" != "inactive" || "${overlay_revision}" != "none" ]]; then
+    echo "ERROR: Stable platform ${receipt} requires the image-default sysroot, but overlay ${overlay_revision:-unknown} is ${overlay_state:-unknown}." >&2
+    echo "ERROR: Recreate the SDK container to remove the prerelease sysroot overlay." >&2
+    return 1
+  fi
+  echo "Using stable SDK sysroot ${image_platform} with no active overlay."
 )
 
 ensure_neat_core() {

--- a/tests/scripts/test_manifest_contract.py
+++ b/tests/scripts/test_manifest_contract.py
@@ -614,7 +614,11 @@ def _write_fake_sysroot(tmp_path: Path) -> dict[str, str]:
     bin_dir.mkdir(exist_ok=True)
     sdk_release = tmp_path / "sdk-release"
     sdk_release.write_text(
-        "SDK Version = 2.0.0\neLXr Version = 12.9.0\n", encoding="utf-8"
+        "SDK Version = 2.0.0\n"
+        "eLXr Version = 12.9.0\n"
+        "Platform Base = 2.0.0\n"
+        "Platform Version = 2.0.0\n",
+        encoding="utf-8",
     )
     id_path = bin_dir / "id"
     id_path.write_text(
@@ -639,7 +643,13 @@ def _write_fake_sysroot(tmp_path: Path) -> dict[str, str]:
             fi
             case "${1:-}" in
               update) exit "${NEAT_APPS_TEST_SYSROOT_UPDATE_STATUS:-0}" ;;
-              status) exit "${NEAT_APPS_TEST_SYSROOT_STATUS_STATUS:-0}" ;;
+              status)
+                printf 'SDK image platform:       %s\n' "${NEAT_APPS_TEST_SYSROOT_IMAGE_PLATFORM:-2.0.0}"
+                printf 'Platform Base:            %s\n' "${NEAT_APPS_TEST_SYSROOT_PLATFORM_BASE:-2.0.0}"
+                printf 'Sysroot overlay state:    %s\n' "${NEAT_APPS_TEST_SYSROOT_OVERLAY_STATE:-inactive}"
+                printf 'Sysroot overlay revision: %s\n' "${NEAT_APPS_TEST_SYSROOT_OVERLAY_REVISION:-none}"
+                exit "${NEAT_APPS_TEST_SYSROOT_STATUS_STATUS:-0}"
+                ;;
             esac
             """
         ),
@@ -1040,6 +1050,58 @@ def test_vulcan_sysroot_sync_accepts_empty_receipt(tmp_path):
     assert "Apps is using the existing SDK sysroot." in proc.stdout
 
 
+def test_vulcan_sysroot_sync_accepts_stable_receipt_without_overlay(tmp_path):
+    proc = _run_build(
+        tmp_path,
+        args=["--only-install-neat-core"],
+        env=_sysroot_sync_env(
+            tmp_path, manifest_text='{"sysroot-version":"2.0.0"}\n'
+        ),
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert (tmp_path / "events.log").read_text(encoding="utf-8").splitlines() == [
+        "sima-cli:neat install --env production -t minimal --json "
+        "core@scratch-core-for-test:scratchsha1",
+        "sysroot:status",
+        "sima-cli:neat install --env production -d . -t minimal "
+        "core@scratch-core-for-test:scratchsha1",
+    ]
+    assert "Using stable SDK sysroot 2.0.0 with no active overlay." in proc.stdout
+
+
+def test_vulcan_sysroot_sync_rejects_stable_receipt_on_wrong_image(tmp_path):
+    env = _sysroot_sync_env(
+        tmp_path, manifest_text='{"sysroot-version":"2.0.0"}\n'
+    )
+    env["NEAT_APPS_TEST_SYSROOT_IMAGE_PLATFORM"] = "2.0.0~pre9999"
+
+    proc = _run_build(tmp_path, args=["--only-install-neat-core"], env=env)
+
+    assert proc.returncode != 0
+    assert "does not match required stable platform 2.0.0" in proc.stderr
+    assert (tmp_path / "sysroot.log").read_text(encoding="utf-8").splitlines() == [
+        "status"
+    ]
+
+
+def test_vulcan_sysroot_sync_rejects_active_overlay_for_stable_receipt(tmp_path):
+    env = _sysroot_sync_env(
+        tmp_path, manifest_text='{"sysroot-version":"2.0.0"}\n'
+    )
+    env["NEAT_APPS_TEST_SYSROOT_OVERLAY_STATE"] = "active"
+    env["NEAT_APPS_TEST_SYSROOT_OVERLAY_REVISION"] = "2.0.0~pre9999"
+
+    proc = _run_build(tmp_path, args=["--only-install-neat-core"], env=env)
+
+    assert proc.returncode != 0
+    assert "overlay 2.0.0~pre9999 is active" in proc.stderr
+    assert "Recreate the SDK container" in proc.stderr
+    assert (tmp_path / "sysroot.log").read_text(encoding="utf-8").splitlines() == [
+        "status"
+    ]
+
+
 def test_vulcan_sysroot_sync_runs_before_installed_core_shortcut(tmp_path):
     env = _sysroot_sync_env(tmp_path)
     _write_fake_neat_json(
@@ -1069,6 +1131,7 @@ def test_vulcan_sysroot_sync_runs_before_installed_core_shortcut(tmp_path):
         '{"sysroot-version":"latest"}',
         '{"sysroot-version":"2.0.0~pre9999; touch /tmp/nope"}',
         '{"sysroot-version":"2.0.0~pre9999\\nstatus"}',
+        '{"sysroot-version":"2.0.1"}',
         '{"sysroot-version":"2.0.1~pre9999"}',
     ],
 )


### PR DESCRIPTION
## Summary

- accept stable `X.Y.Z` receipts as well as prerelease `X.Y.Z~preN` receipts from the selected Core artifact
- retain exact `sysroot update` behavior for prerelease receipts
- require stable receipts to match the SDK image platform with no active sysroot overlay
- fail with an actionable SDK-container refresh message instead of silently compiling against a stale prerelease overlay

## Context

Internals now publishes the final `2.1.3` sysroot receipt. Apps still enforced the earlier prerelease-only contract from #443, so it rejected stable receipts. Checking only `/etc/sdk-release` is insufficient because a persistent SDK container can report platform `2.1.3` while an active `2.1.3~preN` overlay remains.

Relates to sima-neat/core#775.

## Validation

- `python3 -m pytest -q tests/scripts/test_manifest_contract.py` — 88 passed
- `bash -n build.sh`
- `python3 -m py_compile tests/scripts/test_manifest_contract.py`
- `git diff --check`

The repository-wide `scripts/check_all.sh` was also attempted locally. CMake style and include hygiene passed; other checks were blocked by the local environment (`clang-format` unavailable and macOS Bash 3 lacks `mapfile`) plus a pre-existing missing example README.