### PR TITLE
docs(models): match download instructions to 2.1.3

### DIFF
--- a/examples/object-detection/ssd-mobilenet-object-detector/README.md
+++ b/examples/object-detection/ssd-mobilenet-object-detector/README.md
@@ -43,10 +43,10 @@ Run the remaining commands from `prebuilt-apps/`.
 ## Prepare the Model
 
 The tested model is SSD-MobileNetV2 INT8 with tessellation inside the MLA. Download its SDK
-2.1.2 artifact:
+2.1.3 artifact:
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download \

--- a/examples/tracking/yolo26-tiny-drone-tracker/README.md
+++ b/examples/tracking/yolo26-tiny-drone-tracker/README.md
@@ -51,10 +51,10 @@ Run the remaining commands from `prebuilt-apps/`.
 
 ## Prepare the Model
 
-Download the tested SDK 2.1.2 model artifact:
+Download the tested SDK 2.1.3 model artifact:
 
 ```bash
-export MODELZOO_VERSION="2.1.2"
+export MODELZOO_VERSION="2.1.3"
 mkdir -p models
 cd models
 sima-cli download \


### PR DESCRIPTION
## Why

Apps pins Model Zoo 2.1.3, but the SSD and tiny-drone download instructions still select 2.1.2. Following those commands can fetch artifacts from the wrong release and violates the version pin contract.

## What Changed

- Update both README labels and `MODELZOO_VERSION` exports to 2.1.3.

## Validation

- `python3 scripts/validate_readmes.py`
- All five checks in `tests/scripts/test_modelzoo_version_pin.py` executed directly
- `git diff --check`

Refs #455