### PR TITLE
feat(deps): use Model Zoo 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Model Zoo release, which can differ from the installed platform version.
 Before downloading a model, set the Model Zoo version:
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 ```
 
 Runtime sample data is included under `assets/datasets/`.

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -6,5 +6,5 @@
     "channel": "develop"
   },
   "platform-version": "2.1.3",
-  "modelzoo-version": "2.1.2"
+  "modelzoo-version": "2.1.3"
 }

--- a/examples/TEMPLATE_README.md
+++ b/examples/TEMPLATE_README.md
@@ -55,7 +55,7 @@ Model packages come from the Model Zoo release below, which can differ from the 
 Model Zoo:
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli modelzoo -v "${MODELZOO_VERSION}" get <model-name>

--- a/examples/benchmarking/model-benchmark/README.md
+++ b/examples/benchmarking/model-benchmark/README.md
@@ -46,7 +46,7 @@ Use any compatible compiled MPK. Apps CI exercises the benchmark with `yolo26m-d
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Download a Model Zoo package:
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli modelzoo -v "${MODELZOO_VERSION}" get <model-name>

--- a/examples/benchmarking/model-benchmark/tests/test-scope.yaml
+++ b/examples/benchmarking/model-benchmark/tests/test-scope.yaml
@@ -4,8 +4,8 @@ models:
     name: resnet_50
     file: resnet_50_mpk.tar.gz
   depth_anything_v2_vits:
-    source: modelzoo
-    name: depth_anything_v2_vits
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/depth_anything_v2_vits_mpk.tar.gz
     file: depth_anything_v2_vits_mpk.tar.gz
   retinaface_mobilenet25:
     source: url

--- a/examples/classification/image-classifier/README.md
+++ b/examples/classification/image-classifier/README.md
@@ -47,7 +47,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli modelzoo -v "${MODELZOO_VERSION}" get resnet_50

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -45,7 +45,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli modelzoo -v "${MODELZOO_VERSION}" get depth_anything_v2_vits

--- a/examples/depth-estimation/depth-estimator/README.md
+++ b/examples/depth-estimation/depth-estimator/README.md
@@ -38,9 +38,9 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-| Model package | Role | Model Zoo name |
+| Model package | Role | Source |
 | --- | --- | --- |
-| `depth_anything_v2_vits_mpk.tar.gz` | Default | `depth_anything_v2_vits` |
+| `depth_anything_v2_vits_mpk.tar.gz` | Default | Direct artifact |
 
 Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
@@ -48,7 +48,8 @@ Model packages come from the Model Zoo release below, which can differ from the 
 export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
-sima-cli modelzoo -v "${MODELZOO_VERSION}" get depth_anything_v2_vits
+sima-cli download \
+  "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/depth_anything_v2_vits_mpk.tar.gz"
 cd ..
 ```
 

--- a/examples/depth-estimation/depth-estimator/tests/test-scope.yaml
+++ b/examples/depth-estimation/depth-estimator/tests/test-scope.yaml
@@ -1,7 +1,7 @@
 models:
   depth_anything_v2_vits:
-    source: modelzoo
-    name: depth_anything_v2_vits
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/depth_anything_v2_vits_mpk.tar.gz
     file: depth_anything_v2_vits_mpk.tar.gz
 unit:
   python: true

--- a/examples/face-detection/face-detector/README.md
+++ b/examples/face-detection/face-detector/README.md
@@ -47,7 +47,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/retinaface_mobilenet25_mod_0_mpk.tar.gz"

--- a/examples/face-detection/single-stream-thermal-face-detector/README.md
+++ b/examples/face-detection/single-stream-thermal-face-detector/README.md
@@ -62,7 +62,7 @@ Model packages come from the Model Zoo release below, which can differ from the
 installed platform version.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download \

--- a/examples/genai/detection-to-vlm-assistant/README.md
+++ b/examples/genai/detection-to-vlm-assistant/README.md
@@ -57,7 +57,7 @@ Supported detector packages:
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"

--- a/examples/object-detection/detr-object-detector/README.md
+++ b/examples/object-detection/detr-object-detector/README.md
@@ -47,7 +47,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/detr_resnet50_modified_class_embed_bbox_embed_mpk.tar.gz"

--- a/examples/object-detection/high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/high-density-multi-stream-object-detector/README.md
@@ -79,7 +79,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz"

--- a/examples/object-detection/multi-stream-object-detector/README.md
+++ b/examples/object-detection/multi-stream-object-detector/README.md
@@ -53,7 +53,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"

--- a/examples/object-detection/pcie-high-density-multi-stream-object-detector/README.md
+++ b/examples/object-detection/pcie-high-density-multi-stream-object-detector/README.md
@@ -64,9 +64,10 @@ To build the card application yourself, see
 Download the model on the Modalix PCIe Card:
 
 ```bash
+export MODELZOO_VERSION="2.1.3"
 mkdir -p /workspace/models
 cd /workspace/models
-sima-cli download https://docs.sima.ai/pkg_downloads/SDK2.1.2/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz
+sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/yolo26n-det-int8-b1.tar.gz"
 ```
 
 Use this absolute path for `model.path` in the configuration:

--- a/examples/object-detection/single-stream-object-detector/README.md
+++ b/examples/object-detection/single-stream-object-detector/README.md
@@ -54,7 +54,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"

--- a/examples/object-detection/yolo26-object-detector/README.md
+++ b/examples/object-detection/yolo26-object-detector/README.md
@@ -51,7 +51,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"

--- a/examples/pose-estimation/multi-stream-pose-estimator/README.md
+++ b/examples/pose-estimation/multi-stream-pose-estimator/README.md
@@ -55,7 +55,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-pose/<model-file>"

--- a/examples/segmentation/single-stream-instance-segmenter/README.md
+++ b/examples/segmentation/single-stream-instance-segmenter/README.md
@@ -57,7 +57,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-segmentation/<model-file>"

--- a/examples/segmentation/yolov8-instance-segmenter/README.md
+++ b/examples/segmentation/yolov8-instance-segmenter/README.md
@@ -48,7 +48,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-name>` with a model from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli modelzoo -v "${MODELZOO_VERSION}" get <model-name>

--- a/examples/tracking/multi-stream-people-tracker/README.md
+++ b/examples/tracking/multi-stream-people-tracker/README.md
@@ -53,7 +53,7 @@ Run the remaining commands from `prebuilt-apps/`.
 Model packages come from the Model Zoo release below, which can differ from the installed platform version. Replace `<model-file>` with a file from the table.
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26-detection/<model-file>"

--- a/scripts/create_example_scaffold.sh
+++ b/scripts/create_example_scaffold.sh
@@ -256,7 +256,7 @@ Model packages come from the Model Zoo release below, which can differ from the 
 Model Zoo:
 
 \`\`\`bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli modelzoo -v "\${MODELZOO_VERSION}" get <model-name>

--- a/tests/scripts/test_modelzoo_version_pin.py
+++ b/tests/scripts/test_modelzoo_version_pin.py
@@ -13,6 +13,7 @@ APPS_ROOT = Path(__file__).resolve().parents[2]
 # customer-facing commands carry a copy-pasteable literal instead of resolving the
 # version at run time. These tests are what keeps that literal honest.
 DOCUMENTED_VERSION_RE = re.compile(r'export MODELZOO_VERSION="([^"]+)"')
+DOCUMENTED_MODEL_URL_LITERAL_RE = re.compile(r"pkg_downloads/SDK\d")
 PLATFORM_BADGE_RE = re.compile(r"Neat%20Development%20Environment-([^-]+)-")
 # Scope files interpolate the version at download time. A hardcoded SDK<version>
 # would still download successfully, so only a static check catches it.
@@ -67,6 +68,16 @@ def test_scope_files_interpolate_the_version_instead_of_hardcoding_it():
         str(path.relative_to(APPS_ROOT))
         for path in _scope_files()
         if SCOPE_VERSION_LITERAL_RE.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert offenders == []
+
+
+def test_documented_model_urls_do_not_hardcode_versions():
+    offenders = [
+        str(path.relative_to(APPS_ROOT))
+        for path in _documented_surfaces()
+        if DOCUMENTED_MODEL_URL_LITERAL_RE.search(path.read_text(encoding="utf-8"))
     ]
 
     assert offenders == []


### PR DESCRIPTION
## Why

The Model Zoo GA selector now resolves to 2.1.3, while Apps still pins and documents 2.1.2. This change prepares Apps to use the matching release without relying on the mutable GA default.

Refs #396

## What Changed

- Pin Apps model downloads to Model Zoo 2.1.3.
- Update root, template, scaffold, and example download commands to match the pin.
- Replace the PCIe example's hardcoded SDK URL with `MODELZOO_VERSION` and reject future hardcoded Model Zoo URL versions.

## Validation

- `42 passed, 12 skipped`: Model Zoo pin, scope, and README contracts.
- `88 passed`: dependency manifest contracts.
- `git diff --check`.
- `scripts/validate_readmes.py` still reports four failures in the unchanged tiny-drone README already present on `develop`.

## Risk

Model Zoo 2.1.3 currently publishes an empty Modalix catalog, and the current Apps direct-model paths are unavailable under `SDK2.1.3`. Do not merge this PR until the 2.1.3 model publication is complete and Vulcan CI passes.
