### PR TITLE
Use SDK ModelZoo artifacts for SSD and tiny-drone

### DIFF
--- a/examples/object-detection/ssd-mobilenet-object-detector/README.md
+++ b/examples/object-detection/ssd-mobilenet-object-detector/README.md
@@ -42,13 +42,16 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-The tested model is SSD-MobileNetV2 INT8 with tessellation inside the MLA. Install its staging
-Model Registry package:
+The tested model is SSD-MobileNetV2 INT8 with tessellation inside the MLA. Download its SDK
+2.1.2 artifact:
 
 ```bash
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
-sima-cli neat install --stg models/ssd_mobilenet_v2@develop:latest \
-  --install-dir ./models
+cd models
+sima-cli download \
+  "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz"
+cd ..
 ```
 
 The configuration below uses

--- a/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
+++ b/examples/object-detection/ssd-mobilenet-object-detector/tests/test-scope.yaml
@@ -1,9 +1,7 @@
 models:
   ssd_v2_int8_tess_mla:
-    source: model-registry
-    name: ssd_mobilenet_v2
-    ref: develop
-    spec: d15c24ddb8cd
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz
     file: ssd_mobilenet_v2_modalix_int8_tess_mla_mpk.tar.gz
 unit:
   python: true

--- a/examples/tracking/yolo26-tiny-drone-tracker/README.md
+++ b/examples/tracking/yolo26-tiny-drone-tracker/README.md
@@ -51,20 +51,19 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-Install the accepted immutable Model Registry candidate used by this app's CI:
+Download the tested SDK 2.1.2 model artifact:
 
 ```bash
+export MODELZOO_VERSION="2.1.2"
 mkdir -p models
-sima-cli neat install --stg \
-  models/yolo26_tiny_drone@develop:d13a9ed31daa \
-  --install-dir ./models
+cd models
+sima-cli download \
+  "https://docs.sima.ai/pkg_downloads/SDK${MODELZOO_VERSION}/models/modalix/yolo26n_p2_tiny_drone_int8_qat_b1_mpk.tar.gz"
+cd ..
 ```
 
-The command installs
-`models/yolo26n_p2_tiny_drone_int8_qat_b1_mpk.tar.gz`. This immutable staging
-reference tracks the model workflow merged into Models `develop`. Replace it
-here and in `tests/test-scope.yaml` with the production Model Registry reference
-before release.
+The command stores
+`models/yolo26n_p2_tiny_drone_int8_qat_b1_mpk.tar.gz`.
 
 ## Prepare Insight
 

--- a/examples/tracking/yolo26-tiny-drone-tracker/README.md
+++ b/examples/tracking/yolo26-tiny-drone-tracker/README.md
@@ -8,7 +8,7 @@
 | Difficulty | Advanced |
 | Tags | object-detection, yolo26, rtsp, insight, tiny-drone, tracking |
 | Languages | C++, Python |
-| Status | experimental |
+| Status | stable |
 | Binary Name | yolo26-tiny-drone-tracker |
 | Model | yolo26n-p2-tiny-drone-int8-qat |
 
@@ -29,8 +29,7 @@ per-stream IDs.
 
 - `sima-cli` 2.1.15 or newer
   ([documentation](https://developer.sima.ai/software/tools/sima-cli/)) on a
-  supported Modalix or DevKit target. Earlier clients cannot install this
-  Model Registry package.
+  supported Modalix or DevKit target.
 - One or more H.264 or H.265 RTSP sources and an
   [Insight](https://developer.sima.ai/software/tools/insight/) endpoint
   reachable from the target.
@@ -45,6 +44,7 @@ Install the latest Neat Apps runtime and enter the installed bundle:
 ```bash
 sima-cli neat install apps
 cd prebuilt-apps
+APP_DIR=examples/tracking/yolo26-tiny-drone-tracker
 ```
 
 Run the remaining commands from `prebuilt-apps/`.
@@ -94,8 +94,8 @@ confirmed track but cannot create or confirm an identity.
 Validate the config without opening a stream:
 
 ```bash
-APP_BIN=examples/tracking/yolo26-tiny-drone-tracker/src/cpp/pre-built/yolo26-tiny-drone-tracker
-CONFIG=examples/tracking/yolo26-tiny-drone-tracker/src/common/config.yaml
+APP_BIN="$APP_DIR/src/cpp/pre-built/yolo26-tiny-drone-tracker"
+CONFIG="$APP_DIR/src/common/config.yaml"
 "$APP_BIN" \
   --config "$CONFIG" \
   --validate-config-only
@@ -104,8 +104,8 @@ CONFIG=examples/tracking/yolo26-tiny-drone-tracker/src/common/config.yaml
 ### C++
 
 ```bash
-APP_BIN=examples/tracking/yolo26-tiny-drone-tracker/src/cpp/pre-built/yolo26-tiny-drone-tracker
-CONFIG=examples/tracking/yolo26-tiny-drone-tracker/src/common/config.yaml
+APP_BIN="$APP_DIR/src/cpp/pre-built/yolo26-tiny-drone-tracker"
+CONFIG="$APP_DIR/src/common/config.yaml"
 "$APP_BIN" --config "$CONFIG"
 ```
 

--- a/examples/tracking/yolo26-tiny-drone-tracker/tests/test-scope.yaml
+++ b/examples/tracking/yolo26-tiny-drone-tracker/tests/test-scope.yaml
@@ -1,9 +1,7 @@
 models:
   yolo26-tiny-drone-int8-qat-mla-tess:
-    source: model-registry
-    name: yolo26_tiny_drone
-    ref: develop
-    spec: d13a9ed31daa
+    source: url
+    url: https://docs.sima.ai/pkg_downloads/SDK{modelzoo_version}/models/modalix/yolo26n_p2_tiny_drone_int8_qat_b1_mpk.tar.gz
     file: yolo26n_p2_tiny_drone_int8_qat_b1_mpk.tar.gz
 unit:
   python: true


### PR DESCRIPTION
Refs #453

## Why

The SSD-MobileNet and YOLO26 tiny-drone examples still direct customers to staging Models `develop` artifacts even though the tested packages are now published under SDK 2.1.2.

## What changed

- switched both test scopes to version-interpolated SDK ModelZoo URLs
- updated both READMEs to download the public artifacts with `sima-cli`
- retained the tested model filenames used by the example configurations
- marked the merged tiny-drone example as stable and reused `APP_DIR` in its packaged run commands

## Validation

- focused scope and ModelZoo contract tests: 25 passed, 12 platform-dependent tests skipped on macOS
- repository-wide scope validation: passed
- public downloads through `sima-cli`: passed and matched the registry artifacts byte-for-byte
- README validation: passed, 21 READMEs
- `git diff --check`: passed
